### PR TITLE
fix(auth): reload SQLite credentials before AWS SSO OIDC token refresh

### DIFF
--- a/kiro_gateway/auth.py
+++ b/kiro_gateway/auth.py
@@ -464,6 +464,11 @@ class KiroAuthManager:
             ValueError: If required credentials are not set
             httpx.HTTPError: On HTTP request error
         """
+        # Re-read credentials from SQLite to pick up fresh tokens after kiro-cli re-login
+        if self._sqlite_db:
+            logger.debug("Reloading credentials from SQLite before token refresh...")
+            self._load_credentials_from_sqlite(self._sqlite_db)
+        
         if not self._refresh_token:
             raise ValueError("Refresh token is not set")
         if not self._client_id:


### PR DESCRIPTION
## Problem

When kiro-cli refreshes tokens and updates the SQLite database, kiro-gateway continues using stale credentials from memory, causing 400 errors from AWS SSO OIDC endpoint.

Users had to manually restart the container after every `kiro login`.

### Error Pattern
```
AWS SSO OIDC refresh failed: status=400
body={"error":"invalid_request","error_description":"Invalid request","reason":null}
```

## Solution

Reload credentials from SQLite at the beginning of `_refresh_token_aws_sso_oidc()` to pick up fresh tokens after kiro-cli re-login.

## Changes

- `kiro_gateway/auth.py`: Add SQLite reload before token refresh (4 lines)
- `tests/unit/test_auth_manager.py`: Add test for reload behavior

## Related

- Addresses #14
- Improvement on closed #17 (keeps correct form-urlencoded format)

## Testing

- [x] New test added and passes
- [x] All existing tests pass (60 passed)