### PR TITLE
 fix: Migrate to Q endpoints & update headers to Kiro IDE 0.8.86

### DIFF
--- a/kiro/__init__.py
+++ b/kiro/__init__.py
@@ -48,7 +48,11 @@ from kiro.auth import KiroAuthManager
 from kiro.cache import ModelInfoCache
 from kiro.http_client import KiroHttpClient
 from kiro.routes_openai import router
-from kiro.model_resolver import ModelResolver, normalize_model_name, get_model_id_for_kiro
+from kiro.model_resolver import (
+    ModelResolver,
+    normalize_model_name,
+    get_model_id_for_kiro,
+)
 
 # Configuration
 from kiro.config import (
@@ -94,43 +98,35 @@ from kiro.exceptions import (
 __all__ = [
     # Version
     "__version__",
-    
     # Main classes
     "KiroAuthManager",
     "ModelInfoCache",
     "KiroHttpClient",
     "ModelResolver",
     "router",
-    
     # Configuration
     "PROXY_API_KEY",
     "REGION",
     "HIDDEN_MODELS",
     "APP_VERSION",
-    
     # Model resolution
     "normalize_model_name",
     "get_model_id_for_kiro",
-    
     # Models
     "ChatCompletionRequest",
     "ChatMessage",
     "OpenAIModel",
     "ModelList",
-    
     # Converters
     "build_kiro_payload",
     "extract_text_content",
     "merge_adjacent_messages",
-    
     # Parsers
     "AwsEventStreamParser",
     "parse_bracket_tool_calls",
-    
     # Streaming
     "stream_kiro_to_openai",
     "collect_stream_response",
-    
     # Exceptions
     "validation_exception_handler",
     "sanitize_validation_errors",

--- a/kiro/auth.py
+++ b/kiro/auth.py
@@ -51,16 +51,17 @@ from kiro.utils import get_machine_fingerprint
 class AuthType(Enum):
     """
     Type of authentication mechanism.
-    
+
     KIRO_DESKTOP: Kiro IDE credentials (default)
         - Uses https://prod.{region}.auth.desktop.kiro.dev/refreshToken
         - JSON body: {"refreshToken": "..."}
-    
+
     AWS_SSO_OIDC: AWS SSO credentials from kiro-cli
         - Uses https://oidc.{region}.amazonaws.com/token
         - Form body: grant_type=refresh_token&client_id=...&client_secret=...&refresh_token=...
         - Requires clientId and clientSecret from credentials file
     """
+
     KIRO_DESKTOP = "kiro_desktop"
     AWS_SSO_OIDC = "aws_sso_oidc"
 
@@ -68,14 +69,14 @@ class AuthType(Enum):
 class KiroAuthManager:
     """
     Manages the token lifecycle for accessing Kiro API.
-    
+
     Supports:
     - Loading credentials from .env or JSON file
     - Automatic token refresh on expiration
     - Expiration time validation (expiresAt)
     - Saving updated tokens to file
     - Both Kiro Desktop Auth and AWS SSO OIDC (kiro-cli) authentication
-    
+
     Attributes:
         profile_arn: AWS CodeWhisperer profile ARN
         region: AWS region
@@ -83,7 +84,7 @@ class KiroAuthManager:
         q_host: Q API host for the current region
         fingerprint: Unique machine fingerprint
         auth_type: Type of authentication (KIRO_DESKTOP or AWS_SSO_OIDC)
-    
+
     Example:
         >>> # Kiro Desktop Auth (default)
         >>> auth_manager = KiroAuthManager(
@@ -91,14 +92,14 @@ class KiroAuthManager:
         ...     region="us-east-1"
         ... )
         >>> token = await auth_manager.get_access_token()
-        
+
         >>> # AWS SSO OIDC (kiro-cli) - auto-detected from credentials file
         >>> auth_manager = KiroAuthManager(
         ...     creds_file="~/.aws/sso/cache/your-cache.json"
         ... )
         >>> token = await auth_manager.get_access_token()
     """
-    
+
     def __init__(
         self,
         refresh_token: Optional[str] = None,
@@ -111,7 +112,7 @@ class KiroAuthManager:
     ):
         """
         Initializes the authentication manager.
-        
+
         Args:
             refresh_token: Refresh token for obtaining access token
             profile_arn: AWS CodeWhisperer profile ARN
@@ -127,42 +128,44 @@ class KiroAuthManager:
         self._region = region
         self._creds_file = creds_file
         self._sqlite_db = sqlite_db
-        
+
         # AWS SSO OIDC specific fields
         self._client_id: Optional[str] = client_id
         self._client_secret: Optional[str] = client_secret
         self._scopes: Optional[list] = None  # OAuth scopes for AWS SSO OIDC
-        self._sso_region: Optional[str] = None  # SSO region for OIDC token refresh (may differ from API region)
-        
+        self._sso_region: Optional[str] = (
+            None  # SSO region for OIDC token refresh (may differ from API region)
+        )
+
         self._access_token: Optional[str] = None
         self._expires_at: Optional[datetime] = None
         self._lock = asyncio.Lock()
-        
+
         # Auth type will be determined after loading credentials
         self._auth_type: AuthType = AuthType.KIRO_DESKTOP
-        
+
         # Dynamic URLs based on region
         self._refresh_url = get_kiro_refresh_url(region)
         self._api_host = get_kiro_api_host(region)
         self._q_host = get_kiro_q_host(region)
-        
+
         # Fingerprint for User-Agent
         self._fingerprint = get_machine_fingerprint()
-        
+
         # Load credentials from SQLite if specified (takes priority over JSON)
         if sqlite_db:
             self._load_credentials_from_sqlite(sqlite_db)
         # Load credentials from JSON file if specified
         elif creds_file:
             self._load_credentials_from_file(creds_file)
-        
+
         # Determine auth type based on available credentials
         self._detect_auth_type()
-    
+
     def _detect_auth_type(self) -> None:
         """
         Detects authentication type based on available credentials.
-        
+
         AWS SSO OIDC credentials contain clientId and clientSecret.
         Kiro Desktop credentials do not contain these fields.
         """
@@ -172,15 +175,15 @@ class KiroAuthManager:
         else:
             self._auth_type = AuthType.KIRO_DESKTOP
             logger.info("Detected auth type: Kiro Desktop")
-    
+
     def _load_credentials_from_sqlite(self, db_path: str) -> None:
         """
         Loads credentials from kiro-cli SQLite database.
-        
+
         The database contains an auth_kv table with key-value pairs:
         - 'codewhisperer:odic:token': JSON with access_token, refresh_token, expires_at, region
         - 'codewhisperer:odic:device-registration': JSON with client_id, client_secret
-        
+
         Args:
             db_path: Path to SQLite database file
         """
@@ -189,93 +192,112 @@ class KiroAuthManager:
             if not path.exists():
                 logger.warning(f"SQLite database not found: {db_path}")
                 return
-            
+
             conn = sqlite3.connect(str(path))
             cursor = conn.cursor()
-            
+
             # Load token data (try both kiro-cli and codewhisperer key formats)
-            cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:token",))
+            cursor.execute(
+                "SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:token",)
+            )
             token_row = cursor.fetchone()
             if not token_row:
-                cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("codewhisperer:odic:token",))
+                cursor.execute(
+                    "SELECT value FROM auth_kv WHERE key = ?",
+                    ("codewhisperer:odic:token",),
+                )
                 token_row = cursor.fetchone()
-            
+
             if token_row:
                 token_data = json.loads(token_row[0])
                 if token_data:
                     # Load token fields (using snake_case as in Rust struct)
-                    if 'access_token' in token_data:
-                        self._access_token = token_data['access_token']
-                    if 'refresh_token' in token_data:
-                        self._refresh_token = token_data['refresh_token']
-                    if 'region' in token_data:
+                    if "access_token" in token_data:
+                        self._access_token = token_data["access_token"]
+                    if "refresh_token" in token_data:
+                        self._refresh_token = token_data["refresh_token"]
+                    if "region" in token_data:
                         # Store SSO region for OIDC token refresh only
                         # IMPORTANT: CodeWhisperer API is only available in us-east-1,
                         # so we don't update _api_host and _q_host here.
                         # The SSO region (e.g., ap-southeast-1) is only used for OIDC token refresh.
-                        self._sso_region = token_data['region']
-                        logger.debug(f"SSO region from SQLite: {self._sso_region} (API stays at {self._region})")
-                    
+                        self._sso_region = token_data["region"]
+                        logger.debug(
+                            f"SSO region from SQLite: {self._sso_region} (API stays at {self._region})"
+                        )
+
                     # Load scopes if available
-                    if 'scopes' in token_data:
-                        self._scopes = token_data['scopes']
-                    
+                    if "scopes" in token_data:
+                        self._scopes = token_data["scopes"]
+
                     # Parse expires_at (RFC3339 format)
-                    if 'expires_at' in token_data:
+                    if "expires_at" in token_data:
                         try:
-                            expires_str = token_data['expires_at']
+                            expires_str = token_data["expires_at"]
                             # Handle various ISO 8601 formats
-                            if expires_str.endswith('Z'):
-                                self._expires_at = datetime.fromisoformat(expires_str.replace('Z', '+00:00'))
+                            if expires_str.endswith("Z"):
+                                self._expires_at = datetime.fromisoformat(
+                                    expires_str.replace("Z", "+00:00")
+                                )
                             else:
                                 self._expires_at = datetime.fromisoformat(expires_str)
                         except Exception as e:
-                            logger.warning(f"Failed to parse expires_at from SQLite: {e}")
-            
+                            logger.warning(
+                                f"Failed to parse expires_at from SQLite: {e}"
+                            )
+
             # Load device registration (client_id, client_secret) - try both key formats
-            cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:device-registration",))
+            cursor.execute(
+                "SELECT value FROM auth_kv WHERE key = ?",
+                ("kirocli:odic:device-registration",),
+            )
             registration_row = cursor.fetchone()
             if not registration_row:
-                cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("codewhisperer:odic:device-registration",))
+                cursor.execute(
+                    "SELECT value FROM auth_kv WHERE key = ?",
+                    ("codewhisperer:odic:device-registration",),
+                )
                 registration_row = cursor.fetchone()
-            
+
             if registration_row:
                 registration_data = json.loads(registration_row[0])
                 if registration_data:
-                    if 'client_id' in registration_data:
-                        self._client_id = registration_data['client_id']
-                    if 'client_secret' in registration_data:
-                        self._client_secret = registration_data['client_secret']
+                    if "client_id" in registration_data:
+                        self._client_id = registration_data["client_id"]
+                    if "client_secret" in registration_data:
+                        self._client_secret = registration_data["client_secret"]
                     # SSO region from registration (fallback if not in token data)
-                    if 'region' in registration_data and not self._sso_region:
-                        self._sso_region = registration_data['region']
-                        logger.debug(f"SSO region from device-registration: {self._sso_region}")
-            
+                    if "region" in registration_data and not self._sso_region:
+                        self._sso_region = registration_data["region"]
+                        logger.debug(
+                            f"SSO region from device-registration: {self._sso_region}"
+                        )
+
             conn.close()
             logger.info(f"Credentials loaded from SQLite database: {db_path}")
-            
+
         except sqlite3.Error as e:
             logger.error(f"SQLite error loading credentials: {e}")
         except json.JSONDecodeError as e:
             logger.error(f"JSON decode error in SQLite data: {e}")
         except Exception as e:
             logger.error(f"Error loading credentials from SQLite: {e}")
-    
+
     def _load_credentials_from_file(self, file_path: str) -> None:
         """
         Loads credentials from a JSON file.
-        
+
         Supported JSON fields (Kiro Desktop):
         - refreshToken: Refresh token
         - accessToken: Access token (if already available)
         - profileArn: Profile ARN
         - region: AWS region
         - expiresAt: Token expiration time (ISO 8601)
-        
+
         Additional fields for AWS SSO OIDC (kiro-cli):
         - clientId: OAuth client ID
         - clientSecret: OAuth client secret
-        
+
         Args:
             file_path: Path to JSON file
         """
@@ -284,123 +306,125 @@ class KiroAuthManager:
             if not path.exists():
                 logger.warning(f"Credentials file not found: {file_path}")
                 return
-            
-            with open(path, 'r', encoding='utf-8') as f:
+
+            with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)
-            
+
             # Load common data from file
-            if 'refreshToken' in data:
-                self._refresh_token = data['refreshToken']
-            if 'accessToken' in data:
-                self._access_token = data['accessToken']
-            if 'profileArn' in data:
-                self._profile_arn = data['profileArn']
-            if 'region' in data:
-                self._region = data['region']
+            if "refreshToken" in data:
+                self._refresh_token = data["refreshToken"]
+            if "accessToken" in data:
+                self._access_token = data["accessToken"]
+            if "profileArn" in data:
+                self._profile_arn = data["profileArn"]
+            if "region" in data:
+                self._region = data["region"]
                 # Update URLs for new region
                 self._refresh_url = get_kiro_refresh_url(self._region)
                 self._api_host = get_kiro_api_host(self._region)
                 self._q_host = get_kiro_q_host(self._region)
-            
+
             # Load AWS SSO OIDC specific fields
-            if 'clientId' in data:
-                self._client_id = data['clientId']
-            if 'clientSecret' in data:
-                self._client_secret = data['clientSecret']
-            
+            if "clientId" in data:
+                self._client_id = data["clientId"]
+            if "clientSecret" in data:
+                self._client_secret = data["clientSecret"]
+
             # Parse expiresAt
-            if 'expiresAt' in data:
+            if "expiresAt" in data:
                 try:
-                    expires_str = data['expiresAt']
+                    expires_str = data["expiresAt"]
                     # Support for different date formats
-                    if expires_str.endswith('Z'):
-                        self._expires_at = datetime.fromisoformat(expires_str.replace('Z', '+00:00'))
+                    if expires_str.endswith("Z"):
+                        self._expires_at = datetime.fromisoformat(
+                            expires_str.replace("Z", "+00:00")
+                        )
                     else:
                         self._expires_at = datetime.fromisoformat(expires_str)
                 except Exception as e:
                     logger.warning(f"Failed to parse expiresAt: {e}")
-            
+
             logger.info(f"Credentials loaded from {file_path}")
-            
+
         except Exception as e:
             logger.error(f"Error loading credentials from file: {e}")
-    
+
     def _save_credentials_to_file(self) -> None:
         """
         Saves updated credentials to a JSON file.
-        
+
         Updates the existing file while preserving other fields.
         """
         if not self._creds_file:
             return
-        
+
         try:
             path = Path(self._creds_file).expanduser()
-            
+
             # Read existing data
             existing_data = {}
             if path.exists():
-                with open(path, 'r', encoding='utf-8') as f:
+                with open(path, "r", encoding="utf-8") as f:
                     existing_data = json.load(f)
-            
+
             # Update data
-            existing_data['accessToken'] = self._access_token
-            existing_data['refreshToken'] = self._refresh_token
+            existing_data["accessToken"] = self._access_token
+            existing_data["refreshToken"] = self._refresh_token
             if self._expires_at:
-                existing_data['expiresAt'] = self._expires_at.isoformat()
+                existing_data["expiresAt"] = self._expires_at.isoformat()
             if self._profile_arn:
-                existing_data['profileArn'] = self._profile_arn
-            
+                existing_data["profileArn"] = self._profile_arn
+
             # Save
-            with open(path, 'w', encoding='utf-8') as f:
+            with open(path, "w", encoding="utf-8") as f:
                 json.dump(existing_data, f, indent=2, ensure_ascii=False)
-            
+
             logger.debug(f"Credentials saved to {self._creds_file}")
-            
+
         except Exception as e:
             logger.error(f"Error saving credentials: {e}")
-    
+
     def is_token_expiring_soon(self) -> bool:
         """
         Checks if the token is expiring soon.
-        
+
         Returns:
             True if the token expires within TOKEN_REFRESH_THRESHOLD seconds
             or if expiration time information is not available
         """
         if not self._expires_at:
             return True  # If no expiration info available, assume refresh is needed
-        
+
         now = datetime.now(timezone.utc)
         threshold = now.timestamp() + TOKEN_REFRESH_THRESHOLD
-        
+
         return self._expires_at.timestamp() <= threshold
-    
+
     def is_token_expired(self) -> bool:
         """
         Checks if the token is actually expired (not just expiring soon).
-        
+
         This is used for graceful degradation when refresh fails but
         the access token might still be valid for a short time.
-        
+
         Returns:
             True if the token has already expired or if expiration time
             information is not available
         """
         if not self._expires_at:
             return True  # If no expiration info available, assume expired
-        
+
         now = datetime.now(timezone.utc)
         return now >= self._expires_at
-    
+
     async def _refresh_token_request(self) -> None:
         """
         Performs a token refresh request.
-        
+
         Routes to appropriate refresh method based on auth type:
         - KIRO_DESKTOP: Uses Kiro Desktop Auth endpoint
         - AWS_SSO_OIDC: Uses AWS SSO OIDC endpoint
-        
+
         Raises:
             ValueError: If refresh token is not set or response doesn't contain accessToken
             httpx.HTTPError: On HTTP request error
@@ -409,82 +433,85 @@ class KiroAuthManager:
             await self._refresh_token_aws_sso_oidc()
         else:
             await self._refresh_token_kiro_desktop()
-    
+
     async def _refresh_token_kiro_desktop(self) -> None:
         """
         Refreshes token using Kiro Desktop Auth endpoint.
-        
+
         Endpoint: https://prod.{region}.auth.desktop.kiro.dev/refreshToken
         Method: POST
         Content-Type: application/json
         Body: {"refreshToken": "..."}
-        
+
         Raises:
             ValueError: If refresh token is not set or response doesn't contain accessToken
             httpx.HTTPError: On HTTP request error
         """
         if not self._refresh_token:
             raise ValueError("Refresh token is not set")
-        
+
         logger.info("Refreshing Kiro token via Kiro Desktop Auth...")
-        
-        payload = {'refreshToken': self._refresh_token}
+
+        payload = {"refreshToken": self._refresh_token}
         headers = {
             "Content-Type": "application/json",
             "User-Agent": f"KiroIDE-0.7.45-{self._fingerprint}",
         }
-        
+
         async with httpx.AsyncClient(timeout=30) as client:
-            response = await client.post(self._refresh_url, json=payload, headers=headers)
+            response = await client.post(
+                self._refresh_url, json=payload, headers=headers
+            )
             response.raise_for_status()
             data = response.json()
-        
+
         new_access_token = data.get("accessToken")
         new_refresh_token = data.get("refreshToken")
         expires_in = data.get("expiresIn", 3600)
         new_profile_arn = data.get("profileArn")
-        
+
         if not new_access_token:
             raise ValueError(f"Response does not contain accessToken: {data}")
-        
+
         # Update data
         self._access_token = new_access_token
         if new_refresh_token:
             self._refresh_token = new_refresh_token
         if new_profile_arn:
             self._profile_arn = new_profile_arn
-        
+
         # Calculate expiration time with buffer (minus 60 seconds)
         self._expires_at = datetime.now(timezone.utc).replace(microsecond=0)
         self._expires_at = datetime.fromtimestamp(
-            self._expires_at.timestamp() + expires_in - 60,
-            tz=timezone.utc
+            self._expires_at.timestamp() + expires_in - 60, tz=timezone.utc
         )
-        
-        logger.info(f"Token refreshed via Kiro Desktop Auth, expires: {self._expires_at.isoformat()}")
-        
+
+        logger.info(
+            f"Token refreshed via Kiro Desktop Auth, expires: {self._expires_at.isoformat()}"
+        )
+
         # Save to file
         self._save_credentials_to_file()
-    
+
     async def _refresh_token_aws_sso_oidc(self) -> None:
         """
         Refreshes token using AWS SSO OIDC endpoint.
-        
+
         Used by kiro-cli which authenticates via AWS IAM Identity Center.
-        
+
         Strategy: Try with current in-memory token first. If it fails with 400
         (invalid_request - token was invalidated by kiro-cli re-login), reload
         credentials from SQLite and retry once.
-        
+
         This approach handles both scenarios:
         1. Container successfully refreshed token (uses in-memory token)
         2. kiro-cli re-login invalidated token (reloads from SQLite on failure)
-        
+
         Endpoint: https://oidc.{region}.amazonaws.com/token
         Method: POST
         Content-Type: application/x-www-form-urlencoded
         Body: grant_type=refresh_token&client_id=...&client_secret=...&refresh_token=...
-        
+
         Raises:
             ValueError: If required credentials are not set
             httpx.HTTPError: On HTTP request error
@@ -494,19 +521,21 @@ class KiroAuthManager:
         except httpx.HTTPStatusError as e:
             # 400 = invalid_request, likely stale token after kiro-cli re-login
             if e.response.status_code == 400 and self._sqlite_db:
-                logger.warning("Token refresh failed with 400, reloading credentials from SQLite and retrying...")
+                logger.warning(
+                    "Token refresh failed with 400, reloading credentials from SQLite and retrying..."
+                )
                 self._load_credentials_from_sqlite(self._sqlite_db)
                 await self._do_aws_sso_oidc_refresh()
             else:
                 raise
-    
+
     async def _do_aws_sso_oidc_refresh(self) -> None:
         """
         Performs the actual AWS SSO OIDC token refresh.
-        
+
         This is the internal implementation called by _refresh_token_aws_sso_oidc().
         It performs a single refresh attempt with current in-memory credentials.
-        
+
         Raises:
             ValueError: If required credentials are not set
             httpx.HTTPStatusError: On HTTP error (including 400 for invalid token)
@@ -517,9 +546,9 @@ class KiroAuthManager:
             raise ValueError("Client ID is not set (required for AWS SSO OIDC)")
         if not self._client_secret:
             raise ValueError("Client secret is not set (required for AWS SSO OIDC)")
-        
+
         logger.info("Refreshing Kiro token via AWS SSO OIDC...")
-        
+
         # AWS SSO OIDC uses form-urlencoded data
         # Use SSO region for OIDC endpoint (may differ from API region)
         sso_region = self._sso_region or self._region
@@ -530,73 +559,85 @@ class KiroAuthManager:
             "client_secret": self._client_secret,
             "refresh_token": self._refresh_token,
         }
-        
+
         # Note: scope parameter is NOT sent during refresh per OAuth 2.0 RFC 6749 Section 6
         # AWS SSO OIDC uses the originally granted scopes automatically
         headers = {
             "Content-Type": "application/x-www-form-urlencoded",
         }
-        
+
         # Log request details (without secrets) for debugging
-        logger.debug(f"AWS SSO OIDC refresh request: url={url}, sso_region={sso_region}, "
-                     f"api_region={self._region}, client_id={self._client_id[:8]}...")
-        
+        logger.debug(
+            f"AWS SSO OIDC refresh request: url={url}, sso_region={sso_region}, "
+            f"api_region={self._region}, client_id={self._client_id[:8]}..."
+        )
+
         async with httpx.AsyncClient(timeout=30) as client:
             response = await client.post(url, data=data, headers=headers)
-            
+
             # Log response details for debugging (especially on errors)
             if response.status_code != 200:
                 error_body = response.text
-                logger.error(f"AWS SSO OIDC refresh failed: status={response.status_code}, "
-                             f"body={error_body}")
+                logger.error(
+                    f"AWS SSO OIDC refresh failed: status={response.status_code}, "
+                    f"body={error_body}"
+                )
                 # Try to parse AWS error for more details
                 try:
                     error_json = response.json()
                     error_code = error_json.get("error", "unknown")
                     error_desc = error_json.get("error_description", "no description")
-                    logger.error(f"AWS SSO OIDC error details: error={error_code}, "
-                                 f"description={error_desc}")
+                    logger.error(
+                        f"AWS SSO OIDC error details: error={error_code}, "
+                        f"description={error_desc}"
+                    )
                 except Exception:
                     pass  # Body wasn't JSON, already logged as text
                 response.raise_for_status()
-            
+
             result = response.json()
-        
+
         new_access_token = result.get("accessToken")
         new_refresh_token = result.get("refreshToken")
         expires_in = result.get("expiresIn", 3600)
-        
+
         if not new_access_token:
-            raise ValueError(f"AWS SSO OIDC response does not contain accessToken: {result}")
-        
+            raise ValueError(
+                f"AWS SSO OIDC response does not contain accessToken: {result}"
+            )
+
         # Update data
         self._access_token = new_access_token
         if new_refresh_token:
             self._refresh_token = new_refresh_token
-        
+
         # Calculate expiration time with buffer (minus 60 seconds)
-        self._expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in - 60)
-        
-        logger.info(f"Token refreshed via AWS SSO OIDC, expires: {self._expires_at.isoformat()}")
-        
+        self._expires_at = datetime.now(timezone.utc) + timedelta(
+            seconds=expires_in - 60
+        )
+
+        logger.info(
+            f"Token refreshed via AWS SSO OIDC, expires: {self._expires_at.isoformat()}"
+        )
+
         # Save to file
         self._save_credentials_to_file()
-    
+
     async def get_access_token(self) -> str:
         """
         Returns a valid access_token, refreshing it if necessary.
-        
+
         Thread-safe method using asyncio.Lock.
         Automatically refreshes the token if it has expired or is about to expire.
-        
+
         For SQLite mode (kiro-cli): implements graceful degradation when refresh fails.
         If kiro-cli has been running and refreshing tokens in memory (without persisting
         to SQLite), the refresh_token in SQLite becomes stale. In this case, we fall back
         to using the access_token directly until it actually expires.
-        
+
         Returns:
             Valid access token
-        
+
         Raises:
             ValueError: If unable to obtain access token
         """
@@ -604,16 +645,20 @@ class KiroAuthManager:
             # Token is valid and not expiring soon - just return it
             if self._access_token and not self.is_token_expiring_soon():
                 return self._access_token
-            
+
             # SQLite mode: reload credentials first, kiro-cli might have updated them
             if self._sqlite_db and self.is_token_expiring_soon():
-                logger.debug("SQLite mode: reloading credentials before refresh attempt")
+                logger.debug(
+                    "SQLite mode: reloading credentials before refresh attempt"
+                )
                 self._load_credentials_from_sqlite(self._sqlite_db)
                 # Check if reloaded token is now valid
                 if self._access_token and not self.is_token_expiring_soon():
-                    logger.debug("SQLite reload provided fresh token, no refresh needed")
+                    logger.debug(
+                        "SQLite reload provided fresh token, no refresh needed"
+                    )
                     return self._access_token
-            
+
             # Try to refresh the token
             try:
                 await self._refresh_token_request()
@@ -642,50 +687,50 @@ class KiroAuthManager:
             except Exception:
                 # For any other exception, propagate it
                 raise
-            
+
             if not self._access_token:
                 raise ValueError("Failed to obtain access token")
-            
+
             return self._access_token
-    
+
     async def force_refresh(self) -> str:
         """
         Forces a token refresh.
-        
+
         Used when receiving a 403 error from the API.
-        
+
         Returns:
             New access token
         """
         async with self._lock:
             await self._refresh_token_request()
             return self._access_token
-    
+
     @property
     def profile_arn(self) -> Optional[str]:
         """AWS CodeWhisperer profile ARN."""
         return self._profile_arn
-    
+
     @property
     def region(self) -> str:
         """AWS region."""
         return self._region
-    
+
     @property
     def api_host(self) -> str:
         """API host for the current region."""
         return self._api_host
-    
+
     @property
     def q_host(self) -> str:
         """Q API host for the current region."""
         return self._q_host
-    
+
     @property
     def fingerprint(self) -> str:
         """Unique machine fingerprint."""
         return self._fingerprint
-    
+
     @property
     def auth_type(self) -> AuthType:
         """Authentication type (KIRO_DESKTOP or AWS_SSO_OIDC)."""

--- a/kiro/cache.py
+++ b/kiro/cache.py
@@ -36,24 +36,24 @@ from kiro.config import MODEL_CACHE_TTL, DEFAULT_MAX_INPUT_TOKENS
 class ModelInfoCache:
     """
     Thread-safe cache for storing model metadata.
-    
+
     Uses Lazy Loading for population - data is loaded
     only on first access or when cache is stale.
-    
+
     Attributes:
         cache_ttl: Cache time-to-live in seconds
-    
+
     Example:
         >>> cache = ModelInfoCache()
         >>> await cache.update([{"modelId": "claude-sonnet-4", "tokenLimits": {...}}])
         >>> info = cache.get("claude-sonnet-4")
         >>> max_tokens = cache.get_max_input_tokens("claude-sonnet-4")
     """
-    
+
     def __init__(self, cache_ttl: int = MODEL_CACHE_TTL):
         """
         Initializes the model cache.
-        
+
         Args:
             cache_ttl: Cache time-to-live in seconds (default from config)
         """
@@ -61,13 +61,13 @@ class ModelInfoCache:
         self._lock = asyncio.Lock()
         self._last_update: Optional[float] = None
         self._cache_ttl = cache_ttl
-    
+
     async def update(self, models_data: List[Dict[str, Any]]) -> None:
         """
         Updates the model cache.
-        
+
         Thread-safely replaces cache contents with new data.
-        
+
         Args:
             models_data: List of dictionaries with model information.
                         Each dictionary must contain the "modelId" key.
@@ -76,41 +76,41 @@ class ModelInfoCache:
             logger.info(f"Updating model cache. Found {len(models_data)} models.")
             self._cache = {model["modelId"]: model for model in models_data}
             self._last_update = time.time()
-    
+
     def get(self, model_id: str) -> Optional[Dict[str, Any]]:
         """
         Returns model information.
-        
+
         Args:
             model_id: Model ID
-        
+
         Returns:
             Dictionary with model information or None if model not found
         """
         return self._cache.get(model_id)
-    
+
     def is_valid_model(self, model_id: str) -> bool:
         """
         Check if model exists in dynamic cache.
-        
+
         Used by ModelResolver to verify if a model is available.
-        
+
         Args:
             model_id: Model ID to check
-        
+
         Returns:
             True if model exists in cache, False otherwise
         """
         return model_id in self._cache
-    
+
     def add_hidden_model(self, display_name: str, internal_id: str) -> None:
         """
         Add a hidden model to the cache.
-        
+
         Hidden models are not returned by Kiro /ListAvailableModels API
         but are still functional. They are added to the cache so they
         appear in our /v1/models endpoint.
-        
+
         Args:
             display_name: Model name to display (e.g., "claude-3.7-sonnet")
             internal_id: Internal Kiro ID (e.g., "CLAUDE_3_7_SONNET_20250219_V1_0")
@@ -125,35 +125,37 @@ class ModelInfoCache:
                 "_is_hidden": True,  # Mark as hidden model
             }
             logger.debug(f"Added hidden model: {display_name} → {internal_id}")
-    
+
     def get_max_input_tokens(self, model_id: str) -> int:
         """
         Returns maxInputTokens for the model.
-        
+
         Args:
             model_id: Model ID
-        
+
         Returns:
             Maximum number of input tokens or DEFAULT_MAX_INPUT_TOKENS
         """
         model = self._cache.get(model_id)
         if model and model.get("tokenLimits"):
-            return model["tokenLimits"].get("maxInputTokens") or DEFAULT_MAX_INPUT_TOKENS
+            return (
+                model["tokenLimits"].get("maxInputTokens") or DEFAULT_MAX_INPUT_TOKENS
+            )
         return DEFAULT_MAX_INPUT_TOKENS
-    
+
     def is_empty(self) -> bool:
         """
         Checks if the cache is empty.
-        
+
         Returns:
             True if cache is empty
         """
         return not self._cache
-    
+
     def is_stale(self) -> bool:
         """
         Checks if the cache is stale.
-        
+
         Returns:
             True if cache is stale (more than cache_ttl seconds have passed)
             or if cache was never updated
@@ -161,21 +163,21 @@ class ModelInfoCache:
         if not self._last_update:
             return True
         return time.time() - self._last_update > self._cache_ttl
-    
+
     def get_all_model_ids(self) -> List[str]:
         """
         Returns a list of all model IDs in the cache.
-        
+
         Returns:
             List of model IDs
         """
         return list(self._cache.keys())
-    
+
     @property
     def size(self) -> int:
         """Number of models in the cache."""
         return len(self._cache)
-    
+
     @property
     def last_update_time(self) -> Optional[float]:
         """Last update time (timestamp) or None."""

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -37,44 +37,45 @@ load_dotenv()
 def _get_raw_env_value(var_name: str, env_file: str = ".env") -> Optional[str]:
     """
     Read variable value from .env file without processing escape sequences.
-    
+
     This is necessary for correct handling of Windows paths where backslashes
     (e.g., D:\\Projects\\file.json) may be incorrectly interpreted
     as escape sequences (\\a -> bell, \\n -> newline, etc.).
-    
+
     Args:
         var_name: Environment variable name
         env_file: Path to .env file (default ".env")
-    
+
     Returns:
         Raw variable value or None if not found
     """
     env_path = Path(env_file)
     if not env_path.exists():
         return None
-    
+
     try:
         # Read file as-is, without interpretation
         content = env_path.read_text(encoding="utf-8")
-        
+
         # Search for variable considering different formats:
         # VAR="value" or VAR='value' or VAR=value
         # Pattern captures value with or without quotes
         pattern = rf'^{re.escape(var_name)}=(["\']?)(.+?)\1\s*$'
-        
+
         for line in content.splitlines():
             line = line.strip()
             if line.startswith("#") or not line:
                 continue
-            
+
             match = re.match(pattern, line)
             if match:
                 # Return value as-is, without processing escape sequences
                 return match.group(2)
     except Exception:
         pass
-    
+
     return None
+
 
 # ==================================================================================================
 # Server Settings
@@ -114,14 +115,18 @@ REGION: str = os.getenv("KIRO_REGION", "us-east-1")
 # Path to credentials file (optional, alternative to .env)
 # Read directly from .env to avoid escape sequence issues on Windows
 # (e.g., \a in path D:\Projects\adolf is interpreted as bell character)
-_raw_creds_file = _get_raw_env_value("KIRO_CREDS_FILE") or os.getenv("KIRO_CREDS_FILE", "")
+_raw_creds_file = _get_raw_env_value("KIRO_CREDS_FILE") or os.getenv(
+    "KIRO_CREDS_FILE", ""
+)
 # Normalize path for cross-platform compatibility
 KIRO_CREDS_FILE: str = str(Path(_raw_creds_file)) if _raw_creds_file else ""
 
 # Path to kiro-cli SQLite database (optional, for AWS SSO OIDC authentication)
 # Default location: ~/.local/share/kiro-cli/data.sqlite3 (Linux/macOS)
 # or ~/.local/share/amazon-q/data.sqlite3 (amazon-q-developer-cli)
-_raw_cli_db_file = _get_raw_env_value("KIRO_CLI_DB_FILE") or os.getenv("KIRO_CLI_DB_FILE", "")
+_raw_cli_db_file = _get_raw_env_value("KIRO_CLI_DB_FILE") or os.getenv(
+    "KIRO_CLI_DB_FILE", ""
+)
 KIRO_CLI_DB_FILE: str = str(Path(_raw_cli_db_file)) if _raw_cli_db_file else ""
 
 # ==================================================================================================
@@ -129,13 +134,16 @@ KIRO_CLI_DB_FILE: str = str(Path(_raw_cli_db_file)) if _raw_cli_db_file else ""
 # ==================================================================================================
 
 # URL for token refresh (Kiro Desktop Auth)
-KIRO_REFRESH_URL_TEMPLATE: str = "https://prod.{region}.auth.desktop.kiro.dev/refreshToken"
+KIRO_REFRESH_URL_TEMPLATE: str = (
+    "https://prod.{region}.auth.desktop.kiro.dev/refreshToken"
+)
 
 # URL for token refresh (AWS SSO OIDC - used by kiro-cli)
 AWS_SSO_OIDC_URL_TEMPLATE: str = "https://oidc.{region}.amazonaws.com/token"
 
 # Host for main API (generateAssistantResponse)
-KIRO_API_HOST_TEMPLATE: str = "https://codewhisperer.{region}.amazonaws.com"
+# CHANGED: Updated to q.{region}.amazonaws.com based on new inspection logs
+KIRO_API_HOST_TEMPLATE: str = "https://q.{region}.amazonaws.com"
 
 # Host for Q API (ListAvailableModels)
 KIRO_Q_HOST_TEMPLATE: str = "https://q.{region}.amazonaws.com"
@@ -176,7 +184,6 @@ HIDDEN_MODELS: Dict[str, str] = {
     # Claude 3.7 Sonnet - legacy flagship model, still works!
     # Hidden in Kiro API but functional. Great for users who prefer it.
     "claude-3.7-sonnet": "CLAUDE_3_7_SONNET_20250219_V1_0",
-    
     # Add other hidden/experimental models here as discovered.
     # Example: "claude-secret-model": "INTERNAL_SECRET_MODEL_ID",
 }
@@ -210,7 +217,9 @@ DEFAULT_MAX_INPUT_TOKENS: int = 200000
 # Maximum length of tool description in characters.
 # Descriptions longer than this limit will be moved to system prompt.
 # Set to 0 to disable (not recommended - will cause Kiro API errors).
-TOOL_DESCRIPTION_MAX_LENGTH: int = int(os.getenv("TOOL_DESCRIPTION_MAX_LENGTH", "10000"))
+TOOL_DESCRIPTION_MAX_LENGTH: int = int(
+    os.getenv("TOOL_DESCRIPTION_MAX_LENGTH", "10000")
+)
 
 # ==================================================================================================
 # Logging Settings
@@ -282,10 +291,11 @@ def _warn_deprecated_debug_setting():
     """
     if _DEBUG_LAST_REQUEST_RAW and not _DEBUG_MODE_RAW:
         import sys
+
         # ANSI escape codes: yellow text
         YELLOW = "\033[93m"
         RESET = "\033[0m"
-        
+
         warning_text = f"""
 {YELLOW}⚠️  DEPRECATED: DEBUG_LAST_REQUEST will be removed in future releases.
     Please use DEBUG_MODE instead:
@@ -303,16 +313,17 @@ def _warn_timeout_configuration():
     """
     Print warning if timeout configuration is suboptimal.
     Called at application startup.
-    
+
     FIRST_TOKEN_TIMEOUT should be less than STREAMING_READ_TIMEOUT:
     - FIRST_TOKEN_TIMEOUT: time to wait for model to START responding
     - STREAMING_READ_TIMEOUT: time to wait BETWEEN chunks during streaming
     """
     if FIRST_TOKEN_TIMEOUT >= STREAMING_READ_TIMEOUT:
         import sys
+
         YELLOW = "\033[93m"
         RESET = "\033[0m"
-        
+
         warning_text = f"""
 {YELLOW}⚠️  WARNING: Suboptimal timeout configuration detected.
     
@@ -330,6 +341,7 @@ def _warn_timeout_configuration():
 """
         print(warning_text, file=sys.stderr)
 
+
 # ==================================================================================================
 # Fake Reasoning Settings (Extended Thinking via Tag Injection)
 # ==================================================================================================
@@ -346,7 +358,13 @@ def _warn_timeout_configuration():
 # Default: true (enabled) - provides premium experience out of the box
 _FAKE_REASONING_RAW: str = os.getenv("FAKE_REASONING", "").lower()
 # Default is True - if env var is not set or empty, enable fake reasoning
-FAKE_REASONING_ENABLED: bool = _FAKE_REASONING_RAW not in ("false", "0", "no", "disabled", "off")
+FAKE_REASONING_ENABLED: bool = _FAKE_REASONING_RAW not in (
+    "false",
+    "0",
+    "no",
+    "disabled",
+    "off",
+)
 
 # Maximum thinking length in tokens.
 # This value is injected into the request as <max_thinking_length>{value}</max_thinking_length>
@@ -361,8 +379,15 @@ FAKE_REASONING_MAX_TOKENS: int = int(os.getenv("FAKE_REASONING_MAX_TOKENS", "400
 # - "strip_tags": Remove tags but keep thinking content in regular content
 #
 # Default: "as_reasoning_content"
-_FAKE_REASONING_HANDLING_RAW: str = os.getenv("FAKE_REASONING_HANDLING", "as_reasoning_content").lower()
-if _FAKE_REASONING_HANDLING_RAW in ("as_reasoning_content", "remove", "pass", "strip_tags"):
+_FAKE_REASONING_HANDLING_RAW: str = os.getenv(
+    "FAKE_REASONING_HANDLING", "as_reasoning_content"
+).lower()
+if _FAKE_REASONING_HANDLING_RAW in (
+    "as_reasoning_content",
+    "remove",
+    "pass",
+    "strip_tags",
+):
     FAKE_REASONING_HANDLING: str = _FAKE_REASONING_HANDLING_RAW
 else:
     FAKE_REASONING_HANDLING: str = "as_reasoning_content"
@@ -370,13 +395,20 @@ else:
 # List of opening tags to detect thinking blocks.
 # The parser will look for any of these tags at the start of the response.
 # Order matters - first match wins.
-FAKE_REASONING_OPEN_TAGS: List[str] = ["<thinking>", "<think>", "<reasoning>", "<thought>"]
+FAKE_REASONING_OPEN_TAGS: List[str] = [
+    "<thinking>",
+    "<think>",
+    "<reasoning>",
+    "<thought>",
+]
 
 # Maximum size of initial buffer for tag detection (characters).
 # If no thinking tag is found within this limit, content is treated as regular response.
 # Lower values = faster first token, but may miss tags with leading whitespace.
 # Default: 30 characters (enough for longest tag + some whitespace)
-FAKE_REASONING_INITIAL_BUFFER_SIZE: int = int(os.getenv("FAKE_REASONING_INITIAL_BUFFER_SIZE", "20"))
+FAKE_REASONING_INITIAL_BUFFER_SIZE: int = int(
+    os.getenv("FAKE_REASONING_INITIAL_BUFFER_SIZE", "20")
+)
 
 
 # ==================================================================================================
@@ -385,7 +417,9 @@ FAKE_REASONING_INITIAL_BUFFER_SIZE: int = int(os.getenv("FAKE_REASONING_INITIAL_
 
 APP_VERSION: str = "2.0"
 APP_TITLE: str = "Kiro Gateway"
-APP_DESCRIPTION: str = "OpenAI-compatible interface for Kiro API (AWS CodeWhisperer). Made by @jwadow"
+APP_DESCRIPTION: str = (
+    "OpenAI-compatible interface for Kiro API (AWS CodeWhisperer). Made by @jwadow"
+)
 
 
 def get_kiro_refresh_url(region: str) -> str:
@@ -406,4 +440,3 @@ def get_kiro_api_host(region: str) -> str:
 def get_kiro_q_host(region: str) -> str:
     """Return Q API host for the specified region."""
     return KIRO_Q_HOST_TEMPLATE.format(region=region)
-

--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -47,20 +47,20 @@ from kiro.converters_core import (
 def convert_anthropic_content_to_text(content: Any) -> str:
     """
     Extracts text content from Anthropic message content.
-    
+
     Anthropic content can be:
     - String: "Hello, world!"
     - List of content blocks: [{"type": "text", "text": "Hello"}]
-    
+
     Args:
         content: Anthropic message content
-    
+
     Returns:
         Extracted text content
     """
     if isinstance(content, str):
         return content
-    
+
     if isinstance(content, list):
         text_parts = []
         for block in content:
@@ -70,33 +70,33 @@ def convert_anthropic_content_to_text(content: Any) -> str:
             elif hasattr(block, "type") and block.type == "text":
                 text_parts.append(block.text)
         return "".join(text_parts)
-    
+
     return str(content) if content else ""
 
 
 def extract_system_prompt(system: Any) -> str:
     """
     Extracts system prompt text from Anthropic system field.
-    
+
     Anthropic API supports system in two formats:
     1. String: "You are helpful"
     2. List of content blocks: [{"type": "text", "text": "...", "cache_control": {...}}]
-    
+
     The second format is used for prompt caching with cache_control.
     We extract only the text, ignoring cache_control (not supported by Kiro).
-    
+
     Args:
         system: System prompt in string or list format
-    
+
     Returns:
         Extracted system prompt as string
     """
     if system is None:
         return ""
-    
+
     if isinstance(system, str):
         return system
-    
+
     if isinstance(system, list):
         text_parts = []
         for block in system:
@@ -108,32 +108,32 @@ def extract_system_prompt(system: Any) -> str:
                 # Handle Pydantic model
                 text_parts.append(getattr(block, "text", ""))
         return "\n".join(text_parts)
-    
+
     return str(system)
 
 
 def extract_tool_results_from_anthropic_content(content: Any) -> List[Dict[str, Any]]:
     """
     Extracts tool results from Anthropic message content.
-    
+
     Looks for content blocks with type="tool_result".
-    
+
     Args:
         content: Anthropic message content (list of content blocks)
-    
+
     Returns:
         List of tool results in unified format
     """
     tool_results = []
-    
+
     if not isinstance(content, list):
         return tool_results
-    
+
     for block in content:
         block_type = None
         tool_use_id = None
         result_content = ""
-        
+
         if isinstance(block, dict):
             block_type = block.get("type")
             tool_use_id = block.get("tool_use_id")
@@ -142,46 +142,48 @@ def extract_tool_results_from_anthropic_content(content: Any) -> List[Dict[str, 
             block_type = block.type
             tool_use_id = getattr(block, "tool_use_id", None)
             result_content = getattr(block, "content", "")
-        
+
         if block_type == "tool_result" and tool_use_id:
             # Convert content to text if it's a list
             if isinstance(result_content, list):
                 result_content = extract_text_content(result_content)
             elif not isinstance(result_content, str):
                 result_content = str(result_content) if result_content else ""
-            
-            tool_results.append({
-                "type": "tool_result",
-                "tool_use_id": tool_use_id,
-                "content": result_content or "(empty result)"
-            })
-    
+
+            tool_results.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": result_content or "(empty result)",
+                }
+            )
+
     return tool_results
 
 
 def extract_tool_uses_from_anthropic_content(content: Any) -> List[Dict[str, Any]]:
     """
     Extracts tool uses from Anthropic assistant message content.
-    
+
     Looks for content blocks with type="tool_use".
-    
+
     Args:
         content: Anthropic message content (list of content blocks)
-    
+
     Returns:
         List of tool calls in unified format
     """
     tool_calls = []
-    
+
     if not isinstance(content, list):
         return tool_calls
-    
+
     for block in content:
         block_type = None
         tool_id = None
         tool_name = None
         tool_input = {}
-        
+
         if isinstance(block, dict):
             block_type = block.get("type")
             tool_id = block.get("id")
@@ -192,102 +194,110 @@ def extract_tool_uses_from_anthropic_content(content: Any) -> List[Dict[str, Any
             tool_id = getattr(block, "id", None)
             tool_name = getattr(block, "name", None)
             tool_input = getattr(block, "input", {})
-        
+
         if block_type == "tool_use" and tool_id and tool_name:
-            tool_calls.append({
-                "id": tool_id,
-                "type": "function",
-                "function": {
-                    "name": tool_name,
-                    "arguments": tool_input if isinstance(tool_input, str) else tool_input
+            tool_calls.append(
+                {
+                    "id": tool_id,
+                    "type": "function",
+                    "function": {
+                        "name": tool_name,
+                        "arguments": tool_input
+                        if isinstance(tool_input, str)
+                        else tool_input,
+                    },
                 }
-            })
-    
+            )
+
     return tool_calls
 
 
-def convert_anthropic_messages(messages: List[AnthropicMessage]) -> List[UnifiedMessage]:
+def convert_anthropic_messages(
+    messages: List[AnthropicMessage],
+) -> List[UnifiedMessage]:
     """
     Converts Anthropic messages to unified format.
-    
+
     Handles:
     - Text content (string or list of text blocks)
     - Tool use blocks (assistant messages)
     - Tool result blocks (user messages)
-    
+
     Args:
         messages: List of Anthropic messages
-    
+
     Returns:
         List of messages in unified format
     """
-    
+
     unified_messages = []
     total_tool_calls = 0
     total_tool_results = 0
     total_images = 0
-    
+
     for msg in messages:
         role = msg.role
         content = msg.content
-        
+
         # Extract text content
         text_content = convert_anthropic_content_to_text(content)
-        
+
         # Extract tool-related data and images based on role
         tool_calls = None
         tool_results = None
         images = None
-        
+
         if role == "assistant":
             # Assistant messages may contain tool_use blocks
             tool_calls = extract_tool_uses_from_anthropic_content(content)
             if tool_calls:
                 total_tool_calls += len(tool_calls)
-        
+
         elif role == "user":
             # User messages may contain tool_result blocks and images
             tool_results = extract_tool_results_from_anthropic_content(content)
             if tool_results:
                 total_tool_results += len(tool_results)
-            
+
             # Extract images from user messages
             images = extract_images_from_content(content)
             if images:
                 total_images += len(images)
-        
+
         unified_msg = UnifiedMessage(
             role=role,
             content=text_content,
             tool_calls=tool_calls if tool_calls else None,
             tool_results=tool_results if tool_results else None,
-            images=images if images else None
+            images=images if images else None,
         )
         unified_messages.append(unified_msg)
-    
+
     # Log summary if any tool content or images were found
     if total_tool_calls > 0 or total_tool_results > 0 or total_images > 0:
         logger.debug(
             f"Converted {len(messages)} Anthropic messages: "
             f"{total_tool_calls} tool_calls, {total_tool_results} tool_results, {total_images} images"
         )
-    
+
     return unified_messages
 
 
-def convert_anthropic_tools(tools: Optional[List[AnthropicTool]]) -> Optional[List[UnifiedTool]]:
+def convert_anthropic_tools(
+    tools: Optional[List[AnthropicTool]],
+) -> Optional[List[UnifiedTool]]:
     """
     Converts Anthropic tools to unified format.
-    
+
     Args:
         tools: List of Anthropic tools
-    
+
     Returns:
         List of tools in unified format, or None if no tools
     """
     if not tools:
         return None
-    
+
     unified_tools = []
     for tool in tools:
         # Handle both dict and Pydantic model
@@ -299,62 +309,58 @@ def convert_anthropic_tools(tools: Optional[List[AnthropicTool]]) -> Optional[Li
             name = tool.name
             description = tool.description
             input_schema = tool.input_schema
-        
-        unified_tools.append(UnifiedTool(
-            name=name,
-            description=description,
-            input_schema=input_schema
-        ))
-    
+
+        unified_tools.append(
+            UnifiedTool(name=name, description=description, input_schema=input_schema)
+        )
+
     return unified_tools if unified_tools else None
 
 
 def anthropic_to_kiro(
-    request: AnthropicMessagesRequest,
-    conversation_id: str,
-    profile_arn: str
+    request: AnthropicMessagesRequest, conversation_id: str, profile_arn: str
 ) -> dict:
     """
     Converts Anthropic Messages API request to Kiro API payload.
-    
+
     This is the main entry point for Anthropic → Kiro conversion.
-    
+
     Key differences from OpenAI:
     - System prompt is a separate field (not in messages)
     - Content can be string or list of content blocks
     - Tool format uses input_schema instead of parameters
-    
+
     Args:
         request: Anthropic MessagesRequest
         conversation_id: Unique conversation ID
         profile_arn: AWS CodeWhisperer profile ARN
-    
+
     Returns:
         Payload dictionary for POST request to Kiro API
-    
+
     Raises:
         ValueError: If there are no messages to send
     """
     # Convert messages to unified format
     unified_messages = convert_anthropic_messages(request.messages)
-    
+
     # Convert tools to unified format
     unified_tools = convert_anthropic_tools(request.tools)
-    
+
     # System prompt is already separate in Anthropic format!
     # It can be a string or list of content blocks (for prompt caching)
     system_prompt = extract_system_prompt(request.system)
-    
+
     # Get model ID for Kiro API (normalizes + resolves hidden models)
     # Pass-through principle: we normalize and send to Kiro, Kiro decides if valid
     model_id = get_model_id_for_kiro(request.model, HIDDEN_MODELS)
-    
+
     logger.debug(
         f"Converting Anthropic request: model={request.model} -> {model_id}, "
         f"messages={len(unified_messages)}, tools={len(unified_tools) if unified_tools else 0}, "
         f"system_prompt_length={len(system_prompt)}"
     )
-    
+
     # Use core function to build payload
     result = build_kiro_payload(
         messages=unified_messages,
@@ -363,7 +369,7 @@ def anthropic_to_kiro(
         tools=unified_tools,
         conversation_id=conversation_id,
         profile_arn=profile_arn,
-        inject_thinking=True
+        inject_thinking=True,
     )
-    
+
     return result.payload

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -31,7 +31,7 @@ to convert their formats to Kiro API format.
 """
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
 from loguru import logger
@@ -47,14 +47,15 @@ from kiro.config import (
 # Data Classes for Unified Message Format
 # ==================================================================================================
 
+
 @dataclass
 class UnifiedMessage:
     """
     Unified message format used internally by converters.
-    
+
     This format is API-agnostic and can be created from both OpenAI and Anthropic formats.
     Serves as the canonical representation for all message data before conversion to Kiro API.
-    
+
     Attributes:
         role: Message role (user, assistant, system)
         content: Text content or list of content blocks
@@ -63,6 +64,7 @@ class UnifiedMessage:
         images: List of images in unified format (for multimodal user messages)
                 Format: [{"media_type": "image/jpeg", "data": "base64..."}]
     """
+
     role: str
     content: Any = ""
     tool_calls: Optional[List[Dict[str, Any]]] = None
@@ -74,12 +76,13 @@ class UnifiedMessage:
 class UnifiedTool:
     """
     Unified tool format used internally by converters.
-    
+
     Attributes:
         name: Tool name
         description: Tool description
         input_schema: JSON Schema for tool parameters
     """
+
     name: str
     description: Optional[str] = None
     input_schema: Optional[Dict[str, Any]] = None
@@ -89,11 +92,12 @@ class UnifiedTool:
 class KiroPayloadResult:
     """
     Result of building Kiro payload.
-    
+
     Attributes:
         payload: The complete Kiro API payload
         tool_documentation: Documentation for tools with long descriptions (to add to system prompt)
     """
+
     payload: Dict[str, Any]
     tool_documentation: str = ""
 
@@ -102,21 +106,22 @@ class KiroPayloadResult:
 # Text Content Extraction
 # ==================================================================================================
 
+
 def extract_text_content(content: Any) -> str:
     """
     Extracts text content from various formats.
-    
+
     Supports multiple content formats used by different APIs:
     - String: "Hello, world!"
     - List of content blocks: [{"type": "text", "text": "Hello"}]
     - None: empty message
-    
+
     Args:
         content: Content in any supported format
-    
+
     Returns:
         Extracted text or empty string
-    
+
     Example:
         >>> extract_text_content("Hello")
         'Hello'
@@ -149,31 +154,31 @@ def extract_text_content(content: Any) -> str:
 def extract_images_from_content(content: Any) -> List[Dict[str, Any]]:
     """
     Extracts images from message content in unified format.
-    
+
     Supports multiple image formats used by different APIs:
-    
+
     OpenAI format (image_url with data URL):
         {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,/9j/..."}}
-    
+
     Anthropic format (image with source):
         {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": "/9j/..."}}
-    
+
     Args:
         content: Content in any supported format (usually a list of content blocks)
-    
+
     Returns:
         List of images in unified format: [{"media_type": "image/jpeg", "data": "base64..."}]
         Empty list if no images found or content is not a list.
-    
+
     Example:
         >>> extract_images_from_content([{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "abc123"}}])
         [{'media_type': 'image/png', 'data': 'abc123'}]
     """
     images: List[Dict[str, Any]] = []
-    
+
     if not isinstance(content, list):
         return images
-    
+
     for item in content:
         # Handle both dict and Pydantic model objects
         if isinstance(item, dict):
@@ -182,21 +187,21 @@ def extract_images_from_content(content: Any) -> List[Dict[str, Any]]:
             item_type = item.type
         else:
             continue
-        
+
         # OpenAI format: {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}
         if item_type == "image_url":
             if isinstance(item, dict):
                 image_url_obj = item.get("image_url", {})
             else:
                 image_url_obj = getattr(item, "image_url", {})
-            
+
             if isinstance(image_url_obj, dict):
                 url = image_url_obj.get("url", "")
             elif hasattr(image_url_obj, "url"):
                 url = image_url_obj.url
             else:
                 url = ""
-            
+
             if url.startswith("data:"):
                 # Parse data URL: data:image/jpeg;base64,/9j/4AAQ...
                 try:
@@ -204,60 +209,61 @@ def extract_images_from_content(content: Any) -> List[Dict[str, Any]]:
                     # Extract media type from "data:image/jpeg;base64"
                     media_part = header.split(";")[0]  # "data:image/jpeg"
                     media_type = media_part.replace("data:", "")  # "image/jpeg"
-                    
+
                     if data:
-                        images.append({
-                            "media_type": media_type,
-                            "data": data
-                        })
+                        images.append({"media_type": media_type, "data": data})
                 except (ValueError, IndexError) as e:
                     logger.warning(f"Failed to parse image data URL: {e}")
             elif url.startswith("http"):
                 # URL-based images require fetching - not supported by Kiro API directly
-                logger.warning(f"URL-based images are not supported by Kiro API, skipping: {url[:80]}...")
-        
+                logger.warning(
+                    f"URL-based images are not supported by Kiro API, skipping: {url[:80]}..."
+                )
+
         # Anthropic format: {"type": "image", "source": {"type": "base64", "media_type": "...", "data": "..."}}
         elif item_type == "image":
-            source = item.get("source", {}) if isinstance(item, dict) else getattr(item, "source", None)
-            
+            source = (
+                item.get("source", {})
+                if isinstance(item, dict)
+                else getattr(item, "source", None)
+            )
+
             if source is None:
                 continue
-            
+
             if isinstance(source, dict):
                 source_type = source.get("type")
-                
+
                 if source_type == "base64":
                     media_type = source.get("media_type", "image/jpeg")
                     data = source.get("data", "")
-                    
+
                     if data:
-                        images.append({
-                            "media_type": media_type,
-                            "data": data
-                        })
+                        images.append({"media_type": media_type, "data": data})
                 elif source_type == "url":
                     # URL-based images in Anthropic format
                     url = source.get("url", "")
-                    logger.warning(f"URL-based images are not supported by Kiro API, skipping: {url[:80]}...")
-            
+                    logger.warning(
+                        f"URL-based images are not supported by Kiro API, skipping: {url[:80]}..."
+                    )
+
             # Handle Pydantic model objects (ImageContentBlock.source)
             elif hasattr(source, "type"):
                 if source.type == "base64":
                     media_type = getattr(source, "media_type", "image/jpeg")
                     data = getattr(source, "data", "")
-                    
+
                     if data:
-                        images.append({
-                            "media_type": media_type,
-                            "data": data
-                        })
+                        images.append({"media_type": media_type, "data": data})
                 elif source.type == "url":
                     url = getattr(source, "url", "")
-                    logger.warning(f"URL-based images are not supported by Kiro API, skipping: {url[:80]}...")
-    
+                    logger.warning(
+                        f"URL-based images are not supported by Kiro API, skipping: {url[:80]}..."
+                    )
+
     if images:
         logger.debug(f"Extracted {len(images)} image(s) from content")
-    
+
     return images
 
 
@@ -265,21 +271,22 @@ def extract_images_from_content(content: Any) -> List[Dict[str, Any]]:
 # Thinking Mode Support (Fake Reasoning)
 # ==================================================================================================
 
+
 def get_thinking_system_prompt_addition() -> str:
     """
     Generate system prompt addition that legitimizes thinking tags.
-    
+
     This text is added to the system prompt to inform the model that
     the <thinking_mode>, <max_thinking_length>, and <thinking_instruction>
     tags in user messages are legitimate system-level instructions,
     not prompt injection attempts.
-    
+
     Returns:
         System prompt addition text (empty string if fake reasoning is disabled)
     """
     if not FAKE_REASONING_ENABLED:
         return ""
-    
+
     return (
         "\n\n---\n"
         "# Extended Thinking Mode\n\n"
@@ -298,20 +305,20 @@ def get_thinking_system_prompt_addition() -> str:
 def inject_thinking_tags(content: str) -> str:
     """
     Inject fake reasoning tags into content.
-    
+
     When FAKE_REASONING_ENABLED is True, this function prepends the special
     thinking mode tags to the content. These tags instruct the model to
     include its reasoning process in the response.
-    
+
     Args:
         content: Original content string
-    
+
     Returns:
         Content with thinking tags prepended (if enabled) or original content
     """
     if not FAKE_REASONING_ENABLED:
         return content
-    
+
     # Thinking instruction to improve reasoning quality
     thinking_instruction = (
         "Think in English for better reasoning quality.\n\n"
@@ -323,15 +330,17 @@ def inject_thinking_tags(content: str) -> str:
         "- Verify your reasoning before reaching a conclusion\n\n"
         "Take the time you need. Quality of thought matters more than speed."
     )
-    
+
     thinking_prefix = (
         f"<thinking_mode>enabled</thinking_mode>\n"
         f"<max_thinking_length>{FAKE_REASONING_MAX_TOKENS}</max_thinking_length>\n"
         f"<thinking_instruction>{thinking_instruction}</thinking_instruction>\n\n"
     )
-    
-    logger.debug(f"Injecting fake reasoning tags with max_tokens={FAKE_REASONING_MAX_TOKENS}")
-    
+
+    logger.debug(
+        f"Injecting fake reasoning tags with max_tokens={FAKE_REASONING_MAX_TOKENS}"
+    )
+
     return thinking_prefix + content
 
 
@@ -339,40 +348,43 @@ def inject_thinking_tags(content: str) -> str:
 # JSON Schema Sanitization
 # ==================================================================================================
 
+
 def sanitize_json_schema(schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """
     Sanitizes JSON Schema from fields that Kiro API doesn't accept.
-    
+
     Kiro API returns 400 "Improperly formed request" error if:
     - required is an empty array []
     - additionalProperties is present in schema
-    
+
     This function recursively processes the schema and removes problematic fields.
-    
+
     Args:
         schema: JSON Schema to sanitize
-    
+
     Returns:
         Sanitized copy of schema
     """
     if not schema:
         return {}
-    
+
     result = {}
-    
+
     for key, value in schema.items():
         # Skip empty required arrays
         if key == "required" and isinstance(value, list) and len(value) == 0:
             continue
-        
+
         # Skip additionalProperties - Kiro API doesn't support it
         if key == "additionalProperties":
             continue
-        
+
         # Recursively process nested objects
         if key == "properties" and isinstance(value, dict):
             result[key] = {
-                prop_name: sanitize_json_schema(prop_value) if isinstance(prop_value, dict) else prop_value
+                prop_name: sanitize_json_schema(prop_value)
+                if isinstance(prop_value, dict)
+                else prop_value
                 for prop_name, prop_value in value.items()
             }
         elif isinstance(value, dict):
@@ -385,7 +397,7 @@ def sanitize_json_schema(schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
             ]
         else:
             result[key] = value
-    
+
     return result
 
 
@@ -393,19 +405,20 @@ def sanitize_json_schema(schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
 # Tool Processing
 # ==================================================================================================
 
+
 def process_tools_with_long_descriptions(
-    tools: Optional[List[UnifiedTool]]
+    tools: Optional[List[UnifiedTool]],
 ) -> Tuple[Optional[List[UnifiedTool]], str]:
     """
     Processes tools with long descriptions.
-    
+
     Kiro API has a limit on description length in toolSpecification.
     If description exceeds the limit, full description is moved to system prompt,
     and a reference to documentation remains in the tool.
-    
+
     Args:
         tools: List of tools in unified format
-    
+
     Returns:
         Tuple of:
         - List of tools with processed descriptions (or None if tools is empty)
@@ -413,17 +426,17 @@ def process_tools_with_long_descriptions(
     """
     if not tools:
         return None, ""
-    
+
     # If limit is disabled (0), return tools unchanged
     if TOOL_DESCRIPTION_MAX_LENGTH <= 0:
         return tools, ""
-    
+
     tool_documentation_parts = []
     processed_tools = []
-    
+
     for tool in tools:
         description = tool.description or ""
-        
+
         if len(description) <= TOOL_DESCRIPTION_MAX_LENGTH:
             # Description is short - leave as is
             processed_tools.append(tool)
@@ -433,20 +446,22 @@ def process_tools_with_long_descriptions(
                 f"Tool '{tool.name}' has long description ({len(description)} chars > {TOOL_DESCRIPTION_MAX_LENGTH}), "
                 f"moving to system prompt"
             )
-            
+
             # Create documentation for system prompt
             tool_documentation_parts.append(f"## Tool: {tool.name}\n\n{description}")
-            
+
             # Create copy of tool with reference description
-            reference_description = f"[Full documentation in system prompt under '## Tool: {tool.name}']"
-            
+            reference_description = (
+                f"[Full documentation in system prompt under '## Tool: {tool.name}']"
+            )
+
             processed_tool = UnifiedTool(
                 name=tool.name,
                 description=reference_description,
-                input_schema=tool.input_schema
+                input_schema=tool.input_schema,
             )
             processed_tools.append(processed_tool)
-    
+
     # Form final documentation
     tool_documentation = ""
     if tool_documentation_parts:
@@ -456,42 +471,46 @@ def process_tools_with_long_descriptions(
             "The following tools have detailed documentation that couldn't fit in the tool definition.\n\n"
             + "\n\n---\n\n".join(tool_documentation_parts)
         )
-    
+
     return processed_tools if processed_tools else None, tool_documentation
 
 
-def convert_tools_to_kiro_format(tools: Optional[List[UnifiedTool]]) -> List[Dict[str, Any]]:
+def convert_tools_to_kiro_format(
+    tools: Optional[List[UnifiedTool]],
+) -> List[Dict[str, Any]]:
     """
     Converts unified tools to Kiro API format.
-    
+
     Args:
         tools: List of tools in unified format
-    
+
     Returns:
         List of tools in Kiro toolSpecification format
     """
     if not tools:
         return []
-    
+
     kiro_tools = []
     for tool in tools:
         # Sanitize parameters from fields that Kiro API doesn't accept
         sanitized_params = sanitize_json_schema(tool.input_schema)
-        
+
         # Kiro API requires non-empty description
         description = tool.description
         if not description or not description.strip():
             description = f"Tool: {tool.name}"
             logger.debug(f"Tool '{tool.name}' has empty description, using placeholder")
-        
-        kiro_tools.append({
-            "toolSpecification": {
-                "name": tool.name,
-                "description": description,
-                "inputSchema": {"json": sanitized_params}
+
+        kiro_tools.append(
+            {
+                "toolSpecification": {
+                    "name": tool.name,
+                    "description": description,
+                    "inputSchema": {"json": sanitized_params},
+                }
             }
-        })
-    
+        )
+
     return kiro_tools
 
 
@@ -499,41 +518,44 @@ def convert_tools_to_kiro_format(tools: Optional[List[UnifiedTool]]) -> List[Dic
 # Image Conversion to Kiro Format
 # ==================================================================================================
 
-def convert_images_to_kiro_format(images: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+
+def convert_images_to_kiro_format(
+    images: Optional[List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
     """
     Converts unified images to Kiro API format.
-    
+
     Unified format: [{"media_type": "image/jpeg", "data": "base64..."}]
     Kiro format: [{"format": "jpeg", "source": {"bytes": "base64..."}}]
-    
+
     IMPORTANT: Images must be placed directly in userInputMessage.images,
     NOT in userInputMessageContext.images. This matches the native Kiro IDE format.
-    
+
     Also handles the case where data contains a full data URL (data:image/jpeg;base64,...)
     by stripping the prefix and extracting pure base64.
-    
+
     Args:
         images: List of images in unified format
-    
+
     Returns:
         List of images in Kiro format, ready for userInputMessage.images
-    
+
     Example:
         >>> convert_images_to_kiro_format([{"media_type": "image/png", "data": "abc123"}])
         [{'format': 'png', 'source': {'bytes': 'abc123'}}]
     """
     if not images:
         return []
-    
+
     kiro_images = []
     for img in images:
         media_type = img.get("media_type", "image/jpeg")
         data = img.get("data", "")
-        
+
         if not data:
             logger.warning("Skipping image with empty data")
             continue
-        
+
         # Strip data URL prefix if present (some clients send "data:image/jpeg;base64,..." in data field)
         # Kiro API expects pure base64 without the prefix
         if data.startswith("data:"):
@@ -545,23 +567,20 @@ def convert_images_to_kiro_format(images: Optional[List[Dict[str, Any]]]) -> Lis
                 if extracted_media_type:
                     media_type = extracted_media_type
                 data = actual_data
-                logger.debug(f"Stripped data URL prefix, extracted media_type: {media_type}")
+                logger.debug(
+                    f"Stripped data URL prefix, extracted media_type: {media_type}"
+                )
             except (ValueError, IndexError) as e:
                 logger.warning(f"Failed to parse data URL prefix: {e}")
-        
+
         # Extract format from media_type: "image/jpeg" -> "jpeg"
         format_str = media_type.split("/")[-1] if "/" in media_type else media_type
-        
-        kiro_images.append({
-            "format": format_str,
-            "source": {
-                "bytes": data
-            }
-        })
-    
+
+        kiro_images.append({"format": format_str, "source": {"bytes": data}})
+
     if kiro_images:
         logger.debug(f"Converted {len(kiro_images)} image(s) to Kiro format")
-    
+
     return kiro_images
 
 
@@ -569,16 +588,19 @@ def convert_images_to_kiro_format(images: Optional[List[Dict[str, Any]]]) -> Lis
 # Tool Results and Tool Uses Extraction
 # ==================================================================================================
 
-def convert_tool_results_to_kiro_format(tool_results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+
+def convert_tool_results_to_kiro_format(
+    tool_results: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
     """
     Converts unified tool results to Kiro API format.
-    
+
     Unified format: {"type": "tool_result", "tool_use_id": "...", "content": "..."}
     Kiro format: {"content": [{"text": "..."}], "status": "success", "toolUseId": "..."}
-    
+
     Args:
         tool_results: List of tool results in unified format
-    
+
     Returns:
         List of tool results in Kiro format
     """
@@ -589,67 +611,75 @@ def convert_tool_results_to_kiro_format(tool_results: List[Dict[str, Any]]) -> L
             content_text = content
         else:
             content_text = extract_text_content(content)
-        
+
         # Ensure content is not empty - Kiro API requires non-empty content
         if not content_text:
             content_text = "(empty result)"
-        
-        kiro_results.append({
-            "content": [{"text": content_text}],
-            "status": "success",
-            "toolUseId": tr.get("tool_use_id", "")
-        })
-    
+
+        kiro_results.append(
+            {
+                "content": [{"text": content_text}],
+                "status": "success",
+                "toolUseId": tr.get("tool_use_id", ""),
+            }
+        )
+
     return kiro_results
 
 
 def extract_tool_results_from_content(content: Any) -> List[Dict[str, Any]]:
     """
     Extracts tool results from message content.
-    
+
     Looks for content blocks with type="tool_result" and converts them
     to Kiro API format.
-    
+
     Args:
         content: Message content (can be a list of content blocks)
-    
+
     Returns:
         List of tool results in Kiro format
     """
     tool_results = []
-    
+
     if isinstance(content, list):
         for item in content:
             if isinstance(item, dict) and item.get("type") == "tool_result":
-                tool_results.append({
-                    "content": [{"text": extract_text_content(item.get("content", "")) or "(empty result)"}],
-                    "status": "success",
-                    "toolUseId": item.get("tool_use_id", "")
-                })
-    
+                tool_results.append(
+                    {
+                        "content": [
+                            {
+                                "text": extract_text_content(item.get("content", ""))
+                                or "(empty result)"
+                            }
+                        ],
+                        "status": "success",
+                        "toolUseId": item.get("tool_use_id", ""),
+                    }
+                )
+
     return tool_results
 
 
 def extract_tool_uses_from_message(
-    content: Any,
-    tool_calls: Optional[List[Dict[str, Any]]] = None
+    content: Any, tool_calls: Optional[List[Dict[str, Any]]] = None
 ) -> List[Dict[str, Any]]:
     """
     Extracts tool uses from assistant message.
-    
+
     Looks for tool calls in both:
     - tool_calls field (OpenAI format)
     - content blocks with type="tool_use" (Anthropic format)
-    
+
     Args:
         content: Message content
         tool_calls: List of tool calls (OpenAI format)
-    
+
     Returns:
         List of tool uses in Kiro format
     """
     tool_uses = []
-    
+
     # From tool_calls field (OpenAI format or unified format from Anthropic)
     if tool_calls:
         for tc in tool_calls:
@@ -661,22 +691,26 @@ def extract_tool_uses_from_message(
                     input_data = json.loads(arguments) if arguments else {}
                 else:
                     input_data = arguments if arguments else {}
-                tool_uses.append({
-                    "name": func.get("name", ""),
-                    "input": input_data,
-                    "toolUseId": tc.get("id", "")
-                })
-    
+                tool_uses.append(
+                    {
+                        "name": func.get("name", ""),
+                        "input": input_data,
+                        "toolUseId": tc.get("id", ""),
+                    }
+                )
+
     # From content blocks (Anthropic format)
     if isinstance(content, list):
         for item in content:
             if isinstance(item, dict) and item.get("type") == "tool_use":
-                tool_uses.append({
-                    "name": item.get("name", ""),
-                    "input": item.get("input", {}),
-                    "toolUseId": item.get("id", "")
-                })
-    
+                tool_uses.append(
+                    {
+                        "name": item.get("name", ""),
+                        "input": item.get("input", {}),
+                        "toolUseId": item.get("id", ""),
+                    }
+                )
+
     return tool_uses
 
 
@@ -684,84 +718,85 @@ def extract_tool_uses_from_message(
 # Tool Content to Text Conversion (for stripping when no tools defined)
 # ==================================================================================================
 
+
 def tool_calls_to_text(tool_calls: List[Dict[str, Any]]) -> str:
     """
     Converts tool_calls to human-readable text representation.
-    
+
     This is used when stripping tool content from messages (when no tools are defined).
     Instead of losing the context, we convert tool calls to text so the model
     can still understand what happened in the conversation.
-    
+
     Args:
         tool_calls: List of tool calls in unified format
-    
+
     Returns:
         Text representation of tool calls
-    
+
     Example:
         >>> tool_calls_to_text([{"id": "call_123", "function": {"name": "bash", "arguments": '{"command": "ls"}'}}])
         '[Tool: bash] (call_123)\\n{"command": "ls"}'
     """
     if not tool_calls:
         return ""
-    
+
     parts = []
     for tc in tool_calls:
         func = tc.get("function", {})
         name = func.get("name", "unknown")
         arguments = func.get("arguments", "{}")
         tool_id = tc.get("id", "")
-        
+
         # Format: [Tool: name] (id)\narguments
         if tool_id:
             parts.append(f"[Tool: {name} ({tool_id})]\n{arguments}")
         else:
             parts.append(f"[Tool: {name}]\n{arguments}")
-    
+
     return "\n\n".join(parts)
 
 
 def tool_results_to_text(tool_results: List[Dict[str, Any]]) -> str:
     """
     Converts tool_results to human-readable text representation.
-    
+
     This is used when stripping tool content from messages (when no tools are defined).
     Instead of losing the context, we convert tool results to text so the model
     can still understand what happened in the conversation.
-    
+
     Args:
         tool_results: List of tool results in unified format
-    
+
     Returns:
         Text representation of tool results
-    
+
     Example:
         >>> tool_results_to_text([{"tool_use_id": "call_123", "content": "file1.txt\\nfile2.txt"}])
         '[Tool Result] (call_123)\\nfile1.txt\\nfile2.txt'
     """
     if not tool_results:
         return ""
-    
+
     parts = []
     for tr in tool_results:
         content = tr.get("content", "")
         tool_use_id = tr.get("tool_use_id", "")
-        
+
         if isinstance(content, str):
             content_text = content
         else:
             content_text = extract_text_content(content)
-        
+
         # Use placeholder if content is empty
         if not content_text:
             content_text = "(empty result)"
-        
+
         # Format: [Tool Result] (id)\ncontent
         if tool_use_id:
             parts.append(f"[Tool Result ({tool_use_id})]\n{content_text}")
         else:
             parts.append(f"[Tool Result]\n{content_text}")
-    
+
     return "\n\n".join(parts)
 
 
@@ -769,20 +804,23 @@ def tool_results_to_text(tool_results: List[Dict[str, Any]]) -> str:
 # Message Merging
 # ==================================================================================================
 
-def strip_all_tool_content(messages: List[UnifiedMessage]) -> Tuple[List[UnifiedMessage], bool]:
+
+def strip_all_tool_content(
+    messages: List[UnifiedMessage],
+) -> Tuple[List[UnifiedMessage], bool]:
     """
     Strips ALL tool-related content from messages, converting it to text representation.
-    
+
     This is used when no tools are defined in the request. Kiro API rejects
     requests that have toolResults but no tools defined.
-    
+
     Instead of simply removing tool content, this function converts tool_calls
     and tool_results to human-readable text, preserving the context for
     summarization and other use cases.
-    
+
     Args:
         messages: List of messages in unified format
-    
+
     Returns:
         Tuple of:
         - List of messages with tool content converted to text
@@ -790,82 +828,81 @@ def strip_all_tool_content(messages: List[UnifiedMessage]) -> Tuple[List[Unified
     """
     if not messages:
         return [], False
-    
+
     result = []
     total_tool_calls_stripped = 0
     total_tool_results_stripped = 0
-    
+
     for msg in messages:
         # Check if this message has any tool content
         has_tool_calls = bool(msg.tool_calls)
         has_tool_results = bool(msg.tool_results)
-        
+
         if has_tool_calls or has_tool_results:
             if has_tool_calls:
                 total_tool_calls_stripped += len(msg.tool_calls)
             if has_tool_results:
                 total_tool_results_stripped += len(msg.tool_results)
-            
+
             # Start with existing text content
             existing_content = extract_text_content(msg.content)
             content_parts = []
-            
+
             if existing_content:
                 content_parts.append(existing_content)
-            
+
             # Convert tool_calls to text (for assistant messages)
             if has_tool_calls:
                 tool_text = tool_calls_to_text(msg.tool_calls)
                 if tool_text:
                     content_parts.append(tool_text)
-            
+
             # Convert tool_results to text (for user messages)
             if has_tool_results:
                 result_text = tool_results_to_text(msg.tool_results)
                 if result_text:
                     content_parts.append(result_text)
-            
+
             # Join all parts with double newline
             content = "\n\n".join(content_parts) if content_parts else "(empty)"
-            
+
             # Create a copy of the message without tool content but with text representation
             cleaned_msg = UnifiedMessage(
-                role=msg.role,
-                content=content,
-                tool_calls=None,
-                tool_results=None
+                role=msg.role, content=content, tool_calls=None, tool_results=None
             )
             result.append(cleaned_msg)
         else:
             result.append(msg)
-    
+
     had_tool_content = total_tool_calls_stripped > 0 or total_tool_results_stripped > 0
-    
+
     # Log summary once (DEBUG level - this is normal for clients like Cline/Roo)
     if had_tool_content:
         logger.debug(
             f"Converted tool content to text (no tools defined): "
             f"{total_tool_calls_stripped} tool_calls, {total_tool_results_stripped} tool_results"
         )
-    
+
     return result, had_tool_content
 
 
-def ensure_assistant_before_tool_results(messages: List[UnifiedMessage]) -> Tuple[List[UnifiedMessage], bool]:
+def ensure_assistant_before_tool_results(
+    messages: List[UnifiedMessage],
+) -> Tuple[List[UnifiedMessage], bool]:
     """
     Ensures that messages with tool_results have a preceding assistant message with tool_calls.
-    
+
     Kiro API requires that when toolResults are present, there must be a preceding
     assistantResponseMessage with toolUses. Some clients (like Cline/Roo) may send
     truncated conversations where the assistant message is missing.
-    
+
     Since we don't know the original tool name and arguments when the assistant message
     is missing, we cannot create a valid synthetic assistant message. Instead, we strip
     the tool_results from such messages to avoid Kiro API rejection.
-    
+
     Args:
         messages: List of messages in unified format
-    
+
     Returns:
         Tuple of:
         - List of messages with orphaned tool_results stripped
@@ -873,20 +910,18 @@ def ensure_assistant_before_tool_results(messages: List[UnifiedMessage]) -> Tupl
     """
     if not messages:
         return [], False
-    
+
     result = []
     stripped_any_tool_results = False
-    
+
     for msg in messages:
         # Check if this message has tool_results
         if msg.tool_results:
             # Check if the previous message is an assistant with tool_calls
             has_preceding_assistant = (
-                result and
-                result[-1].role == "assistant" and
-                result[-1].tool_calls
+                result and result[-1].role == "assistant" and result[-1].tool_calls
             )
-            
+
             if not has_preceding_assistant:
                 # We cannot create a valid synthetic assistant message because we don't know
                 # the original tool name and arguments. Kiro API validates tool names.
@@ -896,84 +931,88 @@ def ensure_assistant_before_tool_results(messages: List[UnifiedMessage]) -> Tupl
                     f"(no preceding assistant message with tool_calls). "
                     f"Tool IDs: {[tr.get('tool_use_id', 'unknown') for tr in msg.tool_results]}"
                 )
-                
+
                 # Create a copy of the message without tool_results
                 cleaned_msg = UnifiedMessage(
                     role=msg.role,
                     content=msg.content,
                     tool_calls=msg.tool_calls,
-                    tool_results=None  # Strip orphaned tool_results
+                    tool_results=None,  # Strip orphaned tool_results
                 )
                 result.append(cleaned_msg)
                 stripped_any_tool_results = True
                 continue
-        
+
         result.append(msg)
-    
+
     return result, stripped_any_tool_results
 
 
 def merge_adjacent_messages(messages: List[UnifiedMessage]) -> List[UnifiedMessage]:
     """
     Merges adjacent messages with the same role.
-    
+
     Kiro API does not accept multiple consecutive messages from the same role.
     This function merges such messages into one.
-    
+
     Args:
         messages: List of messages in unified format
-    
+
     Returns:
         List of messages with merged adjacent messages
     """
     if not messages:
         return []
-    
+
     merged = []
     # Statistics for summary logging
     merge_counts = {"user": 0, "assistant": 0}
     total_tool_calls_merged = 0
     total_tool_results_merged = 0
-    
+
     for msg in messages:
         if not merged:
             merged.append(msg)
             continue
-        
+
         last = merged[-1]
         if msg.role == last.role:
             # Merge content
             if isinstance(last.content, list) and isinstance(msg.content, list):
                 last.content = last.content + msg.content
             elif isinstance(last.content, list):
-                last.content = last.content + [{"type": "text", "text": extract_text_content(msg.content)}]
+                last.content = last.content + [
+                    {"type": "text", "text": extract_text_content(msg.content)}
+                ]
             elif isinstance(msg.content, list):
-                last.content = [{"type": "text", "text": extract_text_content(last.content)}] + msg.content
+                last.content = [
+                    {"type": "text", "text": extract_text_content(last.content)}
+                ] + msg.content
             else:
                 last_text = extract_text_content(last.content)
                 current_text = extract_text_content(msg.content)
                 last.content = f"{last_text}\n{current_text}"
-            
+
             # Merge tool_calls for assistant messages
             if msg.role == "assistant" and msg.tool_calls:
                 if last.tool_calls is None:
                     last.tool_calls = []
                 last.tool_calls = list(last.tool_calls) + list(msg.tool_calls)
                 total_tool_calls_merged += len(msg.tool_calls)
-            
+
             # Merge tool_results for user messages
             if msg.role == "user" and msg.tool_results:
                 if last.tool_results is None:
                     last.tool_results = []
                 last.tool_results = list(last.tool_results) + list(msg.tool_results)
                 total_tool_results_merged += len(msg.tool_results)
-            
+
             # Count merges by role
             if msg.role in merge_counts:
                 merge_counts[msg.role] += 1
         else:
             merged.append(msg)
-    
+
     # Log summary if any merges occurred
     total_merges = sum(merge_counts.values())
     if total_merges > 0:
@@ -982,18 +1021,20 @@ def merge_adjacent_messages(messages: List[UnifiedMessage]) -> List[UnifiedMessa
             if count > 0:
                 parts.append(f"{count} {role}")
         merge_summary = ", ".join(parts)
-        
+
         extras = []
         if total_tool_calls_merged > 0:
             extras.append(f"{total_tool_calls_merged} tool_calls")
         if total_tool_results_merged > 0:
             extras.append(f"{total_tool_results_merged} tool_results")
-        
+
         if extras:
-            logger.debug(f"Merged {total_merges} adjacent messages ({merge_summary}), including {', '.join(extras)}")
+            logger.debug(
+                f"Merged {total_merges} adjacent messages ({merge_summary}), including {', '.join(extras)}"
+            )
         else:
             logger.debug(f"Merged {total_merges} adjacent messages ({merge_summary})")
-    
+
     return merged
 
 
@@ -1001,36 +1042,39 @@ def merge_adjacent_messages(messages: List[UnifiedMessage]) -> List[UnifiedMessa
 # Kiro History Building
 # ==================================================================================================
 
-def build_kiro_history(messages: List[UnifiedMessage], model_id: str) -> List[Dict[str, Any]]:
+
+def build_kiro_history(
+    messages: List[UnifiedMessage], model_id: str
+) -> List[Dict[str, Any]]:
     """
     Builds history array for Kiro API from unified messages.
-    
+
     Kiro API expects alternating userInputMessage and assistantResponseMessage.
     This function converts unified format to Kiro format.
-    
+
     Args:
         messages: List of messages in unified format
         model_id: Internal Kiro model ID
-    
+
     Returns:
         List of dictionaries for history field in Kiro API
     """
     history = []
-    
+
     for msg in messages:
         if msg.role == "user":
             content = extract_text_content(msg.content)
-            
+
             # Fallback for empty content - Kiro API requires non-empty content
             if not content:
                 content = "(empty)"
-            
+
             user_input = {
                 "content": content,
                 "modelId": model_id,
                 "origin": "AI_EDITOR",
             }
-            
+
             # Process images - extract from message or content
             # IMPORTANT: images go directly into userInputMessage, NOT into userInputMessageContext
             # This matches the native Kiro IDE format
@@ -1039,13 +1083,15 @@ def build_kiro_history(messages: List[UnifiedMessage], model_id: str) -> List[Di
                 kiro_images = convert_images_to_kiro_format(images)
                 if kiro_images:
                     user_input["images"] = kiro_images
-            
+
             # Build userInputMessageContext for tools and toolResults only
             user_input_context: Dict[str, Any] = {}
-            
+
             # Process tool_results - convert to Kiro format if present
             if msg.tool_results:
-                kiro_tool_results = convert_tool_results_to_kiro_format(msg.tool_results)
+                kiro_tool_results = convert_tool_results_to_kiro_format(
+                    msg.tool_results
+                )
                 if kiro_tool_results:
                     user_input_context["toolResults"] = kiro_tool_results
             else:
@@ -1053,35 +1099,36 @@ def build_kiro_history(messages: List[UnifiedMessage], model_id: str) -> List[Di
                 tool_results = extract_tool_results_from_content(msg.content)
                 if tool_results:
                     user_input_context["toolResults"] = tool_results
-            
+
             # Add context if not empty (contains toolResults only, not images)
             if user_input_context:
                 user_input["userInputMessageContext"] = user_input_context
-            
+
             history.append({"userInputMessage": user_input})
-            
+
         elif msg.role == "assistant":
             content = extract_text_content(msg.content)
-            
+
             # Fallback for empty content - Kiro API requires non-empty content
             if not content:
                 content = "(empty)"
-            
+
             assistant_response = {"content": content}
-            
+
             # Process tool_calls
             tool_uses = extract_tool_uses_from_message(msg.content, msg.tool_calls)
             if tool_uses:
                 assistant_response["toolUses"] = tool_uses
-            
+
             history.append({"assistantResponseMessage": assistant_response})
-    
+
     return history
 
 
 # ==================================================================================================
 # Main Payload Building
 # ==================================================================================================
+
 
 def build_kiro_payload(
     messages: List[UnifiedMessage],
@@ -1090,14 +1137,14 @@ def build_kiro_payload(
     tools: Optional[List[UnifiedTool]],
     conversation_id: str,
     profile_arn: str,
-    inject_thinking: bool = True
+    inject_thinking: bool = True,
 ) -> KiroPayloadResult:
     """
     Builds complete payload for Kiro API from unified data.
-    
+
     This is the main function that assembles the Kiro API payload from
     API-agnostic unified message and tool formats.
-    
+
     Args:
         messages: List of messages in unified format (without system messages)
         system_prompt: Already extracted system prompt
@@ -1106,26 +1153,34 @@ def build_kiro_payload(
         conversation_id: Unique conversation ID
         profile_arn: AWS CodeWhisperer profile ARN
         inject_thinking: Whether to inject thinking tags (default True)
-    
+
     Returns:
         KiroPayloadResult with payload and tool documentation
-    
+
     Raises:
         ValueError: If there are no messages to send
     """
     # Process tools with long descriptions
     processed_tools, tool_documentation = process_tools_with_long_descriptions(tools)
-    
+
     # Add tool documentation to system prompt if present
     full_system_prompt = system_prompt
     if tool_documentation:
-        full_system_prompt = full_system_prompt + tool_documentation if full_system_prompt else tool_documentation.strip()
-    
+        full_system_prompt = (
+            full_system_prompt + tool_documentation
+            if full_system_prompt
+            else tool_documentation.strip()
+        )
+
     # Add thinking mode legitimization to system prompt if enabled
     thinking_system_addition = get_thinking_system_prompt_addition()
     if thinking_system_addition:
-        full_system_prompt = full_system_prompt + thinking_system_addition if full_system_prompt else thinking_system_addition.strip()
-    
+        full_system_prompt = (
+            full_system_prompt + thinking_system_addition
+            if full_system_prompt
+            else thinking_system_addition.strip()
+        )
+
     # If no tools are defined, strip ALL tool-related content from messages
     # Kiro API rejects requests with toolResults but no tools
     if not tools:
@@ -1135,70 +1190,72 @@ def build_kiro_payload(
     else:
         # Ensure assistant messages exist before tool_results (Kiro API requirement)
         # Also returns flag if any tool_results were stripped (to skip thinking tag injection)
-        messages_with_assistants, stripped_tool_results = ensure_assistant_before_tool_results(messages)
-    
+        messages_with_assistants, stripped_tool_results = (
+            ensure_assistant_before_tool_results(messages)
+        )
+
     # Merge adjacent messages with the same role
     merged_messages = merge_adjacent_messages(messages_with_assistants)
-    
+
     if not merged_messages:
         raise ValueError("No messages to send")
-    
+
     # Build history (all messages except the last one)
     history_messages = merged_messages[:-1] if len(merged_messages) > 1 else []
-    
+
     # If there's a system prompt, add it to the first user message in history
     if full_system_prompt and history_messages:
         first_msg = history_messages[0]
         if first_msg.role == "user":
             original_content = extract_text_content(first_msg.content)
             first_msg.content = f"{full_system_prompt}\n\n{original_content}"
-    
+
     history = build_kiro_history(history_messages, model_id)
-    
+
     # Current message (the last one)
     current_message = merged_messages[-1]
     current_content = extract_text_content(current_message.content)
-    
+
     # If system prompt exists but history is empty - add to current message
     if full_system_prompt and not history:
         current_content = f"{full_system_prompt}\n\n{current_content}"
-    
+
     # If current message is assistant, need to add it to history
     # and create user message "Continue"
     if current_message.role == "assistant":
-        history.append({
-            "assistantResponseMessage": {
-                "content": current_content
-            }
-        })
+        history.append({"assistantResponseMessage": {"content": current_content}})
         current_content = "Continue"
-    
+
     # If content is empty - use "Continue"
     if not current_content:
         current_content = "Continue"
-    
+
     # Process images in current message - extract from message or content
     # IMPORTANT: images go directly into userInputMessage, NOT into userInputMessageContext
     # This matches the native Kiro IDE format
-    images = current_message.images or extract_images_from_content(current_message.content)
+    images = current_message.images or extract_images_from_content(
+        current_message.content
+    )
     kiro_images = None
     if images:
         kiro_images = convert_images_to_kiro_format(images)
         if kiro_images:
             logger.debug(f"Added {len(kiro_images)} image(s) to current message")
-    
+
     # Build user_input_context for tools and toolResults only (NOT images)
     user_input_context: Dict[str, Any] = {}
-    
+
     # Add tools if present
     kiro_tools = convert_tools_to_kiro_format(processed_tools)
     if kiro_tools:
         user_input_context["tools"] = kiro_tools
-    
+
     # Process tool_results in current message - convert to Kiro format if present
     if current_message.tool_results:
         # Convert unified format to Kiro format
-        kiro_tool_results = convert_tool_results_to_kiro_format(current_message.tool_results)
+        kiro_tool_results = convert_tool_results_to_kiro_format(
+            current_message.tool_results
+        )
         if kiro_tool_results:
             user_input_context["toolResults"] = kiro_tool_results
     else:
@@ -1206,43 +1263,41 @@ def build_kiro_payload(
         tool_results = extract_tool_results_from_content(current_message.content)
         if tool_results:
             user_input_context["toolResults"] = tool_results
-    
+
     # Inject thinking tags if enabled (only for the current/last user message)
     if inject_thinking and current_message.role == "user":
         current_content = inject_thinking_tags(current_content)
-    
+
     # Build userInputMessage
     user_input_message = {
         "content": current_content,
         "modelId": model_id,
         "origin": "AI_EDITOR",
     }
-    
+
     # Add images directly to userInputMessage (NOT to userInputMessageContext)
     if kiro_images:
         user_input_message["images"] = kiro_images
-    
+
     # Add user_input_context if present (contains tools and toolResults only)
     if user_input_context:
         user_input_message["userInputMessageContext"] = user_input_context
-    
+
     # Assemble final payload
     payload = {
         "conversationState": {
             "chatTriggerType": "MANUAL",
             "conversationId": conversation_id,
-            "currentMessage": {
-                "userInputMessage": user_input_message
-            }
+            "currentMessage": {"userInputMessage": user_input_message},
         }
     }
-    
+
     # Add history only if not empty
     if history:
         payload["conversationState"]["history"] = history
-    
+
     # Add profileArn
     if profile_arn:
         payload["profileArn"] = profile_arn
-    
+
     return KiroPayloadResult(payload=payload, tool_documentation=tool_documentation)

--- a/kiro/converters_openai.py
+++ b/kiro/converters_openai.py
@@ -51,84 +51,92 @@ from kiro.converters_core import (
 # OpenAI-specific Message Processing
 # ==================================================================================================
 
+
 def _extract_tool_results_from_openai(content: Any) -> List[Dict[str, Any]]:
     """
     Extracts tool results from OpenAI message content.
-    
+
     Args:
         content: Message content (can be a list with tool_result blocks)
-    
+
     Returns:
         List of tool results in unified format for UnifiedMessage
     """
     tool_results = []
-    
+
     if isinstance(content, list):
         for item in content:
             if isinstance(item, dict) and item.get("type") == "tool_result":
-                tool_results.append({
-                    "type": "tool_result",
-                    "tool_use_id": item.get("tool_use_id", ""),
-                    "content": extract_text_content(item.get("content", "")) or "(empty result)"
-                })
-    
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": item.get("tool_use_id", ""),
+                        "content": extract_text_content(item.get("content", ""))
+                        or "(empty result)",
+                    }
+                )
+
     return tool_results
 
 
 def _extract_tool_calls_from_openai(msg: ChatMessage) -> List[Dict[str, Any]]:
     """
     Extracts tool calls from OpenAI assistant message.
-    
+
     Args:
         msg: OpenAI ChatMessage
-    
+
     Returns:
         List of tool calls in unified format
     """
     tool_calls = []
-    
+
     if msg.tool_calls:
         for tc in msg.tool_calls:
             if isinstance(tc, dict):
-                tool_calls.append({
-                    "id": tc.get("id", ""),
-                    "type": "function",
-                    "function": {
-                        "name": tc.get("function", {}).get("name", ""),
-                        "arguments": tc.get("function", {}).get("arguments", "{}")
+                tool_calls.append(
+                    {
+                        "id": tc.get("id", ""),
+                        "type": "function",
+                        "function": {
+                            "name": tc.get("function", {}).get("name", ""),
+                            "arguments": tc.get("function", {}).get("arguments", "{}"),
+                        },
                     }
-                })
-    
+                )
+
     return tool_calls
 
 
-def convert_openai_messages_to_unified(messages: List[ChatMessage]) -> Tuple[str, List[UnifiedMessage]]:
+def convert_openai_messages_to_unified(
+    messages: List[ChatMessage],
+) -> Tuple[str, List[UnifiedMessage]]:
     """
     Converts OpenAI messages to unified format.
-    
+
     Handles:
     - System messages (extracted as system prompt)
     - Tool messages (converted to user messages with tool_results)
     - Tool calls in assistant messages
-    
+
     Args:
         messages: List of OpenAI ChatMessage objects
-    
+
     Returns:
         Tuple of (system_prompt, unified_messages)
     """
     # Extract system prompt
     system_prompt = ""
     non_system_messages = []
-    
+
     for msg in messages:
         if msg.role == "system":
             system_prompt += extract_text_content(msg.content) + "\n"
         else:
             non_system_messages.append(msg)
-    
+
     system_prompt = system_prompt.strip()
-    
+
     # Process tool messages - convert to user messages with tool_results
     processed = []
     pending_tool_results = []
@@ -142,7 +150,7 @@ def convert_openai_messages_to_unified(messages: List[ChatMessage]) -> Tuple[str
             tool_result = {
                 "type": "tool_result",
                 "tool_use_id": msg.tool_call_id or "",
-                "content": extract_text_content(msg.content) or "(empty result)"
+                "content": extract_text_content(msg.content) or "(empty result)",
             }
             pending_tool_results.append(tool_result)
             total_tool_results += 1
@@ -150,13 +158,11 @@ def convert_openai_messages_to_unified(messages: List[ChatMessage]) -> Tuple[str
             # If there are accumulated tool results, create user message with them
             if pending_tool_results:
                 unified_msg = UnifiedMessage(
-                    role="user",
-                    content="",
-                    tool_results=pending_tool_results.copy()
+                    role="user", content="", tool_results=pending_tool_results.copy()
                 )
                 processed.append(unified_msg)
                 pending_tool_results.clear()
-            
+
             # Convert regular message
             tool_calls = None
             tool_results = None
@@ -180,53 +186,55 @@ def convert_openai_messages_to_unified(messages: List[ChatMessage]) -> Tuple[str
                 content=extract_text_content(msg.content),
                 tool_calls=tool_calls,
                 tool_results=tool_results,
-                images=images
+                images=images,
             )
             processed.append(unified_msg)
-    
+
     # If tool results remain at the end
     if pending_tool_results:
         unified_msg = UnifiedMessage(
-            role="user",
-            content="",
-            tool_results=pending_tool_results.copy()
+            role="user", content="", tool_results=pending_tool_results.copy()
         )
         processed.append(unified_msg)
-    
+
     # Log summary if any tool content or images were found
     if total_tool_calls > 0 or total_tool_results > 0 or total_images > 0:
         logger.debug(
             f"Converted {len(messages)} OpenAI messages: "
             f"{total_tool_calls} tool_calls, {total_tool_results} tool_results, {total_images} images"
         )
-    
+
     return system_prompt, processed
 
 
-def convert_openai_tools_to_unified(tools: Optional[List[Tool]]) -> Optional[List[UnifiedTool]]:
+def convert_openai_tools_to_unified(
+    tools: Optional[List[Tool]],
+) -> Optional[List[UnifiedTool]]:
     """
     Converts OpenAI tools to unified format.
-    
+
     Args:
         tools: List of OpenAI Tool objects
-    
+
     Returns:
         List of UnifiedTool objects, or None if no tools
     """
     if not tools:
         return None
-    
+
     unified_tools = []
     for tool in tools:
         if tool.type != "function":
             continue
-        
-        unified_tools.append(UnifiedTool(
-            name=tool.function.name,
-            description=tool.function.description,
-            input_schema=tool.function.parameters
-        ))
-    
+
+        unified_tools.append(
+            UnifiedTool(
+                name=tool.function.name,
+                description=tool.function.description,
+                input_schema=tool.function.parameters,
+            )
+        )
+
     return unified_tools if unified_tools else None
 
 
@@ -234,44 +242,45 @@ def convert_openai_tools_to_unified(tools: Optional[List[Tool]]) -> Optional[Lis
 # Main Entry Point
 # ==================================================================================================
 
+
 def build_kiro_payload(
-    request_data: ChatCompletionRequest,
-    conversation_id: str,
-    profile_arn: str
+    request_data: ChatCompletionRequest, conversation_id: str, profile_arn: str
 ) -> dict:
     """
     Builds complete payload for Kiro API from OpenAI request.
-    
+
     This is the main entry point for OpenAI → Kiro conversion.
     Uses the core build_kiro_payload function with OpenAI-specific adapters.
-    
+
     Args:
         request_data: Request in OpenAI format
         conversation_id: Unique conversation ID
         profile_arn: AWS CodeWhisperer profile ARN
-    
+
     Returns:
         Payload dictionary for POST request to Kiro API
-    
+
     Raises:
         ValueError: If there are no messages to send
     """
     # Convert messages to unified format
-    system_prompt, unified_messages = convert_openai_messages_to_unified(request_data.messages)
-    
+    system_prompt, unified_messages = convert_openai_messages_to_unified(
+        request_data.messages
+    )
+
     # Convert tools to unified format
     unified_tools = convert_openai_tools_to_unified(request_data.tools)
-    
+
     # Get model ID for Kiro API (normalizes + resolves hidden models)
     # Pass-through principle: we normalize and send to Kiro, Kiro decides if valid
     model_id = get_model_id_for_kiro(request_data.model, HIDDEN_MODELS)
-    
+
     logger.debug(
         f"Converting OpenAI request: model={request_data.model} -> {model_id}, "
         f"messages={len(unified_messages)}, tools={len(unified_tools) if unified_tools else 0}, "
         f"system_prompt_length={len(system_prompt)}"
     )
-    
+
     # Use core function to build payload
     result = core_build_kiro_payload(
         messages=unified_messages,
@@ -280,7 +289,7 @@ def build_kiro_payload(
         tools=unified_tools,
         conversation_id=conversation_id,
         profile_arn=profile_arn,
-        inject_thinking=True
+        inject_thinking=True,
     )
-    
+
     return result.payload

--- a/kiro/debug_logger.py
+++ b/kiro/debug_logger.py
@@ -45,12 +45,13 @@ from kiro.config import DEBUG_MODE, DEBUG_DIR
 class DebugLogger:
     """
     Singleton for managing debug request logs.
-    
+
     Operating modes:
     - off: does nothing
     - errors: buffers data, flushes to files only on errors
     - all: writes data immediately to files (as before)
     """
+
     _instance = None
 
     def __new__(cls):
@@ -64,25 +65,25 @@ class DebugLogger:
             return
         self.debug_dir = Path(DEBUG_DIR)
         self._initialized = True
-        
+
         # Buffers for "errors" mode
         self._request_body_buffer: Optional[bytes] = None
         self._kiro_request_body_buffer: Optional[bytes] = None
         self._raw_chunks_buffer: bytearray = bytearray()
         self._modified_chunks_buffer: bytearray = bytearray()
-        
+
         # Buffer for application logs (loguru)
         self._app_logs_buffer: io.StringIO = io.StringIO()
         self._loguru_sink_id: Optional[int] = None
-    
+
     def _is_enabled(self) -> bool:
         """Checks if logging is enabled."""
         return DEBUG_MODE in ("errors", "all")
-    
+
     def _is_immediate_write(self) -> bool:
         """Checks if immediate file writing is needed (all mode)."""
         return DEBUG_MODE == "all"
-    
+
     def _clear_buffers(self):
         """Clears all buffers."""
         self._request_body_buffer = None
@@ -90,7 +91,7 @@ class DebugLogger:
         self._raw_chunks_buffer.clear()
         self._modified_chunks_buffer.clear()
         self._clear_app_logs_buffer()
-    
+
     def _clear_app_logs_buffer(self):
         """Clears the application logs buffer and removes sink."""
         # Remove sink from loguru
@@ -101,21 +102,21 @@ class DebugLogger:
                 # Sink already removed
                 pass
             self._loguru_sink_id = None
-        
+
         # Clear buffer
         self._app_logs_buffer = io.StringIO()
-    
+
     def _setup_app_logs_capture(self):
         """
         Sets up application log capture to buffer.
-        
+
         Adds a temporary sink to loguru that writes to StringIO buffer.
         Captures ALL logs without filtering, as sink is active only
         during processing of a specific request.
         """
         # Remove previous sink if exists
         self._clear_app_logs_buffer()
-        
+
         # Add new sink to capture ALL logs
         # Format: time | level | module:function:line | message
         self._loguru_sink_id = logger.add(
@@ -129,17 +130,17 @@ class DebugLogger:
     def prepare_new_request(self):
         """
         Prepares the logger for a new request.
-        
+
         In "all" mode: clears the logs folder.
         In "errors" mode: clears buffers.
         In both modes: sets up application log capture.
         """
         if not self._is_enabled():
             return
-        
+
         # Clear buffers in any case
         self._clear_buffers()
-        
+
         # Set up application log capture
         self._setup_app_logs_capture()
 
@@ -149,14 +150,16 @@ class DebugLogger:
                 if self.debug_dir.exists():
                     shutil.rmtree(self.debug_dir)
                 self.debug_dir.mkdir(parents=True, exist_ok=True)
-                logger.debug(f"[DebugLogger] Directory {self.debug_dir} cleared for new request.")
+                logger.debug(
+                    f"[DebugLogger] Directory {self.debug_dir} cleared for new request."
+                )
             except Exception as e:
                 logger.error(f"[DebugLogger] Error preparing directory: {e}")
 
     def log_request_body(self, body: bytes):
         """
         Saves the request body (from client, OpenAI format).
-        
+
         In "all" mode: writes immediately to file.
         In "errors" mode: buffers.
         """
@@ -172,7 +175,7 @@ class DebugLogger:
     def log_kiro_request_body(self, body: bytes):
         """
         Saves the modified request body (to Kiro API).
-        
+
         In "all" mode: writes immediately to file.
         In "errors" mode: buffers.
         """
@@ -188,7 +191,7 @@ class DebugLogger:
     def log_raw_chunk(self, chunk: bytes):
         """
         Appends raw response chunk (from provider).
-        
+
         In "all" mode: writes immediately to file.
         In "errors" mode: buffers.
         """
@@ -204,7 +207,7 @@ class DebugLogger:
     def log_modified_chunk(self, chunk: bytes):
         """
         Appends modified chunk (to client).
-        
+
         In "all" mode: writes immediately to file.
         In "errors" mode: buffers.
         """
@@ -216,34 +219,31 @@ class DebugLogger:
         else:
             # "errors" mode - buffer
             self._modified_chunks_buffer.extend(chunk)
-    
+
     def log_error_info(self, status_code: int, error_message: str = ""):
         """
         Writes error information to file.
-        
+
         Works in both modes (errors and all).
         In "all" mode writes immediately to file.
         In "errors" mode called from flush_on_error().
-        
+
         Args:
             status_code: HTTP error status code
             error_message: Error message (optional)
         """
         if not self._is_enabled():
             return
-        
+
         try:
             # Ensure directory exists
             self.debug_dir.mkdir(parents=True, exist_ok=True)
-            
-            error_info = {
-                "status_code": status_code,
-                "error_message": error_message
-            }
+
+            error_info = {"status_code": status_code, "error_message": error_message}
             error_file = self.debug_dir / "error_info.json"
             with open(error_file, "w", encoding="utf-8") as f:
                 json.dump(error_info, f, indent=2, ensure_ascii=False)
-            
+
             logger.debug(f"[DebugLogger] Error info saved (status={status_code})")
         except Exception as e:
             logger.error(f"[DebugLogger] Error writing error_info: {e}")
@@ -251,74 +251,78 @@ class DebugLogger:
     def flush_on_error(self, status_code: int, error_message: str = ""):
         """
         Flushes buffers to files on error.
-        
+
         In "errors" mode: flushes buffers and saves error_info.
         In "all" mode: only saves error_info (data already written).
-        
+
         Args:
             status_code: HTTP error status code
             error_message: Error message (optional)
         """
         if not self._is_enabled():
             return
-        
+
         # In "all" mode data is already written, add error_info and app logs
         if self._is_immediate_write():
             self.log_error_info(status_code, error_message)
             self._write_app_logs_to_file()
             self._clear_app_logs_buffer()
             return
-        
+
         # Check if there's anything to flush
-        if not any([
-            self._request_body_buffer,
-            self._kiro_request_body_buffer,
-            self._raw_chunks_buffer,
-            self._modified_chunks_buffer
-        ]):
+        if not any(
+            [
+                self._request_body_buffer,
+                self._kiro_request_body_buffer,
+                self._raw_chunks_buffer,
+                self._modified_chunks_buffer,
+            ]
+        ):
             return
-        
+
         try:
             # Create directory if not exists
             if self.debug_dir.exists():
                 shutil.rmtree(self.debug_dir)
             self.debug_dir.mkdir(parents=True, exist_ok=True)
-            
+
             # Flush buffers to files
             if self._request_body_buffer:
                 self._write_request_body_to_file(self._request_body_buffer)
-            
+
             if self._kiro_request_body_buffer:
                 self._write_kiro_request_body_to_file(self._kiro_request_body_buffer)
-            
+
             if self._raw_chunks_buffer:
                 file_path = self.debug_dir / "response_stream_raw.txt"
                 with open(file_path, "wb") as f:
                     f.write(self._raw_chunks_buffer)
-            
+
             if self._modified_chunks_buffer:
                 file_path = self.debug_dir / "response_stream_modified.txt"
                 with open(file_path, "wb") as f:
                     f.write(self._modified_chunks_buffer)
-            
+
             # Save error information
             self.log_error_info(status_code, error_message)
-            
+
             # Save application logs
             self._write_app_logs_to_file()
-            
-            logger.info(f"[DebugLogger] Error logs flushed to {self.debug_dir} (status={status_code})")
-            
+
+            logger.info(
+                f"[DebugLogger] Error logs flushed to {self.debug_dir} (status={status_code})"
+            )
+
         except Exception as e:
             logger.error(f"[DebugLogger] Error flushing buffers: {e}")
         finally:
             # Clear buffers after flush
             self._clear_buffers()
-    
+
     def discard_buffers(self):
         """
         Clears buffers without writing to files.
-        
+
         Called when request completed successfully in "errors" mode.
         Also called in "all" mode to save logs of successful request.
         """
@@ -328,9 +332,9 @@ class DebugLogger:
             # In "all" mode save logs even for successful requests
             self._write_app_logs_to_file()
             self._clear_app_logs_buffer()
-    
+
     # ==================== Private file writing methods ====================
-    
+
     def _write_request_body_to_file(self, body: bytes):
         """Writes request body to file."""
         try:
@@ -344,7 +348,7 @@ class DebugLogger:
                     f.write(body)
         except Exception as e:
             logger.error(f"[DebugLogger] Error writing request_body: {e}")
-    
+
     def _write_kiro_request_body_to_file(self, body: bytes):
         """Writes Kiro request body to file."""
         try:
@@ -358,7 +362,7 @@ class DebugLogger:
                     f.write(body)
         except Exception as e:
             logger.error(f"[DebugLogger] Error writing kiro_request_body: {e}")
-    
+
     def _append_raw_chunk_to_file(self, chunk: bytes):
         """Appends raw chunk to file."""
         try:
@@ -367,7 +371,7 @@ class DebugLogger:
                 f.write(chunk)
         except Exception:
             pass
-    
+
     def _append_modified_chunk_to_file(self, chunk: bytes):
         """Appends modified chunk to file."""
         try:
@@ -376,25 +380,25 @@ class DebugLogger:
                 f.write(chunk)
         except Exception:
             pass
-    
+
     def _write_app_logs_to_file(self):
         """Writes captured application logs to file."""
         try:
             # Get buffer contents
             logs_content = self._app_logs_buffer.getvalue()
-            
+
             if not logs_content.strip():
                 return
-            
+
             # Ensure directory exists
             self.debug_dir.mkdir(parents=True, exist_ok=True)
-            
+
             file_path = self.debug_dir / "app_logs.txt"
             with open(file_path, "w", encoding="utf-8") as f:
                 f.write(logs_content)
-            
+
             logger.debug(f"[DebugLogger] App logs saved to {file_path}")
-        except Exception as e:
+        except Exception:
             # Don't log error via logger to avoid recursion
             pass
 

--- a/kiro/exceptions.py
+++ b/kiro/exceptions.py
@@ -35,13 +35,13 @@ from loguru import logger
 def sanitize_validation_errors(errors: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Converts validation errors to JSON-serializable format.
-    
+
     Pydantic may include bytes objects in the 'input' field, which
     are not JSON-serializable. This function converts them to strings.
-    
+
     Args:
         errors: List of validation errors from Pydantic
-    
+
     Returns:
         List of errors with bytes converted to strings
     """
@@ -64,42 +64,45 @@ def sanitize_validation_errors(errors: List[Dict[str, Any]]) -> List[Dict[str, A
     return sanitized
 
 
-async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+async def validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
     """
     Pydantic validation error handler.
-    
+
     Logs error details and returns an informative response.
     Correctly handles bytes objects in errors by converting them to strings.
     Also flushes debug logs for validation errors when DEBUG_MODE is enabled.
-    
+
     Args:
         request: FastAPI Request object
         exc: Validation exception from Pydantic
-    
+
     Returns:
         JSONResponse with error details and status 422
     """
     body = await request.body()
     body_str = body.decode("utf-8", errors="replace")
-    
+
     # Sanitize errors for JSON serialization
     sanitized_errors = sanitize_validation_errors(exc.errors())
-    
+
     logger.error(f"Validation error (422): {sanitized_errors}")
     # Log body at DEBUG level to avoid cluttering console with potentially large payloads
     # logger.debug(f"Request body: {body_str[:500]}...")
-    
+
     # Flush debug logs for validation errors
     # This is called AFTER middleware has initialized debug logging,
     # so all app logs during request processing will be captured
     try:
         from kiro.debug_logger import debug_logger
+
         if debug_logger:
             error_message = f"Validation error: {sanitized_errors}"
             debug_logger.flush_on_error(422, error_message)
     except ImportError:
         pass  # debug_logger not available
-    
+
     return JSONResponse(
         status_code=422,
         content={"detail": sanitized_errors, "body": body_str[:500]},

--- a/kiro/http_client.py
+++ b/kiro/http_client.py
@@ -37,7 +37,12 @@ import httpx
 from fastapi import HTTPException
 from loguru import logger
 
-from kiro.config import MAX_RETRIES, BASE_RETRY_DELAY, FIRST_TOKEN_MAX_RETRIES, STREAMING_READ_TIMEOUT
+from kiro.config import (
+    MAX_RETRIES,
+    BASE_RETRY_DELAY,
+    FIRST_TOKEN_MAX_RETRIES,
+    STREAMING_READ_TIMEOUT,
+)
 from kiro.auth import KiroAuthManager
 from kiro.utils import get_kiro_headers
 
@@ -45,43 +50,43 @@ from kiro.utils import get_kiro_headers
 class KiroHttpClient:
     """
     HTTP client for Kiro API with retry logic support.
-    
+
     Automatically handles errors and retries requests:
     - 403: refreshes token and retries
     - 429: waits with exponential backoff
     - 5xx: waits with exponential backoff
     - Timeouts: waits with exponential backoff
-    
+
     Supports two modes of operation:
     1. Per-request client: Creates and owns its own httpx.AsyncClient
     2. Shared client: Uses an application-level shared client (recommended)
-    
+
     Using a shared client reduces memory usage and enables connection pooling,
     which is especially important for handling concurrent requests.
-    
+
     Attributes:
         auth_manager: Authentication manager for obtaining tokens
         client: httpx HTTP client (owned or shared)
-    
+
     Example:
         >>> # Per-request client (legacy mode)
         >>> client = KiroHttpClient(auth_manager)
         >>> response = await client.request_with_retry(...)
-        
+
         >>> # Shared client (recommended)
         >>> shared = httpx.AsyncClient(limits=httpx.Limits(...))
         >>> client = KiroHttpClient(auth_manager, shared_client=shared)
         >>> response = await client.request_with_retry(...)
     """
-    
+
     def __init__(
         self,
         auth_manager: KiroAuthManager,
-        shared_client: Optional[httpx.AsyncClient] = None
+        shared_client: Optional[httpx.AsyncClient] = None,
     ):
         """
         Initializes the HTTP client.
-        
+
         Args:
             auth_manager: Authentication manager
             shared_client: Optional shared httpx.AsyncClient for connection pooling.
@@ -92,27 +97,27 @@ class KiroHttpClient:
         self._shared_client = shared_client
         self._owns_client = shared_client is None
         self.client: Optional[httpx.AsyncClient] = shared_client
-    
+
     async def _get_client(self, stream: bool = False) -> httpx.AsyncClient:
         """
         Returns or creates an HTTP client with proper timeouts.
-        
+
         If a shared client was provided at initialization, it is returned as-is.
         Otherwise, creates a new client with appropriate timeout configuration.
-        
+
         httpx timeouts:
         - connect: TCP handshake (DNS + TCP SYN/ACK)
         - read: waiting for data from server between chunks
         - write: sending data to server
         - pool: waiting for free connection from pool
-        
+
         IMPORTANT: FIRST_TOKEN_TIMEOUT is NOT used here!
         It is applied in streaming_openai.py via asyncio.wait_for() to control
         the wait time for the first token from the model (retry business logic).
-        
+
         Args:
             stream: If True, uses STREAMING_READ_TIMEOUT for read (only for new clients)
-        
+
         Returns:
             Active HTTP client
         """
@@ -120,7 +125,7 @@ class KiroHttpClient:
         # Shared client should be pre-configured with appropriate timeouts
         if self._shared_client is not None:
             return self._shared_client
-        
+
         # Create new client if needed (per-request mode)
         if self.client is None or self.client.is_closed:
             if stream:
@@ -129,34 +134,35 @@ class KiroHttpClient:
                 # - read: STREAMING_READ_TIMEOUT (300 sec) - model may "think" between chunks
                 # - write/pool: standard values
                 timeout_config = httpx.Timeout(
-                    connect=30.0,
-                    read=STREAMING_READ_TIMEOUT,
-                    write=30.0,
-                    pool=30.0
+                    connect=30.0, read=STREAMING_READ_TIMEOUT, write=30.0, pool=30.0
                 )
-                logger.debug(f"Creating streaming HTTP client (read_timeout={STREAMING_READ_TIMEOUT}s)")
+                logger.debug(
+                    f"Creating streaming HTTP client (read_timeout={STREAMING_READ_TIMEOUT}s)"
+                )
             else:
                 # For regular requests: single timeout of 300 sec
                 timeout_config = httpx.Timeout(timeout=300.0)
                 logger.debug("Creating non-streaming HTTP client (timeout=300s)")
-            
-            self.client = httpx.AsyncClient(timeout=timeout_config, follow_redirects=True)
+
+            self.client = httpx.AsyncClient(
+                timeout=timeout_config, follow_redirects=True
+            )
         return self.client
-    
+
     async def close(self) -> None:
         """
         Closes the HTTP client if this instance owns it.
-        
+
         If using a shared client, this method does nothing - the shared client
         should be closed by the application lifecycle manager.
-        
+
         Uses graceful exception handling to prevent errors during cleanup
         from masking the original exception in finally blocks.
         """
         # Don't close shared clients - they're managed by the application
         if not self._owns_client:
             return
-        
+
         if self.client and not self.client.is_closed:
             try:
                 await self.client.aclose()
@@ -164,89 +170,95 @@ class KiroHttpClient:
                 # Log but don't propagate - we're in cleanup code
                 # Propagating here could mask the original exception
                 logger.warning(f"Error closing HTTP client: {e}")
-    
+
     async def request_with_retry(
-        self,
-        method: str,
-        url: str,
-        json_data: dict,
-        stream: bool = False
+        self, method: str, url: str, json_data: dict, stream: bool = False
     ) -> httpx.Response:
         """
         Executes an HTTP request with retry logic.
-        
+
         Automatically handles various error types:
         - 403: refreshes token via auth_manager.force_refresh() and retries
         - 429: waits with exponential backoff (1s, 2s, 4s)
         - 5xx: waits with exponential backoff
         - Timeouts: waits with exponential backoff
-        
+
         For streaming, STREAMING_READ_TIMEOUT is used for waiting between chunks.
         First token timeout is controlled separately in streaming_openai.py via asyncio.wait_for().
-        
+
         Args:
             method: HTTP method (GET, POST, etc.)
             url: Request URL
             json_data: Request body (JSON)
             stream: Use streaming (default False)
-        
+
         Returns:
             httpx.Response with successful response
-        
+
         Raises:
             HTTPException: On failure after all attempts (502/504)
         """
         # Determine the number of retry attempts
         # FIRST_TOKEN_TIMEOUT is used in streaming_openai.py, not here
         max_retries = FIRST_TOKEN_MAX_RETRIES if stream else MAX_RETRIES
-        
+
         client = await self._get_client(stream=stream)
         last_error = None
-        
+
         for attempt in range(max_retries):
             try:
                 # Get current token
                 token = await self.auth_manager.get_access_token()
                 headers = get_kiro_headers(self.auth_manager, token)
-                
+
                 if stream:
-                    req = client.build_request(method, url, json=json_data, headers=headers)
+                    req = client.build_request(
+                        method, url, json=json_data, headers=headers
+                    )
                     response = await client.send(req, stream=True)
                 else:
-                    response = await client.request(method, url, json=json_data, headers=headers)
-                
+                    response = await client.request(
+                        method, url, json=json_data, headers=headers
+                    )
+
                 # Check status
                 if response.status_code == 200:
                     return response
-                
+
                 # 403 - token expired, refresh and retry
                 if response.status_code == 403:
-                    logger.warning(f"Received 403, refreshing token (attempt {attempt + 1}/{MAX_RETRIES})")
+                    logger.warning(
+                        f"Received 403, refreshing token (attempt {attempt + 1}/{MAX_RETRIES})"
+                    )
                     await self.auth_manager.force_refresh()
                     continue
-                
+
                 # 429 - rate limit, wait and retry
                 if response.status_code == 429:
-                    delay = BASE_RETRY_DELAY * (2 ** attempt)
-                    logger.warning(f"Received 429, waiting {delay}s (attempt {attempt + 1}/{MAX_RETRIES})")
+                    delay = BASE_RETRY_DELAY * (2**attempt)
+                    logger.warning(
+                        f"Received 429, waiting {delay}s (attempt {attempt + 1}/{MAX_RETRIES})"
+                    )
                     await asyncio.sleep(delay)
                     continue
-                
+
                 # 5xx - server error, wait and retry
                 if 500 <= response.status_code < 600:
-                    delay = BASE_RETRY_DELAY * (2 ** attempt)
-                    logger.warning(f"Received {response.status_code}, waiting {delay}s (attempt {attempt + 1}/{MAX_RETRIES})")
+                    delay = BASE_RETRY_DELAY * (2**attempt)
+                    logger.warning(
+                        f"Received {response.status_code}, waiting {delay}s (attempt {attempt + 1}/{MAX_RETRIES})"
+                    )
                     await asyncio.sleep(delay)
                     continue
-                
+
                 # Other errors - return as is
                 return response
-                
+
             except httpx.TimeoutException as e:
                 last_error = e
                 # Determine timeout type for logging
                 timeout_type = type(e).__name__
-                
+
                 if stream:
                     # For streaming this could be:
                     # - ConnectTimeout: TCP connection issue
@@ -265,34 +277,36 @@ class KiroHttpClient:
                             f"[{timeout_type}] Timeout during streaming (attempt {attempt + 1}/{max_retries})"
                         )
                 else:
-                    delay = BASE_RETRY_DELAY * (2 ** attempt)
+                    delay = BASE_RETRY_DELAY * (2**attempt)
                     logger.warning(
                         f"[{timeout_type}] Request timeout, waiting {delay}s (attempt {attempt + 1}/{max_retries})"
                     )
                     await asyncio.sleep(delay)
-                
+
             except httpx.RequestError as e:
                 last_error = e
-                delay = BASE_RETRY_DELAY * (2 ** attempt)
-                logger.warning(f"Request error: {e}, waiting {delay}s (attempt {attempt + 1}/{max_retries})")
+                delay = BASE_RETRY_DELAY * (2**attempt)
+                logger.warning(
+                    f"Request error: {e}, waiting {delay}s (attempt {attempt + 1}/{max_retries})"
+                )
                 await asyncio.sleep(delay)
-        
+
         # All attempts exhausted
         if stream:
             raise HTTPException(
                 status_code=504,
-                detail=f"Streaming failed after {max_retries} attempts. Last error: {type(last_error).__name__}"
+                detail=f"Streaming failed after {max_retries} attempts. Last error: {type(last_error).__name__}",
             )
         else:
             raise HTTPException(
                 status_code=502,
-                detail=f"Failed to complete request after {max_retries} attempts: {last_error}"
+                detail=f"Failed to complete request after {max_retries} attempts: {last_error}",
             )
-    
+
     async def __aenter__(self) -> "KiroHttpClient":
         """Async context manager support."""
         return self
-    
+
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         """Closes the client when exiting context."""
         await self.close()

--- a/kiro/model_resolver.py
+++ b/kiro/model_resolver.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 class ModelResolution:
     """
     Result of model resolution.
-    
+
     Attributes:
         internal_id: ID to send to Kiro API
         source: Resolution source - "cache", "hidden", or "passthrough"
@@ -53,6 +53,7 @@ class ModelResolution:
         normalized: Model name after normalization
         is_verified: True if found in cache/hidden, False if passthrough
     """
+
     internal_id: str
     source: str
     original_request: str
@@ -63,7 +64,7 @@ class ModelResolution:
 def normalize_model_name(name: str) -> str:
     """
     Normalize client model name to Kiro format.
-    
+
     Transformations applied:
     1. claude-haiku-4-5 → claude-haiku-4.5 (dash to dot for minor version)
     2. claude-haiku-4-5-20251001 → claude-haiku-4.5 (strip date suffix)
@@ -71,13 +72,13 @@ def normalize_model_name(name: str) -> str:
     4. claude-sonnet-4-20250514 → claude-sonnet-4 (strip date, no minor)
     5. claude-3-7-sonnet → claude-3.7-sonnet (legacy format normalization)
     6. claude-3-7-sonnet-20250219 → claude-3.7-sonnet (legacy + strip date)
-    
+
     Args:
         name: External model name from client
-    
+
     Returns:
         Normalized model name in Kiro format
-    
+
     Examples:
         >>> normalize_model_name("claude-haiku-4-5-20251001")
         'claude-haiku-4.5'
@@ -98,48 +99,54 @@ def normalize_model_name(name: str) -> str:
     """
     if not name:
         return name
-    
+
     # Lowercase for consistent matching
     name_lower = name.lower()
-    
+
     # Pattern 1: Standard format - claude-{family}-{major}-{minor}(-{suffix})?
     # Matches: claude-haiku-4-5, claude-haiku-4-5-20251001, claude-haiku-4-5-latest
     # Groups: (claude-haiku-4), (5), optional suffix
     # IMPORTANT: Minor version is 1-2 digits only! 8-digit dates should NOT match here.
-    standard_pattern = r'^(claude-(?:haiku|sonnet|opus)-\d+)-(\d{1,2})(?:-(?:\d{8}|latest|\d+))?$'
+    standard_pattern = (
+        r"^(claude-(?:haiku|sonnet|opus)-\d+)-(\d{1,2})(?:-(?:\d{8}|latest|\d+))?$"
+    )
     match = re.match(standard_pattern, name_lower)
     if match:
         base = match.group(1)  # claude-haiku-4
         minor = match.group(2)  # 5
         return f"{base}.{minor}"  # claude-haiku-4.5
-    
+
     # Pattern 2: Standard format without minor - claude-{family}-{major}(-{date})?
     # Matches: claude-sonnet-4, claude-sonnet-4-20250514
     # Groups: (claude-sonnet-4), optional date
-    no_minor_pattern = r'^(claude-(?:haiku|sonnet|opus)-\d+)(?:-\d{8})?$'
+    no_minor_pattern = r"^(claude-(?:haiku|sonnet|opus)-\d+)(?:-\d{8})?$"
     match = re.match(no_minor_pattern, name_lower)
     if match:
         return match.group(1)  # claude-sonnet-4
-    
+
     # Pattern 3: Legacy format - claude-{major}-{minor}-{family}(-{suffix})?
     # Matches: claude-3-7-sonnet, claude-3-7-sonnet-20250219
     # Groups: (claude), (3), (7), (sonnet), optional suffix
-    legacy_pattern = r'^(claude)-(\d+)-(\d+)-(haiku|sonnet|opus)(?:-(?:\d{8}|latest|\d+))?$'
+    legacy_pattern = (
+        r"^(claude)-(\d+)-(\d+)-(haiku|sonnet|opus)(?:-(?:\d{8}|latest|\d+))?$"
+    )
     match = re.match(legacy_pattern, name_lower)
     if match:
         prefix = match.group(1)  # claude
-        major = match.group(2)   # 3
-        minor = match.group(3)   # 7
+        major = match.group(2)  # 3
+        minor = match.group(3)  # 7
         family = match.group(4)  # sonnet
         return f"{prefix}-{major}.{minor}-{family}"  # claude-3.7-sonnet
-    
+
     # Pattern 4: Already normalized with dot but has date suffix
     # Matches: claude-haiku-4.5-20251001, claude-3.7-sonnet-20250219
-    dot_with_date_pattern = r'^(claude-(?:\d+\.\d+-)?(?:haiku|sonnet|opus)(?:-\d+\.\d+)?)-\d{8}$'
+    dot_with_date_pattern = (
+        r"^(claude-(?:\d+\.\d+-)?(?:haiku|sonnet|opus)(?:-\d+\.\d+)?)-\d{8}$"
+    )
     match = re.match(dot_with_date_pattern, name_lower)
     if match:
         return match.group(1)
-    
+
     # No transformation needed - return as-is (preserving original case for passthrough)
     return name
 
@@ -147,20 +154,20 @@ def normalize_model_name(name: str) -> str:
 def get_model_id_for_kiro(model_name: str, hidden_models: Dict[str, str]) -> str:
     """
     Get the model ID to send to Kiro API.
-    
+
     This is a simple helper for converters that don't have access to the full
     ModelResolver. It normalizes the name and checks hidden models.
-    
+
     For hidden models (like claude-3.7-sonnet), returns the internal Kiro ID.
     For regular models, returns the normalized name.
-    
+
     Args:
         model_name: External model name from client
         hidden_models: Dict mapping display names to internal Kiro IDs
-    
+
     Returns:
         Model ID to send to Kiro API
-    
+
     Examples:
         >>> get_model_id_for_kiro("claude-haiku-4-5-20251001", {})
         'claude-haiku-4.5'
@@ -176,13 +183,13 @@ def get_model_id_for_kiro(model_name: str, hidden_models: Dict[str, str]) -> str
 def extract_model_family(model_name: str) -> Optional[str]:
     """
     Extract model family from model name.
-    
+
     Args:
         model_name: Model name (normalized or not)
-    
+
     Returns:
         Family name ('haiku', 'sonnet', 'opus') or None if not a Claude model
-    
+
     Examples:
         >>> extract_model_family("claude-haiku-4.5")
         'haiku'
@@ -193,7 +200,7 @@ def extract_model_family(model_name: str) -> Optional[str]:
         >>> extract_model_family("gpt-4")
         None
     """
-    family_match = re.search(r'(haiku|sonnet|opus)', model_name, re.IGNORECASE)
+    family_match = re.search(r"(haiku|sonnet|opus)", model_name, re.IGNORECASE)
     if family_match:
         return family_match.group(1).lower()
     return None
@@ -202,20 +209,20 @@ def extract_model_family(model_name: str) -> Optional[str]:
 class ModelResolver:
     """
     Dynamic model resolver with normalization and optimistic pass-through.
-    
+
     Key principle: We are a gateway, not a gatekeeper.
     Kiro API is the final arbiter of what models exist.
-    
+
     Resolution layers:
     1. Normalize name (dashes→dots, strip dates)
     2. Check dynamic cache (from /ListAvailableModels)
     3. Check hidden models (manual config)
     4. Pass-through (let Kiro decide)
-    
+
     Attributes:
         cache: ModelInfoCache instance for dynamic model lookup
         hidden_models: Dict mapping display names to internal Kiro IDs
-    
+
     Example:
         >>> resolver = ModelResolver(cache, hidden_models)
         >>> resolution = resolver.resolve("claude-haiku-4-5-20251001")
@@ -224,15 +231,13 @@ class ModelResolver:
         >>> resolution.source
         'cache'
     """
-    
+
     def __init__(
-        self,
-        cache: ModelInfoCache,
-        hidden_models: Optional[Dict[str, str]] = None
+        self, cache: ModelInfoCache, hidden_models: Optional[Dict[str, str]] = None
     ):
         """
         Initialize the model resolver.
-        
+
         Args:
             cache: ModelInfoCache instance for dynamic model lookup
             hidden_models: Dict mapping display names to internal Kiro IDs.
@@ -240,28 +245,28 @@ class ModelResolver:
         """
         self.cache = cache
         self.hidden_models = hidden_models or {}
-    
+
     def resolve(self, external_model: str) -> ModelResolution:
         """
         Resolve external model name to internal Kiro ID.
-        
+
         NEVER raises - always returns a resolution.
         If model is not in cache/hidden, we pass it through to Kiro.
         Kiro will be the final judge.
-        
+
         Args:
             external_model: Model name from client request
-        
+
         Returns:
             ModelResolution with internal ID and metadata
         """
         # Layer 1: Normalize name (dashes→dots, strip date)
         normalized = normalize_model_name(external_model)
-        
+
         logger.debug(
             f"Model resolution: '{external_model}' → normalized: '{normalized}'"
         )
-        
+
         # Layer 2: Check dynamic cache (from /ListAvailableModels)
         if self.cache.is_valid_model(normalized):
             logger.debug(f"Model '{normalized}' found in dynamic cache")
@@ -270,9 +275,9 @@ class ModelResolver:
                 source="cache",
                 original_request=external_model,
                 normalized=normalized,
-                is_verified=True
+                is_verified=True,
             )
-        
+
         # Layer 3: Check hidden models
         if normalized in self.hidden_models:
             internal_id = self.hidden_models[normalized]
@@ -284,9 +289,9 @@ class ModelResolver:
                 source="hidden",
                 original_request=external_model,
                 normalized=normalized,
-                is_verified=True
+                is_verified=True,
             )
-        
+
         # Layer 4: Pass-through - let Kiro decide!
         # We don't know all models, Kiro might have hidden ones
         logger.info(
@@ -298,54 +303,54 @@ class ModelResolver:
             source="passthrough",
             original_request=external_model,
             normalized=normalized,
-            is_verified=False  # Not verified locally, Kiro will judge
+            is_verified=False,  # Not verified locally, Kiro will judge
         )
-    
+
     def get_available_models(self) -> List[str]:
         """
         Get list of all available model IDs for /v1/models endpoint.
-        
+
         Combines:
         - Models from dynamic cache (Kiro API)
         - Hidden models (manual config)
-        
+
         Returns:
             List of model IDs in consistent format (with dots)
         """
         # Start with cache models
         models = set(self.cache.get_all_model_ids())
-        
+
         # Add hidden model display names (they use dot format)
         models.update(self.hidden_models.keys())
-        
+
         return sorted(models)
-    
+
     def get_models_by_family(self, family: str) -> List[str]:
         """
         Get available models filtered by family.
-        
+
         Used for error messages to suggest alternatives from the same family.
-        
+
         Args:
             family: Model family ('haiku', 'sonnet', 'opus')
-        
+
         Returns:
             List of model IDs from the specified family
         """
         all_models = self.get_available_models()
         return [m for m in all_models if family.lower() in m.lower()]
-    
+
     def get_suggestions_for_model(self, model_name: str) -> List[str]:
         """
         Get available models from the SAME family for error message.
-        
+
         IMPORTANT: Never suggests models from different family!
         Opus request → only Opus suggestions
         Sonnet request → only Sonnet suggestions
-        
+
         Args:
             model_name: The model that was requested but not found
-        
+
         Returns:
             List of available models from the same family, or all models
             if family cannot be determined
@@ -353,6 +358,6 @@ class ModelResolver:
         family = extract_model_family(model_name)
         if family:
             return self.get_models_by_family(family)
-        
+
         # If we can't determine family, return all models
         return self.get_available_models()

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -26,7 +26,6 @@ Anthropic's Messages API specification.
 Reference: https://docs.anthropic.com/en/api/messages
 """
 
-import time
 from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, Field
 
@@ -35,12 +34,14 @@ from pydantic import BaseModel, Field
 # Content Block Models
 # ==================================================================================================
 
+
 class TextContentBlock(BaseModel):
     """
     Text content block in Anthropic format.
-    
+
     Used in both requests and responses for text content.
     """
+
     type: Literal["text"] = "text"
     text: str
 
@@ -48,15 +49,16 @@ class TextContentBlock(BaseModel):
 class ThinkingContentBlock(BaseModel):
     """
     Thinking content block in Anthropic format.
-    
+
     Represents the model's reasoning/thinking process.
     Used when extended thinking is enabled.
-    
+
     Attributes:
         type: Always "thinking"
         thinking: The thinking/reasoning content
         signature: Cryptographic signature for verification (placeholder in our case)
     """
+
     type: Literal["thinking"] = "thinking"
     thinking: str
     signature: str = ""
@@ -65,9 +67,10 @@ class ThinkingContentBlock(BaseModel):
 class ToolUseContentBlock(BaseModel):
     """
     Tool use content block in Anthropic format.
-    
+
     Represents a tool call made by the assistant.
     """
+
     type: Literal["tool_use"] = "tool_use"
     id: str
     name: str
@@ -77,9 +80,10 @@ class ToolUseContentBlock(BaseModel):
 class ToolResultContentBlock(BaseModel):
     """
     Tool result content block in Anthropic format.
-    
+
     Represents the result of a tool call, sent by the user.
     """
+
     type: Literal["tool_result"] = "tool_result"
     tool_use_id: str
     content: Optional[Union[str, List["TextContentBlock"]]] = None
@@ -90,15 +94,17 @@ class ToolResultContentBlock(BaseModel):
 # Image Content Block Models
 # ==================================================================================================
 
+
 class Base64ImageSource(BaseModel):
     """
     Base64-encoded image source in Anthropic format.
-    
+
     Attributes:
         type: Always "base64"
         media_type: MIME type (e.g., "image/jpeg", "image/png", "image/gif", "image/webp")
         data: Base64-encoded image data
     """
+
     type: Literal["base64"] = "base64"
     media_type: str
     data: str
@@ -107,14 +113,15 @@ class Base64ImageSource(BaseModel):
 class URLImageSource(BaseModel):
     """
     URL-based image source in Anthropic format.
-    
+
     Note: URL images require fetching and converting to base64 for Kiro API.
     Currently logged as warning and skipped.
-    
+
     Attributes:
         type: Always "url"
         url: HTTP(S) URL to the image
     """
+
     type: Literal["url"] = "url"
     url: str
 
@@ -122,14 +129,15 @@ class URLImageSource(BaseModel):
 class ImageContentBlock(BaseModel):
     """
     Image content block in Anthropic format.
-    
+
     Represents an image in a message. Supports both base64-encoded
     images and URL references.
-    
+
     Attributes:
         type: Always "image"
         source: Image source (base64 or URL)
     """
+
     type: Literal["image"] = "image"
     source: Union[Base64ImageSource, URLImageSource]
 
@@ -148,17 +156,19 @@ ContentBlock = Union[
 # Message Models
 # ==================================================================================================
 
+
 class AnthropicMessage(BaseModel):
     """
     Message in Anthropic format.
-    
+
     Attributes:
         role: Message role (user or assistant)
         content: Message content (string or list of content blocks)
     """
+
     role: Literal["user", "assistant"]
     content: Union[str, List[ContentBlock]]
-    
+
     model_config = {"extra": "allow"}
 
 
@@ -166,15 +176,17 @@ class AnthropicMessage(BaseModel):
 # Tool Models
 # ==================================================================================================
 
+
 class AnthropicTool(BaseModel):
     """
     Tool definition in Anthropic format.
-    
+
     Attributes:
         name: Tool name (must match pattern ^[a-zA-Z0-9_-]{1,64}$)
         description: Tool description (optional but recommended)
         input_schema: JSON Schema for tool parameters
     """
+
     name: str
     description: Optional[str] = None
     input_schema: Dict[str, Any]
@@ -182,16 +194,19 @@ class AnthropicTool(BaseModel):
 
 class ToolChoiceAuto(BaseModel):
     """Auto tool choice - model decides whether to use tools."""
+
     type: Literal["auto"] = "auto"
 
 
 class ToolChoiceAny(BaseModel):
     """Any tool choice - model must use at least one tool."""
+
     type: Literal["any"] = "any"
 
 
 class ToolChoiceTool(BaseModel):
     """Specific tool choice - model must use the specified tool."""
+
     type: Literal["tool"] = "tool"
     name: str
 
@@ -203,17 +218,19 @@ ToolChoice = Union[ToolChoiceAuto, ToolChoiceAny, ToolChoiceTool]
 # Request Models
 # ==================================================================================================
 
+
 class SystemContentBlock(BaseModel):
     """
     System content block for prompt caching.
-    
+
     Anthropic API supports system as a list of content blocks
     with optional cache_control for prompt caching.
     """
+
     type: Literal["text"] = "text"
     text: str
     cache_control: Optional[Dict[str, Any]] = None
-    
+
     model_config = {"extra": "allow"}
 
 
@@ -224,7 +241,7 @@ SystemPrompt = Union[str, List[SystemContentBlock], List[Dict[str, Any]]]
 class AnthropicMessagesRequest(BaseModel):
     """
     Request to Anthropic Messages API (/v1/messages).
-    
+
     Attributes:
         model: Model ID (e.g., "claude-sonnet-4-5")
         messages: List of conversation messages
@@ -239,27 +256,28 @@ class AnthropicMessagesRequest(BaseModel):
         stop_sequences: Custom stop sequences
         metadata: Request metadata
     """
+
     model: str
     messages: List[AnthropicMessage] = Field(min_length=1)
     max_tokens: int
-    
+
     # Optional parameters - system can be string or list of content blocks
     system: Optional[SystemPrompt] = None
     stream: bool = False
-    
+
     # Tools
     tools: Optional[List[AnthropicTool]] = None
     tool_choice: Optional[Union[ToolChoice, Dict[str, Any]]] = None
-    
+
     # Sampling parameters
     temperature: Optional[float] = Field(default=None, ge=0, le=1)
     top_p: Optional[float] = Field(default=None, ge=0, le=1)
     top_k: Optional[int] = Field(default=None, ge=0)
-    
+
     # Other parameters
     stop_sequences: Optional[List[str]] = None
     metadata: Optional[Dict[str, Any]] = None
-    
+
     model_config = {"extra": "allow"}
 
 
@@ -267,14 +285,16 @@ class AnthropicMessagesRequest(BaseModel):
 # Response Models
 # ==================================================================================================
 
+
 class AnthropicUsage(BaseModel):
     """
     Token usage information in Anthropic format.
-    
+
     Attributes:
         input_tokens: Number of input tokens
         output_tokens: Number of output tokens
     """
+
     input_tokens: int
     output_tokens: int
 
@@ -282,7 +302,7 @@ class AnthropicUsage(BaseModel):
 class AnthropicMessagesResponse(BaseModel):
     """
     Response from Anthropic Messages API (non-streaming).
-    
+
     Attributes:
         id: Unique message ID
         type: Always "message"
@@ -293,12 +313,15 @@ class AnthropicMessagesResponse(BaseModel):
         stop_sequence: Stop sequence that triggered stop (if any)
         usage: Token usage information
     """
+
     id: str
     type: Literal["message"] = "message"
     role: Literal["assistant"] = "assistant"
     content: List[Union[ThinkingContentBlock, TextContentBlock, ToolUseContentBlock]]
     model: str
-    stop_reason: Optional[Literal["end_turn", "max_tokens", "stop_sequence", "tool_use"]] = None
+    stop_reason: Optional[
+        Literal["end_turn", "max_tokens", "stop_sequence", "tool_use"]
+    ] = None
     stop_sequence: Optional[str] = None
     usage: AnthropicUsage
 
@@ -307,12 +330,14 @@ class AnthropicMessagesResponse(BaseModel):
 # Streaming Event Models
 # ==================================================================================================
 
+
 class MessageStartEvent(BaseModel):
     """
     Event sent at the start of a message stream.
-    
+
     Contains the initial message object with empty content.
     """
+
     type: Literal["message_start"] = "message_start"
     message: Dict[str, Any]
 
@@ -320,11 +345,12 @@ class MessageStartEvent(BaseModel):
 class ContentBlockStartEvent(BaseModel):
     """
     Event sent at the start of a content block.
-    
+
     Attributes:
         index: Index of the content block
         content_block: Initial content block (with empty text for text blocks)
     """
+
     type: Literal["content_block_start"] = "content_block_start"
     index: int
     content_block: Dict[str, Any]
@@ -332,18 +358,21 @@ class ContentBlockStartEvent(BaseModel):
 
 class TextDelta(BaseModel):
     """Delta for text content."""
+
     type: Literal["text_delta"] = "text_delta"
     text: str
 
 
 class ThinkingDelta(BaseModel):
     """Delta for thinking content."""
+
     type: Literal["thinking_delta"] = "thinking_delta"
     thinking: str
 
 
 class InputJsonDelta(BaseModel):
     """Delta for tool input JSON."""
+
     type: Literal["input_json_delta"] = "input_json_delta"
     partial_json: str
 
@@ -351,11 +380,12 @@ class InputJsonDelta(BaseModel):
 class ContentBlockDeltaEvent(BaseModel):
     """
     Event sent when content block is updated.
-    
+
     Attributes:
         index: Index of the content block being updated
         delta: The delta update (text_delta, thinking_delta, or input_json_delta)
     """
+
     type: Literal["content_block_delta"] = "content_block_delta"
     index: int
     delta: Union[TextDelta, ThinkingDelta, InputJsonDelta, Dict[str, Any]]
@@ -365,23 +395,26 @@ class ContentBlockStopEvent(BaseModel):
     """
     Event sent when a content block is complete.
     """
+
     type: Literal["content_block_stop"] = "content_block_stop"
     index: int
 
 
 class MessageDeltaUsage(BaseModel):
     """Usage information in message_delta event."""
+
     output_tokens: int
 
 
 class MessageDeltaEvent(BaseModel):
     """
     Event sent near the end of the stream with final message data.
-    
+
     Attributes:
         delta: Contains stop_reason and stop_sequence
         usage: Output token count
     """
+
     type: Literal["message_delta"] = "message_delta"
     delta: Dict[str, Any]
     usage: MessageDeltaUsage
@@ -391,6 +424,7 @@ class MessageStopEvent(BaseModel):
     """
     Event sent at the end of the message stream.
     """
+
     type: Literal["message_stop"] = "message_stop"
 
 
@@ -398,6 +432,7 @@ class PingEvent(BaseModel):
     """
     Ping event sent periodically to keep connection alive.
     """
+
     type: Literal["ping"] = "ping"
 
 
@@ -405,6 +440,7 @@ class ErrorEvent(BaseModel):
     """
     Error event sent when an error occurs during streaming.
     """
+
     type: Literal["error"] = "error"
     error: Dict[str, Any]
 
@@ -426,10 +462,12 @@ StreamingEvent = Union[
 # Error Models
 # ==================================================================================================
 
+
 class AnthropicErrorDetail(BaseModel):
     """
     Error detail in Anthropic format.
     """
+
     type: str
     message: str
 
@@ -438,5 +476,6 @@ class AnthropicErrorResponse(BaseModel):
     """
     Error response in Anthropic format.
     """
+
     type: Literal["error"] = "error"
     error: AnthropicErrorDetail

--- a/kiro/models_openai.py
+++ b/kiro/models_openai.py
@@ -34,12 +34,14 @@ from pydantic import BaseModel, Field
 # Models for /v1/models endpoint
 # ==================================================================================================
 
+
 class OpenAIModel(BaseModel):
     """
     Data model for describing an AI model in OpenAI format.
-    
+
     Used in the /v1/models endpoint response.
     """
+
     id: str
     object: str = "model"
     created: int = Field(default_factory=lambda: int(time.time()))
@@ -50,9 +52,10 @@ class OpenAIModel(BaseModel):
 class ModelList(BaseModel):
     """
     List of models in OpenAI format.
-    
+
     Response of GET /v1/models endpoint.
     """
+
     object: str = "list"
     data: List[OpenAIModel]
 
@@ -61,13 +64,14 @@ class ModelList(BaseModel):
 # Models for /v1/chat/completions endpoint
 # ==================================================================================================
 
+
 class ChatMessage(BaseModel):
     """
     Chat message in OpenAI format.
-    
+
     Supports various roles (user, assistant, system, tool)
     and various content formats (string, list, object).
-    
+
     Attributes:
         role: Sender role (user, assistant, system, tool)
         content: Message content (can be string, list, or None)
@@ -75,24 +79,26 @@ class ChatMessage(BaseModel):
         tool_calls: List of tool calls (for assistant)
         tool_call_id: Tool call ID (for tool)
     """
+
     role: str
     content: Optional[Union[str, List[Any], Any]] = None
     name: Optional[str] = None
     tool_calls: Optional[List[Any]] = None
     tool_call_id: Optional[str] = None
-    
+
     model_config = {"extra": "allow"}
 
 
 class ToolFunction(BaseModel):
     """
     Tool function description.
-    
+
     Attributes:
         name: Function name
         description: Function description
         parameters: JSON Schema of function parameters
     """
+
     name: str
     description: Optional[str] = None
     parameters: Optional[Dict[str, Any]] = None
@@ -101,11 +107,12 @@ class ToolFunction(BaseModel):
 class Tool(BaseModel):
     """
     Tool in OpenAI format.
-    
+
     Attributes:
         type: Tool type (usually "function")
         function: Function description
     """
+
     type: str = "function"
     function: ToolFunction
 
@@ -113,13 +120,13 @@ class Tool(BaseModel):
 class ChatCompletionRequest(BaseModel):
     """
     Request for response generation in OpenAI Chat Completions API format.
-    
+
     Supports all standard OpenAI API fields, including:
     - Basic parameters (model, messages, stream)
     - Generation parameters (temperature, top_p, max_tokens)
     - Tools (function calling)
     - Additional parameters (ignored but accepted for compatibility)
-    
+
     Attributes:
         model: Model ID for generation
         messages: List of chat messages
@@ -135,10 +142,11 @@ class ChatCompletionRequest(BaseModel):
         tools: List of available tools
         tool_choice: Tool selection strategy
     """
+
     model: str
     messages: Annotated[List[ChatMessage], Field(min_length=1)]
     stream: bool = False
-    
+
     # Generation parameters
     temperature: Optional[float] = None
     top_p: Optional[float] = None
@@ -148,11 +156,11 @@ class ChatCompletionRequest(BaseModel):
     stop: Optional[Union[str, List[str]]] = None
     presence_penalty: Optional[float] = None
     frequency_penalty: Optional[float] = None
-    
+
     # Tools (function calling)
     tools: Optional[List[Tool]] = None
     tool_choice: Optional[Union[str, Dict]] = None
-    
+
     # Compatibility fields (ignored)
     stream_options: Optional[Dict[str, Any]] = None
     logit_bias: Optional[Dict[str, float]] = None
@@ -161,7 +169,7 @@ class ChatCompletionRequest(BaseModel):
     user: Optional[str] = None
     seed: Optional[int] = None
     parallel_tool_calls: Optional[bool] = None
-    
+
     model_config = {"extra": "allow"}
 
 
@@ -169,15 +177,17 @@ class ChatCompletionRequest(BaseModel):
 # Models for responses
 # ==================================================================================================
 
+
 class ChatCompletionChoice(BaseModel):
     """
     Single response variant in Chat Completion.
-    
+
     Attributes:
         index: Variant index
         message: Response message
         finish_reason: Completion reason (stop, tool_calls, length)
     """
+
     index: int = 0
     message: Dict[str, Any]
     finish_reason: Optional[str] = None
@@ -186,13 +196,14 @@ class ChatCompletionChoice(BaseModel):
 class ChatCompletionUsage(BaseModel):
     """
     Token usage information.
-    
+
     Attributes:
         prompt_tokens: Number of tokens in request
         completion_tokens: Number of tokens in response
         total_tokens: Total number of tokens
         credits_used: Credits used (Kiro-specific)
     """
+
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
@@ -202,7 +213,7 @@ class ChatCompletionUsage(BaseModel):
 class ChatCompletionResponse(BaseModel):
     """
     Full Chat Completion response (non-streaming).
-    
+
     Attributes:
         id: Unique response ID
         object: Object type ("chat.completion")
@@ -211,6 +222,7 @@ class ChatCompletionResponse(BaseModel):
         choices: List of response variants
         usage: Token usage information
     """
+
     id: str
     object: str = "chat.completion"
     created: int = Field(default_factory=lambda: int(time.time()))
@@ -222,12 +234,13 @@ class ChatCompletionResponse(BaseModel):
 class ChatCompletionChunkDelta(BaseModel):
     """
     Delta of changes in streaming chunk.
-    
+
     Attributes:
         role: Role (only in first chunk)
         content: New content
         tool_calls: New tool calls
     """
+
     role: Optional[str] = None
     content: Optional[str] = None
     tool_calls: Optional[List[Dict[str, Any]]] = None
@@ -236,12 +249,13 @@ class ChatCompletionChunkDelta(BaseModel):
 class ChatCompletionChunkChoice(BaseModel):
     """
     Single variant in streaming chunk.
-    
+
     Attributes:
         index: Variant index
         delta: Delta of changes
         finish_reason: Completion reason (only in last chunk)
     """
+
     index: int = 0
     delta: ChatCompletionChunkDelta
     finish_reason: Optional[str] = None
@@ -250,7 +264,7 @@ class ChatCompletionChunkChoice(BaseModel):
 class ChatCompletionChunk(BaseModel):
     """
     Streaming chunk in OpenAI format.
-    
+
     Attributes:
         id: Unique response ID
         object: Object type ("chat.completion.chunk")
@@ -259,6 +273,7 @@ class ChatCompletionChunk(BaseModel):
         choices: List of variants
         usage: Usage information (only in last chunk)
     """
+
     id: str
     object: str = "chat.completion.chunk"
     created: int = Field(default_factory=lambda: int(time.time()))

--- a/kiro/parsers.py
+++ b/kiro/parsers.py
@@ -39,69 +39,69 @@ from kiro.utils import generate_tool_call_id
 def find_matching_brace(text: str, start_pos: int) -> int:
     """
     Finds the position of the closing brace considering nesting and strings.
-    
+
     Uses bracket counting for correct parsing of nested JSON.
     Accounts for quoted strings and escape sequences.
-    
+
     Args:
         text: Text to search
         start_pos: Position of opening brace '{'
-    
+
     Returns:
         Position of closing brace or -1 if not found
-    
+
     Example:
         >>> find_matching_brace('{"a": {"b": 1}}', 0)
         14
         >>> find_matching_brace('{"a": "{}"}', 0)
         10
     """
-    if start_pos >= len(text) or text[start_pos] != '{':
+    if start_pos >= len(text) or text[start_pos] != "{":
         return -1
-    
+
     brace_count = 0
     in_string = False
     escape_next = False
-    
+
     for i in range(start_pos, len(text)):
         char = text[i]
-        
+
         if escape_next:
             escape_next = False
             continue
-        
-        if char == '\\' and in_string:
+
+        if char == "\\" and in_string:
             escape_next = True
             continue
-        
+
         if char == '"' and not escape_next:
             in_string = not in_string
             continue
-        
+
         if not in_string:
-            if char == '{':
+            if char == "{":
                 brace_count += 1
-            elif char == '}':
+            elif char == "}":
                 brace_count -= 1
                 if brace_count == 0:
                     return i
-    
+
     return -1
 
 
 def parse_bracket_tool_calls(response_text: str) -> List[Dict[str, Any]]:
     """
     Parses tool calls in [Called func_name with args: {...}] format.
-    
+
     Some models return tool calls in text format instead of
     structured JSON. This function extracts them.
-    
+
     Args:
         response_text: Model response text
-    
+
     Returns:
         List of tool calls in OpenAI format
-    
+
     Example:
         >>> text = "[Called get_weather with args: {\"city\": \"London\"}]"
         >>> calls = parse_bracket_tool_calls(text)
@@ -110,56 +110,55 @@ def parse_bracket_tool_calls(response_text: str) -> List[Dict[str, Any]]:
     """
     if not response_text or "[Called" not in response_text:
         return []
-    
+
     tool_calls = []
-    pattern = r'\[Called\s+(\w+)\s+with\s+args:\s*'
-    
+    pattern = r"\[Called\s+(\w+)\s+with\s+args:\s*"
+
     for match in re.finditer(pattern, response_text, re.IGNORECASE):
         func_name = match.group(1)
         args_start = match.end()
-        
+
         # Find JSON start
-        json_start = response_text.find('{', args_start)
+        json_start = response_text.find("{", args_start)
         if json_start == -1:
             continue
-        
+
         # Find JSON end considering nesting
         json_end = find_matching_brace(response_text, json_start)
         if json_end == -1:
             continue
-        
-        json_str = response_text[json_start:json_end + 1]
-        
+
+        json_str = response_text[json_start : json_end + 1]
+
         try:
             args = json.loads(json_str)
             tool_call_id = generate_tool_call_id()
             # index will be added later when forming the final response
-            tool_calls.append({
-                "id": tool_call_id,
-                "type": "function",
-                "function": {
-                    "name": func_name,
-                    "arguments": json.dumps(args)
+            tool_calls.append(
+                {
+                    "id": tool_call_id,
+                    "type": "function",
+                    "function": {"name": func_name, "arguments": json.dumps(args)},
                 }
-            })
+            )
         except json.JSONDecodeError:
             logger.warning(f"Failed to parse tool call arguments: {json_str[:100]}")
-    
+
     return tool_calls
 
 
 def deduplicate_tool_calls(tool_calls: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Removes duplicate tool calls.
-    
+
     Deduplication occurs by two criteria:
     1. By id - if there are multiple tool calls with the same id, keep the one with
        more arguments (not empty "{}")
     2. By name+arguments - remove complete duplicates
-    
+
     Args:
         tool_calls: List of tool calls
-    
+
     Returns:
         List of unique tool calls
     """
@@ -170,7 +169,7 @@ def deduplicate_tool_calls(tool_calls: List[Dict[str, Any]]) -> List[Dict[str, A
         if not tc_id:
             # Without id - add as is (will be deduplicated by name+args)
             continue
-        
+
         existing = by_id.get(tc_id)
         if existing is None:
             by_id[tc_id] = tc
@@ -178,20 +177,24 @@ def deduplicate_tool_calls(tool_calls: List[Dict[str, Any]]) -> List[Dict[str, A
             # Duplicate by id exists - keep the one with more arguments
             existing_args = existing.get("function", {}).get("arguments", "{}")
             current_args = tc.get("function", {}).get("arguments", "{}")
-            
+
             # Prefer non-empty arguments
-            if current_args != "{}" and (existing_args == "{}" or len(current_args) > len(existing_args)):
-                logger.debug(f"Replacing tool call {tc_id} with better arguments: {len(existing_args)} -> {len(current_args)}")
+            if current_args != "{}" and (
+                existing_args == "{}" or len(current_args) > len(existing_args)
+            ):
+                logger.debug(
+                    f"Replacing tool call {tc_id} with better arguments: {len(existing_args)} -> {len(current_args)}"
+                )
                 by_id[tc_id] = tc
-    
+
     # Collect tool calls: first those with id, then without id
     result_with_id = list(by_id.values())
     result_without_id = [tc for tc in tool_calls if not tc.get("id")]
-    
+
     # Now deduplicate by name+arguments for all
     seen = set()
     unique = []
-    
+
     for tc in result_with_id + result_without_id:
         # Protection against None in function
         func = tc.get("function") or {}
@@ -201,20 +204,20 @@ def deduplicate_tool_calls(tool_calls: List[Dict[str, Any]]) -> List[Dict[str, A
         if key not in seen:
             seen.add(key)
             unique.append(tc)
-    
+
     if len(tool_calls) != len(unique):
         logger.debug(f"Deduplicated tool calls: {len(tool_calls)} -> {len(unique)}")
-    
+
     return unique
 
 
 class AwsEventStreamParser:
     """
     Parser for AWS Event Stream format.
-    
+
     AWS returns events in binary format with :message-type...event delimiters.
     This class extracts JSON events from the stream and converts them to a convenient format.
-    
+
     Supported event types:
     - content: Text content of response
     - tool_start: Start of tool call (name, toolUseId)
@@ -222,13 +225,13 @@ class AwsEventStreamParser:
     - tool_stop: End of tool call
     - usage: Credit consumption information
     - context_usage: Context usage percentage
-    
+
     Attributes:
         buffer: Buffer for accumulating data
         last_content: Last processed content (for deduplication)
         current_tool_call: Current incomplete tool call
         tool_calls: List of completed tool calls
-    
+
     Example:
         >>> parser = AwsEventStreamParser()
         >>> events = parser.feed(chunk)
@@ -236,65 +239,65 @@ class AwsEventStreamParser:
         ...     if event["type"] == "content":
         ...         print(event["data"])
     """
-    
+
     # Patterns for finding JSON events
     EVENT_PATTERNS = [
-        ('{"content":', 'content'),
-        ('{"name":', 'tool_start'),
-        ('{"input":', 'tool_input'),
-        ('{"stop":', 'tool_stop'),
-        ('{"followupPrompt":', 'followup'),
-        ('{"usage":', 'usage'),
-        ('{"contextUsagePercentage":', 'context_usage'),
+        ('{"content":', "content"),
+        ('{"name":', "tool_start"),
+        ('{"input":', "tool_input"),
+        ('{"stop":', "tool_stop"),
+        ('{"followupPrompt":', "followup"),
+        ('{"usage":', "usage"),
+        ('{"contextUsagePercentage":', "context_usage"),
     ]
-    
+
     def __init__(self):
         """Initializes the parser."""
         self.buffer = ""
         self.last_content: Optional[str] = None  # For deduplicating repeating content
         self.current_tool_call: Optional[Dict[str, Any]] = None
         self.tool_calls: List[Dict[str, Any]] = []
-    
+
     def feed(self, chunk: bytes) -> List[Dict[str, Any]]:
         """
         Adds chunk to buffer and returns parsed events.
-        
+
         Args:
             chunk: Bytes of data from stream
-        
+
         Returns:
             List of events in {"type": str, "data": Any} format
         """
         try:
-            self.buffer += chunk.decode('utf-8', errors='ignore')
+            self.buffer += chunk.decode("utf-8", errors="ignore")
         except Exception:
             return []
-        
+
         events = []
-        
+
         while True:
             # Find nearest pattern
             earliest_pos = -1
             earliest_type = None
-            
+
             for pattern, event_type in self.EVENT_PATTERNS:
                 pos = self.buffer.find(pattern)
                 if pos != -1 and (earliest_pos == -1 or pos < earliest_pos):
                     earliest_pos = pos
                     earliest_type = event_type
-            
+
             if earliest_pos == -1:
                 break
-            
+
             # Find JSON end
             json_end = find_matching_brace(self.buffer, earliest_pos)
             if json_end == -1:
                 # JSON not complete, wait for more data
                 break
-            
-            json_str = self.buffer[earliest_pos:json_end + 1]
-            self.buffer = self.buffer[json_end + 1:]
-            
+
+            json_str = self.buffer[earliest_pos : json_end + 1]
+            self.buffer = self.buffer[json_end + 1 :]
+
             try:
                 data = json.loads(json_str)
                 event = self._process_event(data, earliest_type)
@@ -302,149 +305,161 @@ class AwsEventStreamParser:
                     events.append(event)
             except json.JSONDecodeError:
                 logger.warning(f"Failed to parse JSON: {json_str[:100]}")
-        
+
         return events
-    
+
     def _process_event(self, data: dict, event_type: str) -> Optional[Dict[str, Any]]:
         """
         Processes a parsed event.
-        
+
         Args:
             data: Parsed JSON
             event_type: Event type
-        
+
         Returns:
             Processed event or None
         """
-        if event_type == 'content':
+        if event_type == "content":
             return self._process_content_event(data)
-        elif event_type == 'tool_start':
+        elif event_type == "tool_start":
             return self._process_tool_start_event(data)
-        elif event_type == 'tool_input':
+        elif event_type == "tool_input":
             return self._process_tool_input_event(data)
-        elif event_type == 'tool_stop':
+        elif event_type == "tool_stop":
             return self._process_tool_stop_event(data)
-        elif event_type == 'usage':
-            return {"type": "usage", "data": data.get('usage', 0)}
-        elif event_type == 'context_usage':
-            return {"type": "context_usage", "data": data.get('contextUsagePercentage', 0)}
-        
+        elif event_type == "usage":
+            return {"type": "usage", "data": data.get("usage", 0)}
+        elif event_type == "context_usage":
+            return {
+                "type": "context_usage",
+                "data": data.get("contextUsagePercentage", 0),
+            }
+
         return None
-    
+
     def _process_content_event(self, data: dict) -> Optional[Dict[str, Any]]:
         """Processes content event."""
-        content = data.get('content', '')
-        
+        content = data.get("content", "")
+
         # Skip followupPrompt
-        if data.get('followupPrompt'):
+        if data.get("followupPrompt"):
             return None
-        
+
         # Deduplicate repeating content
         if content == self.last_content:
             return None
-        
+
         self.last_content = content
-        
+
         return {"type": "content", "data": content}
-    
+
     def _process_tool_start_event(self, data: dict) -> Optional[Dict[str, Any]]:
         """Processes tool call start."""
         # Finalize previous tool call if exists
         if self.current_tool_call:
             self._finalize_tool_call()
-        
+
         # input can be string or object
-        input_data = data.get('input', '')
+        input_data = data.get("input", "")
         if isinstance(input_data, dict):
             input_str = json.dumps(input_data)
         else:
-            input_str = str(input_data) if input_data else ''
-        
+            input_str = str(input_data) if input_data else ""
+
         self.current_tool_call = {
-            "id": data.get('toolUseId', generate_tool_call_id()),
+            "id": data.get("toolUseId", generate_tool_call_id()),
             "type": "function",
-            "function": {
-                "name": data.get('name', ''),
-                "arguments": input_str
-            }
+            "function": {"name": data.get("name", ""), "arguments": input_str},
         }
-        
-        if data.get('stop'):
+
+        if data.get("stop"):
             self._finalize_tool_call()
-        
+
         return None
-    
+
     def _process_tool_input_event(self, data: dict) -> Optional[Dict[str, Any]]:
         """Processes input continuation for tool call."""
         if self.current_tool_call:
             # input can be string or object
-            input_data = data.get('input', '')
+            input_data = data.get("input", "")
             if isinstance(input_data, dict):
                 input_str = json.dumps(input_data)
             else:
-                input_str = str(input_data) if input_data else ''
-            self.current_tool_call['function']['arguments'] += input_str
+                input_str = str(input_data) if input_data else ""
+            self.current_tool_call["function"]["arguments"] += input_str
         return None
-    
+
     def _process_tool_stop_event(self, data: dict) -> Optional[Dict[str, Any]]:
         """Processes tool call end."""
-        if self.current_tool_call and data.get('stop'):
+        if self.current_tool_call and data.get("stop"):
             self._finalize_tool_call()
         return None
-    
+
     def _finalize_tool_call(self) -> None:
         """Finalizes current tool call and adds to list."""
         if not self.current_tool_call:
             return
-        
+
         # Try to parse and normalize arguments as JSON
-        args = self.current_tool_call['function']['arguments']
-        tool_name = self.current_tool_call['function'].get('name', 'unknown')
-        
-        logger.debug(f"Finalizing tool call '{tool_name}' with raw arguments: {repr(args)[:200]}")
-        
+        args = self.current_tool_call["function"]["arguments"]
+        tool_name = self.current_tool_call["function"].get("name", "unknown")
+
+        logger.debug(
+            f"Finalizing tool call '{tool_name}' with raw arguments: {repr(args)[:200]}"
+        )
+
         if isinstance(args, str):
             if args.strip():
                 try:
                     parsed = json.loads(args)
                     # Ensure result is a JSON string
-                    self.current_tool_call['function']['arguments'] = json.dumps(parsed)
-                    logger.debug(f"Tool '{tool_name}' arguments parsed successfully: {list(parsed.keys()) if isinstance(parsed, dict) else type(parsed)}")
+                    self.current_tool_call["function"]["arguments"] = json.dumps(parsed)
+                    logger.debug(
+                        f"Tool '{tool_name}' arguments parsed successfully: {list(parsed.keys()) if isinstance(parsed, dict) else type(parsed)}"
+                    )
                 except json.JSONDecodeError as e:
                     # If parsing failed, use empty object
-                    logger.warning(f"Failed to parse tool '{tool_name}' arguments: {e}. Raw: {args[:200]}")
-                    self.current_tool_call['function']['arguments'] = "{}"
+                    logger.warning(
+                        f"Failed to parse tool '{tool_name}' arguments: {e}. Raw: {args[:200]}"
+                    )
+                    self.current_tool_call["function"]["arguments"] = "{}"
             else:
                 # Empty string - use empty object
                 # This is normal behavior for duplicate tool calls from Kiro
-                logger.debug(f"Tool '{tool_name}' has empty arguments string (will be deduplicated)")
-                self.current_tool_call['function']['arguments'] = "{}"
+                logger.debug(
+                    f"Tool '{tool_name}' has empty arguments string (will be deduplicated)"
+                )
+                self.current_tool_call["function"]["arguments"] = "{}"
         elif isinstance(args, dict):
             # If already an object - serialize to string
-            self.current_tool_call['function']['arguments'] = json.dumps(args)
-            logger.debug(f"Tool '{tool_name}' arguments already dict with keys: {list(args.keys())}")
+            self.current_tool_call["function"]["arguments"] = json.dumps(args)
+            logger.debug(
+                f"Tool '{tool_name}' arguments already dict with keys: {list(args.keys())}"
+            )
         else:
             # Unknown type - empty object
-            logger.warning(f"Tool '{tool_name}' has unexpected arguments type: {type(args)}")
-            self.current_tool_call['function']['arguments'] = "{}"
-        
+            logger.warning(
+                f"Tool '{tool_name}' has unexpected arguments type: {type(args)}"
+            )
+            self.current_tool_call["function"]["arguments"] = "{}"
+
         self.tool_calls.append(self.current_tool_call)
         self.current_tool_call = None
-    
+
     def get_tool_calls(self) -> List[Dict[str, Any]]:
         """
         Returns all collected tool calls.
-        
+
         Finalizes current tool call if not finished.
         Removes duplicates.
-        
+
         Returns:
             List of unique tool calls
         """
         if self.current_tool_call:
             self._finalize_tool_call()
         return deduplicate_tool_calls(self.tool_calls)
-    
+
     def reset(self) -> None:
         """Resets parser state."""
         self.buffer = ""

--- a/kiro/routes_anthropic.py
+++ b/kiro/routes_anthropic.py
@@ -28,7 +28,6 @@ Reference: https://docs.anthropic.com/en/api/messages
 import json
 from typing import Optional
 
-import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, Security, Header
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import APIKeyHeader
@@ -37,9 +36,6 @@ from loguru import logger
 from kiro.config import PROXY_API_KEY
 from kiro.models_anthropic import (
     AnthropicMessagesRequest,
-    AnthropicMessagesResponse,
-    AnthropicErrorResponse,
-    AnthropicErrorDetail,
 )
 from kiro.auth import KiroAuthManager, AuthType
 from kiro.cache import ModelInfoCache
@@ -50,7 +46,6 @@ from kiro.streaming_anthropic import (
 )
 from kiro.http_client import KiroHttpClient
 from kiro.utils import generate_conversation_id
-from kiro.tokenizer import count_tools_tokens
 
 # Import debug_logger
 try:
@@ -68,33 +63,33 @@ auth_header = APIKeyHeader(name="Authorization", auto_error=False)
 
 async def verify_anthropic_api_key(
     x_api_key: Optional[str] = Security(anthropic_api_key_header),
-    authorization: Optional[str] = Security(auth_header)
+    authorization: Optional[str] = Security(auth_header),
 ) -> bool:
     """
     Verify API key for Anthropic API.
-    
+
     Supports two authentication methods:
     1. x-api-key header (Anthropic native)
     2. Authorization: Bearer header (for compatibility)
-    
+
     Args:
         x_api_key: Value from x-api-key header
         authorization: Value from Authorization header
-    
+
     Returns:
         True if key is valid
-    
+
     Raises:
         HTTPException: 401 if key is invalid or missing
     """
     # Check x-api-key first (Anthropic native)
     if x_api_key and x_api_key == PROXY_API_KEY:
         return True
-    
+
     # Fall back to Authorization: Bearer
     if authorization and authorization == f"Bearer {PROXY_API_KEY}":
         return True
-    
+
     logger.warning("Access attempt with invalid API key (Anthropic endpoint)")
     raise HTTPException(
         status_code=401,
@@ -102,9 +97,9 @@ async def verify_anthropic_api_key(
             "type": "error",
             "error": {
                 "type": "authentication_error",
-                "message": "Invalid or missing API key. Use x-api-key header or Authorization: Bearer."
-            }
-        }
+                "message": "Invalid or missing API key. Use x-api-key header or Authorization: Bearer.",
+            },
+        },
     )
 
 
@@ -116,56 +111,56 @@ router = APIRouter(tags=["Anthropic API"])
 async def messages(
     request: Request,
     request_data: AnthropicMessagesRequest,
-    anthropic_version: Optional[str] = Header(None, alias="anthropic-version")
+    anthropic_version: Optional[str] = Header(None, alias="anthropic-version"),
 ):
     """
     Anthropic Messages API endpoint.
-    
+
     Compatible with Anthropic's /v1/messages endpoint.
     Accepts requests in Anthropic format and translates them to Kiro API.
-    
+
     Required headers:
     - x-api-key: Your API key (or Authorization: Bearer)
     - anthropic-version: API version (optional, for compatibility)
     - Content-Type: application/json
-    
+
     Args:
         request: FastAPI Request for accessing app.state
         request_data: Request in Anthropic MessagesRequest format
         anthropic_version: Anthropic API version header (optional)
-    
+
     Returns:
         StreamingResponse for streaming mode (SSE)
         JSONResponse for non-streaming mode
-    
+
     Raises:
         HTTPException: On validation or API errors
     """
-    logger.info(f"Request to /v1/messages (model={request_data.model}, stream={request_data.stream})")
-    
+    logger.info(
+        f"Request to /v1/messages (model={request_data.model}, stream={request_data.stream})"
+    )
+
     if anthropic_version:
         logger.debug(f"Anthropic-Version header: {anthropic_version}")
-    
+
     auth_manager: KiroAuthManager = request.app.state.auth_manager
     model_cache: ModelInfoCache = request.app.state.model_cache
-    
+
     # Note: prepare_new_request() and log_request_body() are now called by DebugLoggerMiddleware
     # This ensures debug logging works even for requests that fail Pydantic validation (422 errors)
-    
+
     # Generate conversation ID
     conversation_id = generate_conversation_id()
-    
+
     # Build payload for Kiro
     # profileArn is only needed for Kiro Desktop auth
     profile_arn_for_payload = ""
     if auth_manager.auth_type == AuthType.KIRO_DESKTOP and auth_manager.profile_arn:
         profile_arn_for_payload = auth_manager.profile_arn
-    
+
     try:
         kiro_payload = anthropic_to_kiro(
-            request_data,
-            conversation_id,
-            profile_arn_for_payload
+            request_data, conversation_id, profile_arn_for_payload
         )
     except ValueError as e:
         logger.error(f"Conversion error: {e}")
@@ -173,52 +168,47 @@ async def messages(
             status_code=400,
             content={
                 "type": "error",
-                "error": {
-                    "type": "invalid_request_error",
-                    "message": str(e)
-                }
-            }
+                "error": {"type": "invalid_request_error", "message": str(e)},
+            },
         )
-    
+
     # Log Kiro payload
     try:
-        kiro_request_body = json.dumps(kiro_payload, ensure_ascii=False, indent=2).encode('utf-8')
+        kiro_request_body = json.dumps(
+            kiro_payload, ensure_ascii=False, indent=2
+        ).encode("utf-8")
         if debug_logger:
             debug_logger.log_kiro_request_body(kiro_request_body)
     except Exception as e:
         logger.warning(f"Failed to log Kiro request: {e}")
-    
+
     # Create HTTP client with retry logic
     shared_client = request.app.state.http_client
     http_client = KiroHttpClient(auth_manager, shared_client=shared_client)
     url = f"{auth_manager.api_host}/generateAssistantResponse"
-    
+
     # Prepare data for token counting
     # Convert Pydantic models to dicts for tokenizer
     messages_for_tokenizer = [msg.model_dump() for msg in request_data.messages]
-    tools_for_tokenizer = [tool.model_dump() for tool in request_data.tools] if request_data.tools else None
-    
+
     try:
         # Make request to Kiro API (for both streaming and non-streaming modes)
         # Important: we wait for Kiro response BEFORE returning StreamingResponse,
         # so that we can return proper HTTP error codes if Kiro fails
         response = await http_client.request_with_retry(
-            "POST",
-            url,
-            kiro_payload,
-            stream=True
+            "POST", url, kiro_payload, stream=True
         )
-        
+
         if response.status_code != 200:
             try:
                 error_content = await response.aread()
             except Exception:
                 error_content = b"Unknown error"
-            
+
             await http_client.close()
-            error_text = error_content.decode('utf-8', errors='replace')
+            error_text = error_content.decode("utf-8", errors="replace")
             logger.error(f"Error from Kiro API: {response.status_code} - {error_text}")
-            
+
             # Try to parse JSON response from Kiro to extract error message
             error_message = error_text
             try:
@@ -226,31 +216,30 @@ async def messages(
                 if "message" in error_json:
                     error_message = error_json["message"]
                     if "reason" in error_json:
-                        error_message = f"{error_message} (reason: {error_json['reason']})"
+                        error_message = (
+                            f"{error_message} (reason: {error_json['reason']})"
+                        )
             except (json.JSONDecodeError, KeyError):
                 pass
-            
+
             # Log access log for error (before flush, so it gets into app_logs)
             logger.warning(
                 f"HTTP {response.status_code} - POST /v1/messages - {error_message[:100]}"
             )
-            
+
             # Flush debug logs on error
             if debug_logger:
                 debug_logger.flush_on_error(response.status_code, error_message)
-            
+
             # Return error in Anthropic format
             return JSONResponse(
                 status_code=response.status_code,
                 content={
                     "type": "error",
-                    "error": {
-                        "type": "api_error",
-                        "message": error_message
-                    }
-                }
+                    "error": {"type": "api_error", "message": error_message},
+                },
             )
-        
+
         if request_data.stream:
             # Streaming mode - Kiro already returned 200, now stream the response
             async def stream_wrapper():
@@ -262,17 +251,19 @@ async def messages(
                         request_data.model,
                         model_cache,
                         auth_manager,
-                        request_messages=messages_for_tokenizer
+                        request_messages=messages_for_tokenizer,
                     ):
                         yield chunk
                 except GeneratorExit:
                     client_disconnected = True
-                    logger.debug("Client disconnected during streaming (GeneratorExit in routes)")
+                    logger.debug(
+                        "Client disconnected during streaming (GeneratorExit in routes)"
+                    )
                 except Exception as e:
                     streaming_error = e
                     # Send error event to client, then gracefully end the stream
                     try:
-                        error_event = f'event: error\ndata: {json.dumps({"type": "error", "error": {"type": "api_error", "message": str(e)}})}\n\n'
+                        error_event = f"event: error\ndata: {json.dumps({'type': 'error', 'error': {'type': 'api_error', 'message': str(e)}})}\n\n"
                         yield error_event
                     except Exception:
                         pass
@@ -280,28 +271,38 @@ async def messages(
                     await http_client.close()
                     if streaming_error:
                         error_type = type(streaming_error).__name__
-                        error_msg = str(streaming_error) if str(streaming_error) else "(empty message)"
-                        logger.error(f"HTTP 500 - POST /v1/messages (streaming) - [{error_type}] {error_msg[:100]}")
+                        error_msg = (
+                            str(streaming_error)
+                            if str(streaming_error)
+                            else "(empty message)"
+                        )
+                        logger.error(
+                            f"HTTP 500 - POST /v1/messages (streaming) - [{error_type}] {error_msg[:100]}"
+                        )
                     elif client_disconnected:
-                        logger.info(f"HTTP 200 - POST /v1/messages (streaming) - client disconnected")
+                        logger.info(
+                            "HTTP 200 - POST /v1/messages (streaming) - client disconnected"
+                        )
                     else:
-                        logger.info(f"HTTP 200 - POST /v1/messages (streaming) - completed")
-                    
+                        logger.info(
+                            "HTTP 200 - POST /v1/messages (streaming) - completed"
+                        )
+
                     if debug_logger:
                         if streaming_error:
                             debug_logger.flush_on_error(500, str(streaming_error))
                         else:
                             debug_logger.discard_buffers()
-            
+
             return StreamingResponse(
                 stream_wrapper(),
                 media_type="text/event-stream",
                 headers={
                     "Cache-Control": "no-cache",
                     "Connection": "keep-alive",
-                }
+                },
             )
-        
+
         else:
             # Non-streaming mode - collect entire response
             anthropic_response = await collect_anthropic_response(
@@ -309,18 +310,18 @@ async def messages(
                 request_data.model,
                 model_cache,
                 auth_manager,
-                request_messages=messages_for_tokenizer
+                request_messages=messages_for_tokenizer,
             )
-            
+
             await http_client.close()
-            
-            logger.info(f"HTTP 200 - POST /v1/messages (non-streaming) - completed")
-            
+
+            logger.info("HTTP 200 - POST /v1/messages (non-streaming) - completed")
+
             if debug_logger:
                 debug_logger.discard_buffers()
-            
+
             return JSONResponse(content=anthropic_response)
-    
+
     except HTTPException as e:
         await http_client.close()
         logger.warning(f"HTTP {e.status_code} - POST /v1/messages - {e.detail}")
@@ -333,14 +334,14 @@ async def messages(
         logger.error(f"HTTP 500 - POST /v1/messages - {str(e)[:100]}")
         if debug_logger:
             debug_logger.flush_on_error(500, str(e))
-        
+
         return JSONResponse(
             status_code=500,
             content={
                 "type": "error",
                 "error": {
                     "type": "api_error",
-                    "message": f"Internal Server Error: {str(e)}"
-                }
-            }
+                    "message": f"Internal Server Error: {str(e)}",
+                },
+            },
         )

--- a/kiro/streaming_anthropic.py
+++ b/kiro/streaming_anthropic.py
@@ -32,7 +32,6 @@ Reference: https://docs.anthropic.com/en/api/messages-streaming
 """
 
 import json
-import time
 import uuid
 from typing import TYPE_CHECKING, AsyncGenerator, Dict, List, Optional, Any
 
@@ -43,13 +42,16 @@ from kiro.streaming_core import (
     parse_kiro_stream,
     collect_stream_to_result,
     FirstTokenTimeoutError,
-    KiroEvent,
     calculate_tokens_from_context_usage,
     stream_with_first_token_retry,
 )
-from kiro.tokenizer import count_tokens, count_message_tokens, count_tools_tokens
-from kiro.parsers import parse_bracket_tool_calls, deduplicate_tool_calls
-from kiro.config import FIRST_TOKEN_TIMEOUT, FIRST_TOKEN_MAX_RETRIES, FAKE_REASONING_HANDLING
+from kiro.tokenizer import count_tokens, count_message_tokens
+from kiro.parsers import parse_bracket_tool_calls
+from kiro.config import (
+    FIRST_TOKEN_TIMEOUT,
+    FIRST_TOKEN_MAX_RETRIES,
+    FAKE_REASONING_HANDLING,
+)
 
 if TYPE_CHECKING:
     from kiro.auth import KiroAuthManager
@@ -70,15 +72,15 @@ def generate_message_id() -> str:
 def format_sse_event(event_type: str, data: Dict[str, Any]) -> str:
     """
     Format data as Anthropic SSE event.
-    
+
     Anthropic SSE format:
     event: {event_type}
     data: {json_data}
-    
+
     Args:
         event_type: Event type (message_start, content_block_delta, etc.)
         data: Event data dictionary
-    
+
     Returns:
         Formatted SSE string
     """
@@ -88,10 +90,10 @@ def format_sse_event(event_type: str, data: Dict[str, Any]) -> str:
 def generate_thinking_signature() -> str:
     """
     Generate a placeholder signature for thinking content blocks.
-    
+
     In real Anthropic API, this is a cryptographic signature for verification.
     Since we're using fake reasoning via tag injection, we generate a placeholder.
-    
+
     Returns:
         Placeholder signature string
     """
@@ -104,14 +106,14 @@ async def stream_kiro_to_anthropic(
     model_cache: "ModelInfoCache",
     auth_manager: "KiroAuthManager",
     first_token_timeout: float = FIRST_TOKEN_TIMEOUT,
-    request_messages: Optional[list] = None
+    request_messages: Optional[list] = None,
 ) -> AsyncGenerator[str, None]:
     """
     Generator for converting Kiro stream to Anthropic SSE format.
-    
+
     Parses Kiro AWS SSE stream and converts events to Anthropic format.
     Supports thinking content blocks when FAKE_REASONING_HANDLING=as_reasoning_content.
-    
+
     Args:
         response: HTTP response with data stream
         model: Model name to include in response
@@ -119,10 +121,10 @@ async def stream_kiro_to_anthropic(
         auth_manager: Authentication manager
         first_token_timeout: First token wait timeout (seconds)
         request_messages: Original request messages (for token counting)
-    
+
     Yields:
         Strings in Anthropic SSE format
-    
+
     Raises:
         FirstTokenTimeoutError: If first token not received within timeout
     """
@@ -131,11 +133,13 @@ async def stream_kiro_to_anthropic(
     output_tokens = 0
     full_content = ""
     full_thinking_content = ""
-    
+
     # Count input tokens from request messages
     if request_messages:
-        input_tokens = count_message_tokens(request_messages, apply_claude_correction=False)
-    
+        input_tokens = count_message_tokens(
+            request_messages, apply_claude_correction=False
+        )
+
     # Track content blocks - thinking block is index 0, text block is index 1 (when thinking enabled)
     current_block_index = 0
     thinking_block_started = False
@@ -143,322 +147,344 @@ async def stream_kiro_to_anthropic(
     text_block_started = False
     text_block_index: Optional[int] = None
     tool_blocks: List[Dict[str, Any]] = []
-    tool_input_buffers: Dict[int, str] = {}  # index -> accumulated JSON
-    
+
     # Generate signature for thinking block (used if thinking is present)
     thinking_signature = generate_thinking_signature()
-    
+
     # Track context usage for token calculation
     context_usage_percentage: Optional[float] = None
-    
+
     try:
         # Send message_start event
-        yield format_sse_event("message_start", {
-            "type": "message_start",
-            "message": {
-                "id": message_id,
-                "type": "message",
-                "role": "assistant",
-                "content": [],
-                "model": model,
-                "stop_reason": None,
-                "stop_sequence": None,
-                "usage": {
-                    "input_tokens": input_tokens,
-                    "output_tokens": 0
-                }
-            }
-        })
-        
+        yield format_sse_event(
+            "message_start",
+            {
+                "type": "message_start",
+                "message": {
+                    "id": message_id,
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": model,
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": input_tokens, "output_tokens": 0},
+                },
+            },
+        )
+
         async for event in parse_kiro_stream(response, first_token_timeout):
             if event.type == "content":
                 content = event.content or ""
                 full_content += content
-                
+
                 # Close thinking block if it was open and we're now getting regular content
                 if thinking_block_started and thinking_block_index is not None:
-                    yield format_sse_event("content_block_stop", {
-                        "type": "content_block_stop",
-                        "index": thinking_block_index
-                    })
+                    yield format_sse_event(
+                        "content_block_stop",
+                        {"type": "content_block_stop", "index": thinking_block_index},
+                    )
                     thinking_block_started = False
                     current_block_index += 1
-                
+
                 # Start text block if not started
                 if not text_block_started:
                     text_block_index = current_block_index
-                    yield format_sse_event("content_block_start", {
-                        "type": "content_block_start",
-                        "index": text_block_index,
-                        "content_block": {
-                            "type": "text",
-                            "text": ""
-                        }
-                    })
+                    yield format_sse_event(
+                        "content_block_start",
+                        {
+                            "type": "content_block_start",
+                            "index": text_block_index,
+                            "content_block": {"type": "text", "text": ""},
+                        },
+                    )
                     text_block_started = True
-                
+
                 # Send content delta
                 if content:
-                    yield format_sse_event("content_block_delta", {
-                        "type": "content_block_delta",
-                        "index": text_block_index,
-                        "delta": {
-                            "type": "text_delta",
-                            "text": content
-                        }
-                    })
-            
+                    yield format_sse_event(
+                        "content_block_delta",
+                        {
+                            "type": "content_block_delta",
+                            "index": text_block_index,
+                            "delta": {"type": "text_delta", "text": content},
+                        },
+                    )
+
             elif event.type == "thinking":
                 thinking_content = event.thinking_content or ""
                 full_thinking_content += thinking_content
-                
+
                 # Handle thinking content based on mode
                 if FAKE_REASONING_HANDLING == "as_reasoning_content":
                     # Use native Anthropic thinking content blocks
                     if not thinking_block_started:
                         thinking_block_index = current_block_index
-                        yield format_sse_event("content_block_start", {
-                            "type": "content_block_start",
-                            "index": thinking_block_index,
-                            "content_block": {
-                                "type": "thinking",
-                                "thinking": "",
-                                "signature": thinking_signature
-                            }
-                        })
+                        yield format_sse_event(
+                            "content_block_start",
+                            {
+                                "type": "content_block_start",
+                                "index": thinking_block_index,
+                                "content_block": {
+                                    "type": "thinking",
+                                    "thinking": "",
+                                    "signature": thinking_signature,
+                                },
+                            },
+                        )
                         thinking_block_started = True
-                    
+
                     if thinking_content:
-                        yield format_sse_event("content_block_delta", {
-                            "type": "content_block_delta",
-                            "index": thinking_block_index,
-                            "delta": {
-                                "type": "thinking_delta",
-                                "thinking": thinking_content
-                            }
-                        })
-                
+                        yield format_sse_event(
+                            "content_block_delta",
+                            {
+                                "type": "content_block_delta",
+                                "index": thinking_block_index,
+                                "delta": {
+                                    "type": "thinking_delta",
+                                    "thinking": thinking_content,
+                                },
+                            },
+                        )
+
                 elif FAKE_REASONING_HANDLING == "include_as_text":
                     # Include thinking as regular text content
                     # Close thinking block if it was open (shouldn't happen in this mode)
                     if thinking_block_started and thinking_block_index is not None:
-                        yield format_sse_event("content_block_stop", {
-                            "type": "content_block_stop",
-                            "index": thinking_block_index
-                        })
+                        yield format_sse_event(
+                            "content_block_stop",
+                            {
+                                "type": "content_block_stop",
+                                "index": thinking_block_index,
+                            },
+                        )
                         thinking_block_started = False
                         current_block_index += 1
-                    
+
                     # Start text block if not started
                     if not text_block_started:
                         text_block_index = current_block_index
-                        yield format_sse_event("content_block_start", {
-                            "type": "content_block_start",
-                            "index": text_block_index,
-                            "content_block": {
-                                "type": "text",
-                                "text": ""
-                            }
-                        })
+                        yield format_sse_event(
+                            "content_block_start",
+                            {
+                                "type": "content_block_start",
+                                "index": text_block_index,
+                                "content_block": {"type": "text", "text": ""},
+                            },
+                        )
                         text_block_started = True
-                    
+
                     if thinking_content:
-                        yield format_sse_event("content_block_delta", {
-                            "type": "content_block_delta",
-                            "index": text_block_index,
-                            "delta": {
-                                "type": "text_delta",
-                                "text": thinking_content
-                            }
-                        })
+                        yield format_sse_event(
+                            "content_block_delta",
+                            {
+                                "type": "content_block_delta",
+                                "index": text_block_index,
+                                "delta": {
+                                    "type": "text_delta",
+                                    "text": thinking_content,
+                                },
+                            },
+                        )
                 # For "strip" mode, we just skip the thinking content
-            
+
             elif event.type == "tool_use" and event.tool_use:
                 # Close thinking block if open
                 if thinking_block_started and thinking_block_index is not None:
-                    yield format_sse_event("content_block_stop", {
-                        "type": "content_block_stop",
-                        "index": thinking_block_index
-                    })
+                    yield format_sse_event(
+                        "content_block_stop",
+                        {"type": "content_block_stop", "index": thinking_block_index},
+                    )
                     thinking_block_started = False
                     current_block_index += 1
-                
+
                 # Close text block if open
                 if text_block_started and text_block_index is not None:
-                    yield format_sse_event("content_block_stop", {
-                        "type": "content_block_stop",
-                        "index": text_block_index
-                    })
+                    yield format_sse_event(
+                        "content_block_stop",
+                        {"type": "content_block_stop", "index": text_block_index},
+                    )
                     text_block_started = False
                     current_block_index += 1
-                
+
                 tool = event.tool_use
                 tool_id = tool.get("id") or f"toolu_{uuid.uuid4().hex[:24]}"
-                tool_name = tool.get("function", {}).get("name", "") or tool.get("name", "")
-                tool_input = tool.get("function", {}).get("arguments", {}) or tool.get("input", {})
-                
+                tool_name = tool.get("function", {}).get("name", "") or tool.get(
+                    "name", ""
+                )
+                tool_input = tool.get("function", {}).get("arguments", {}) or tool.get(
+                    "input", {}
+                )
+
                 # Parse arguments if string
                 if isinstance(tool_input, str):
                     try:
                         tool_input = json.loads(tool_input)
                     except json.JSONDecodeError:
                         tool_input = {}
-                
+
                 # Send tool_use block start
-                yield format_sse_event("content_block_start", {
-                    "type": "content_block_start",
-                    "index": current_block_index,
-                    "content_block": {
-                        "type": "tool_use",
-                        "id": tool_id,
-                        "name": tool_name,
-                        "input": {}
-                    }
-                })
-                
+                yield format_sse_event(
+                    "content_block_start",
+                    {
+                        "type": "content_block_start",
+                        "index": current_block_index,
+                        "content_block": {
+                            "type": "tool_use",
+                            "id": tool_id,
+                            "name": tool_name,
+                            "input": {},
+                        },
+                    },
+                )
+
                 # Send tool input as delta
                 input_json = json.dumps(tool_input, ensure_ascii=False)
-                yield format_sse_event("content_block_delta", {
-                    "type": "content_block_delta",
-                    "index": current_block_index,
-                    "delta": {
-                        "type": "input_json_delta",
-                        "partial_json": input_json
-                    }
-                })
-                
+                yield format_sse_event(
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": current_block_index,
+                        "delta": {
+                            "type": "input_json_delta",
+                            "partial_json": input_json,
+                        },
+                    },
+                )
+
                 # Close tool block
-                yield format_sse_event("content_block_stop", {
-                    "type": "content_block_stop",
-                    "index": current_block_index
-                })
-                
-                tool_blocks.append({
-                    "id": tool_id,
-                    "name": tool_name,
-                    "input": tool_input
-                })
+                yield format_sse_event(
+                    "content_block_stop",
+                    {"type": "content_block_stop", "index": current_block_index},
+                )
+
+                tool_blocks.append(
+                    {"id": tool_id, "name": tool_name, "input": tool_input}
+                )
                 current_block_index += 1
-            
-            elif event.type == "context_usage" and event.context_usage_percentage is not None:
+
+            elif (
+                event.type == "context_usage"
+                and event.context_usage_percentage is not None
+            ):
                 context_usage_percentage = event.context_usage_percentage
-        
+
         # Check for bracket-style tool calls in full content
         bracket_tool_calls = parse_bracket_tool_calls(full_content)
         if bracket_tool_calls:
             # Close thinking block if open
             if thinking_block_started and thinking_block_index is not None:
-                yield format_sse_event("content_block_stop", {
-                    "type": "content_block_stop",
-                    "index": thinking_block_index
-                })
+                yield format_sse_event(
+                    "content_block_stop",
+                    {"type": "content_block_stop", "index": thinking_block_index},
+                )
                 thinking_block_started = False
                 current_block_index += 1
-            
+
             # Close text block if open
             if text_block_started and text_block_index is not None:
-                yield format_sse_event("content_block_stop", {
-                    "type": "content_block_stop",
-                    "index": text_block_index
-                })
+                yield format_sse_event(
+                    "content_block_stop",
+                    {"type": "content_block_stop", "index": text_block_index},
+                )
                 text_block_started = False
                 current_block_index += 1
-            
+
             for tc in bracket_tool_calls:
                 tool_id = tc.get("id") or f"toolu_{uuid.uuid4().hex[:24]}"
                 tool_name = tc.get("function", {}).get("name", "")
                 tool_input = tc.get("function", {}).get("arguments", {})
-                
+
                 if isinstance(tool_input, str):
                     try:
                         tool_input = json.loads(tool_input)
                     except json.JSONDecodeError:
                         tool_input = {}
-                
-                yield format_sse_event("content_block_start", {
-                    "type": "content_block_start",
-                    "index": current_block_index,
-                    "content_block": {
-                        "type": "tool_use",
-                        "id": tool_id,
-                        "name": tool_name,
-                        "input": {}
-                    }
-                })
-                
+
+                yield format_sse_event(
+                    "content_block_start",
+                    {
+                        "type": "content_block_start",
+                        "index": current_block_index,
+                        "content_block": {
+                            "type": "tool_use",
+                            "id": tool_id,
+                            "name": tool_name,
+                            "input": {},
+                        },
+                    },
+                )
+
                 input_json = json.dumps(tool_input, ensure_ascii=False)
-                yield format_sse_event("content_block_delta", {
-                    "type": "content_block_delta",
-                    "index": current_block_index,
-                    "delta": {
-                        "type": "input_json_delta",
-                        "partial_json": input_json
-                    }
-                })
-                
-                yield format_sse_event("content_block_stop", {
-                    "type": "content_block_stop",
-                    "index": current_block_index
-                })
-                
-                tool_blocks.append({
-                    "id": tool_id,
-                    "name": tool_name,
-                    "input": tool_input
-                })
+                yield format_sse_event(
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": current_block_index,
+                        "delta": {
+                            "type": "input_json_delta",
+                            "partial_json": input_json,
+                        },
+                    },
+                )
+
+                yield format_sse_event(
+                    "content_block_stop",
+                    {"type": "content_block_stop", "index": current_block_index},
+                )
+
+                tool_blocks.append(
+                    {"id": tool_id, "name": tool_name, "input": tool_input}
+                )
                 current_block_index += 1
-        
+
         # Close thinking block if still open
         if thinking_block_started and thinking_block_index is not None:
-            yield format_sse_event("content_block_stop", {
-                "type": "content_block_stop",
-                "index": thinking_block_index
-            })
+            yield format_sse_event(
+                "content_block_stop",
+                {"type": "content_block_stop", "index": thinking_block_index},
+            )
             current_block_index += 1
-        
+
         # Close text block if still open
         if text_block_started and text_block_index is not None:
-            yield format_sse_event("content_block_stop", {
-                "type": "content_block_stop",
-                "index": text_block_index
-            })
-        
+            yield format_sse_event(
+                "content_block_stop",
+                {"type": "content_block_stop", "index": text_block_index},
+            )
+
         # Calculate output tokens
         output_tokens = count_tokens(full_content + full_thinking_content)
-        
+
         # Calculate total tokens from context usage if available
         if context_usage_percentage is not None:
             prompt_tokens, total_tokens, _, _ = calculate_tokens_from_context_usage(
                 context_usage_percentage, output_tokens, model_cache, model
             )
             input_tokens = prompt_tokens
-        
+
         # Determine stop reason
         stop_reason = "tool_use" if tool_blocks else "end_turn"
-        
+
         # Send message_delta with stop_reason and usage
-        yield format_sse_event("message_delta", {
-            "type": "message_delta",
-            "delta": {
-                "stop_reason": stop_reason,
-                "stop_sequence": None
+        yield format_sse_event(
+            "message_delta",
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+                "usage": {"output_tokens": output_tokens},
             },
-            "usage": {
-                "output_tokens": output_tokens
-            }
-        })
-        
+        )
+
         # Send message_stop
-        yield format_sse_event("message_stop", {
-            "type": "message_stop"
-        })
-        
+        yield format_sse_event("message_stop", {"type": "message_stop"})
+
         logger.debug(
             f"[Anthropic Streaming] Completed: "
             f"input_tokens={input_tokens}, output_tokens={output_tokens}, "
             f"tool_blocks={len(tool_blocks)}, stop_reason={stop_reason}"
         )
-        
+
     except FirstTokenTimeoutError:
         raise
     except GeneratorExit:
@@ -467,16 +493,22 @@ async def stream_kiro_to_anthropic(
     except Exception as e:
         error_type = type(e).__name__
         error_msg = str(e) if str(e) else "(empty message)"
-        logger.error(f"Error during Anthropic streaming: [{error_type}] {error_msg}", exc_info=True)
-        
+        logger.error(
+            f"Error during Anthropic streaming: [{error_type}] {error_msg}",
+            exc_info=True,
+        )
+
         # Send error event
-        yield format_sse_event("error", {
-            "type": "error",
-            "error": {
-                "type": "api_error",
-                "message": f"Internal error: {error_msg}"
-            }
-        })
+        yield format_sse_event(
+            "error",
+            {
+                "type": "error",
+                "error": {
+                    "type": "api_error",
+                    "message": f"Internal error: {error_msg}",
+                },
+            },
+        )
         raise
     finally:
         try:
@@ -490,94 +522,92 @@ async def collect_anthropic_response(
     model: str,
     model_cache: "ModelInfoCache",
     auth_manager: "KiroAuthManager",
-    request_messages: Optional[list] = None
+    request_messages: Optional[list] = None,
 ) -> dict:
     """
     Collect full response from Kiro stream in Anthropic format.
-    
+
     Used for non-streaming mode.
-    
+
     Args:
         response: HTTP response with stream
         model: Model name
         model_cache: Model cache
         auth_manager: Authentication manager
         request_messages: Original request messages (for token counting)
-    
+
     Returns:
         Dictionary with full response in Anthropic Messages format
     """
     message_id = generate_message_id()
-    
+
     # Count input tokens
     input_tokens = 0
     if request_messages:
-        input_tokens = count_message_tokens(request_messages, apply_claude_correction=False)
-    
+        input_tokens = count_message_tokens(
+            request_messages, apply_claude_correction=False
+        )
+
     # Collect stream result
     result = await collect_stream_to_result(response)
-    
+
     # Build content blocks
     content_blocks = []
-    
+
     # Add thinking block FIRST if there's thinking content and mode is as_reasoning_content
     if result.thinking_content and FAKE_REASONING_HANDLING == "as_reasoning_content":
-        content_blocks.append({
-            "type": "thinking",
-            "thinking": result.thinking_content,
-            "signature": generate_thinking_signature()
-        })
-    
+        content_blocks.append(
+            {
+                "type": "thinking",
+                "thinking": result.thinking_content,
+                "signature": generate_thinking_signature(),
+            }
+        )
+
     # Add text block if there's content
     # For include_as_text mode, prepend thinking content to regular content
     text_content = result.content
     if result.thinking_content and FAKE_REASONING_HANDLING == "include_as_text":
         text_content = result.thinking_content + text_content
-    
+
     if text_content:
-        content_blocks.append({
-            "type": "text",
-            "text": text_content
-        })
-    
+        content_blocks.append({"type": "text", "text": text_content})
+
     # Add tool use blocks
     for tc in result.tool_calls:
         tool_id = tc.get("id") or f"toolu_{uuid.uuid4().hex[:24]}"
         tool_name = tc.get("function", {}).get("name", "") or tc.get("name", "")
         tool_input = tc.get("function", {}).get("arguments", {}) or tc.get("input", {})
-        
+
         if isinstance(tool_input, str):
             try:
                 tool_input = json.loads(tool_input)
             except json.JSONDecodeError:
                 tool_input = {}
-        
-        content_blocks.append({
-            "type": "tool_use",
-            "id": tool_id,
-            "name": tool_name,
-            "input": tool_input
-        })
-    
+
+        content_blocks.append(
+            {"type": "tool_use", "id": tool_id, "name": tool_name, "input": tool_input}
+        )
+
     # Calculate output tokens
     output_tokens = count_tokens(result.content + result.thinking_content)
-    
+
     # Calculate from context usage if available
     if result.context_usage_percentage is not None:
         prompt_tokens, _, _, _ = calculate_tokens_from_context_usage(
             result.context_usage_percentage, output_tokens, model_cache, model
         )
         input_tokens = prompt_tokens
-    
+
     # Determine stop reason
     stop_reason = "tool_use" if result.tool_calls else "end_turn"
-    
+
     logger.debug(
         f"[Anthropic Non-Streaming] Completed: "
         f"input_tokens={input_tokens}, output_tokens={output_tokens}, "
         f"tool_calls={len(result.tool_calls)}, stop_reason={stop_reason}"
     )
-    
+
     return {
         "id": message_id,
         "type": "message",
@@ -586,10 +616,7 @@ async def collect_anthropic_response(
         "model": model,
         "stop_reason": stop_reason,
         "stop_sequence": None,
-        "usage": {
-            "input_tokens": input_tokens,
-            "output_tokens": output_tokens
-        }
+        "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
     }
 
 
@@ -601,17 +628,17 @@ async def stream_with_first_token_retry_anthropic(
     max_retries: int = FIRST_TOKEN_MAX_RETRIES,
     first_token_timeout: float = FIRST_TOKEN_TIMEOUT,
     request_messages: Optional[list] = None,
-    request_tools: Optional[list] = None
+    request_tools: Optional[list] = None,
 ) -> AsyncGenerator[str, None]:
     """
     Streaming with automatic retry on first token timeout for Anthropic API.
-    
+
     If model doesn't respond within first_token_timeout seconds,
     request is cancelled and a new one is made. Maximum max_retries attempts.
-    
+
     This is seamless for user - they just see a delay,
     but eventually get a response (or error after all attempts).
-    
+
     Args:
         make_request: Function to create new HTTP request
         model: Model name
@@ -621,33 +648,42 @@ async def stream_with_first_token_retry_anthropic(
         first_token_timeout: First token wait timeout (seconds)
         request_messages: Original request messages (for fallback token counting)
         request_tools: Original request tools (for fallback token counting)
-    
+
     Yields:
         Strings in Anthropic SSE format
-    
+
     Raises:
         Exception with Anthropic error format after exhausting all attempts
     """
+
     def create_http_error(status_code: int, error_text: str) -> Exception:
         """Create exception for HTTP errors in Anthropic format."""
-        return Exception(json.dumps({
-            "type": "error",
-            "error": {
-                "type": "api_error",
-                "message": f"Upstream API error: {error_text}"
-            }
-        }))
-    
+        return Exception(
+            json.dumps(
+                {
+                    "type": "error",
+                    "error": {
+                        "type": "api_error",
+                        "message": f"Upstream API error: {error_text}",
+                    },
+                }
+            )
+        )
+
     def create_timeout_error(retries: int, timeout: float) -> Exception:
         """Create exception for timeout errors in Anthropic format."""
-        return Exception(json.dumps({
-            "type": "error",
-            "error": {
-                "type": "timeout_error",
-                "message": f"Model did not respond within {timeout}s after {retries} attempts. Please try again."
-            }
-        }))
-    
+        return Exception(
+            json.dumps(
+                {
+                    "type": "error",
+                    "error": {
+                        "type": "timeout_error",
+                        "message": f"Model did not respond within {timeout}s after {retries} attempts. Please try again.",
+                    },
+                }
+            )
+        )
+
     async def stream_processor(response: httpx.Response) -> AsyncGenerator[str, None]:
         """Process response and yield Anthropic SSE chunks."""
         async for chunk in stream_kiro_to_anthropic(
@@ -656,10 +692,10 @@ async def stream_with_first_token_retry_anthropic(
             model_cache,
             auth_manager,
             first_token_timeout=first_token_timeout,
-            request_messages=request_messages
+            request_messages=request_messages,
         ):
             yield chunk
-    
+
     async for chunk in stream_with_first_token_retry(
         make_request=make_request,
         stream_processor=stream_processor,

--- a/kiro/streaming_core.py
+++ b/kiro/streaming_core.py
@@ -32,12 +32,26 @@ to convert Kiro events to their respective SSE formats.
 
 import asyncio
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Awaitable, Dict, List, Optional, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncGenerator,
+    Callable,
+    Awaitable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
 
 import httpx
 from loguru import logger
 
-from kiro.parsers import AwsEventStreamParser, parse_bracket_tool_calls, deduplicate_tool_calls
+from kiro.parsers import (
+    AwsEventStreamParser,
+    parse_bracket_tool_calls,
+    deduplicate_tool_calls,
+)
 from kiro.config import (
     FIRST_TOKEN_TIMEOUT,
     FIRST_TOKEN_MAX_RETRIES,
@@ -60,13 +74,14 @@ except ImportError:
 # Data Classes
 # ==================================================================================================
 
+
 @dataclass
 class KiroEvent:
     """
     Unified event from Kiro API stream.
-    
+
     This format is API-agnostic and can be converted to both OpenAI and Anthropic formats.
-    
+
     Attributes:
         type: Event type (content, thinking, tool_use, usage, context_usage, error)
         content: Text content (for content events)
@@ -77,6 +92,7 @@ class KiroEvent:
         is_first_thinking_chunk: Whether this is the first thinking chunk
         is_last_thinking_chunk: Whether this is the last thinking chunk
     """
+
     type: str
     content: Optional[str] = None
     thinking_content: Optional[str] = None
@@ -91,7 +107,7 @@ class KiroEvent:
 class StreamResult:
     """
     Result of collecting a complete stream response.
-    
+
     Attributes:
         content: Full text content
         thinking_content: Full thinking/reasoning content
@@ -99,6 +115,7 @@ class StreamResult:
         usage: Usage information
         context_usage_percentage: Context usage percentage from Kiro API
     """
+
     content: str = ""
     thinking_content: str = ""
     tool_calls: List[Dict[str, Any]] = field(default_factory=list)
@@ -108,6 +125,7 @@ class StreamResult:
 
 class FirstTokenTimeoutError(Exception):
     """Exception raised when first token timeout occurs."""
+
     pass
 
 
@@ -115,78 +133,81 @@ class FirstTokenTimeoutError(Exception):
 # Kiro Stream Parsing
 # ==================================================================================================
 
+
 async def parse_kiro_stream(
     response: httpx.Response,
     first_token_timeout: float = FIRST_TOKEN_TIMEOUT,
-    enable_thinking_parser: bool = True
+    enable_thinking_parser: bool = True,
 ) -> AsyncGenerator[KiroEvent, None]:
     """
     Parses Kiro SSE stream and yields unified events.
-    
+
     This is the core parsing function that converts Kiro's AWS SSE format
     into unified KiroEvent objects that can be formatted for any API.
-    
+
     Args:
         response: HTTP response with data stream
         first_token_timeout: First token wait timeout (seconds)
         enable_thinking_parser: Whether to enable thinking block parsing
-    
+
     Yields:
         KiroEvent objects representing stream events
-    
+
     Raises:
         FirstTokenTimeoutError: If first token not received within timeout
     """
     parser = AwsEventStreamParser()
-    first_token_received = False
-    
+
     # Initialize thinking parser if fake reasoning is enabled
     thinking_parser: Optional[ThinkingParser] = None
     if FAKE_REASONING_ENABLED and enable_thinking_parser:
         thinking_parser = ThinkingParser(handling_mode=FAKE_REASONING_HANDLING)
-        logger.debug(f"Thinking parser initialized with mode: {FAKE_REASONING_HANDLING}")
-    
+        logger.debug(
+            f"Thinking parser initialized with mode: {FAKE_REASONING_HANDLING}"
+        )
+
     try:
         # Create iterator for reading bytes
         byte_iterator = response.aiter_bytes()
-        
+
         # Wait for first chunk with timeout
         try:
             logger.debug(f"Waiting for first token (timeout={first_token_timeout}s)...")
             first_byte_chunk = await asyncio.wait_for(
-                byte_iterator.__anext__(),
-                timeout=first_token_timeout
+                byte_iterator.__anext__(), timeout=first_token_timeout
             )
             logger.debug("First token received")
         except asyncio.TimeoutError:
-            logger.warning(f"[FirstTokenTimeout] Model did not respond within {first_token_timeout}s")
-            raise FirstTokenTimeoutError(f"No response within {first_token_timeout} seconds")
+            logger.warning(
+                f"[FirstTokenTimeout] Model did not respond within {first_token_timeout}s"
+            )
+            raise FirstTokenTimeoutError(
+                f"No response within {first_token_timeout} seconds"
+            )
         except StopAsyncIteration:
             # Empty response - this is normal, just finish
             logger.debug("Empty response from Kiro API")
             return
-        
+
         # Process first chunk
         if debug_logger:
             debug_logger.log_raw_chunk(first_byte_chunk)
-        
+
         async for event in _process_chunk(parser, first_byte_chunk, thinking_parser):
-            if event.type == "content" or event.type == "thinking":
-                first_token_received = True
             yield event
-        
+
         # Continue reading remaining chunks
         async for chunk in byte_iterator:
             if debug_logger:
                 debug_logger.log_raw_chunk(chunk)
-            
+
             async for event in _process_chunk(parser, chunk, thinking_parser):
                 yield event
-        
+
         # Finalize thinking parser and yield any remaining content
         if thinking_parser:
             final_result = thinking_parser.finalize()
-            
+
             if final_result.thinking_content:
                 processed_thinking = thinking_parser.process_for_output(
                     final_result.thinking_content,
@@ -200,21 +221,21 @@ async def parse_kiro_stream(
                         is_first_thinking_chunk=final_result.is_first_thinking_chunk,
                         is_last_thinking_chunk=final_result.is_last_thinking_chunk,
                     )
-            
+
             if final_result.regular_content:
                 yield KiroEvent(type="content", content=final_result.regular_content)
-            
+
             if thinking_parser.found_thinking_block:
                 logger.debug("Thinking block processing completed")
-        
+
         # Check bracket-style tool calls in accumulated content
         all_tool_calls = parser.get_tool_calls()
         # Note: bracket tool calls are checked by the caller using full content
-        
+
         # Yield tool calls if any
         for tc in all_tool_calls:
             yield KiroEvent(type="tool_use", tool_use=tc)
-            
+
     except FirstTokenTimeoutError:
         raise
     except GeneratorExit:
@@ -223,36 +244,38 @@ async def parse_kiro_stream(
     except Exception as e:
         error_type = type(e).__name__
         error_msg = str(e) if str(e) else "(empty message)"
-        logger.error(f"Error during stream parsing: [{error_type}] {error_msg}", exc_info=True)
+        logger.error(
+            f"Error during stream parsing: [{error_type}] {error_msg}", exc_info=True
+        )
         raise
 
 
 async def _process_chunk(
     parser: AwsEventStreamParser,
     chunk: bytes,
-    thinking_parser: Optional[ThinkingParser]
+    thinking_parser: Optional[ThinkingParser],
 ) -> AsyncGenerator[KiroEvent, None]:
     """
     Process a single chunk from Kiro stream.
-    
+
     Args:
         parser: AWS event stream parser
         chunk: Raw bytes chunk
         thinking_parser: Optional thinking parser for fake reasoning
-    
+
     Yields:
         KiroEvent objects
     """
     events = parser.feed(chunk)
-    
+
     for event in events:
         if event["type"] == "content":
             content = event["data"]
-            
+
             # Process through thinking parser if enabled
             if thinking_parser:
                 parse_result = thinking_parser.feed(content)
-                
+
                 # Yield thinking content if any
                 if parse_result.thinking_content:
                     processed_thinking = thinking_parser.process_for_output(
@@ -267,48 +290,55 @@ async def _process_chunk(
                             is_first_thinking_chunk=parse_result.is_first_thinking_chunk,
                             is_last_thinking_chunk=parse_result.is_last_thinking_chunk,
                         )
-                
+
                 # Yield regular content if any
                 if parse_result.regular_content:
-                    yield KiroEvent(type="content", content=parse_result.regular_content)
+                    yield KiroEvent(
+                        type="content", content=parse_result.regular_content
+                    )
             else:
                 # No thinking parser - pass through as-is
                 yield KiroEvent(type="content", content=content)
-        
+
         elif event["type"] == "usage":
             yield KiroEvent(type="usage", usage=event["data"])
-        
+
         elif event["type"] == "context_usage":
-            yield KiroEvent(type="context_usage", context_usage_percentage=event["data"])
+            yield KiroEvent(
+                type="context_usage", context_usage_percentage=event["data"]
+            )
 
 
 # ==================================================================================================
 # Full Response Collection
 # ==================================================================================================
 
+
 async def collect_stream_to_result(
     response: httpx.Response,
     first_token_timeout: float = FIRST_TOKEN_TIMEOUT,
-    enable_thinking_parser: bool = True
+    enable_thinking_parser: bool = True,
 ) -> StreamResult:
     """
     Collects full response from Kiro stream.
-    
+
     This function consumes the entire stream and returns a StreamResult
     with all accumulated data.
-    
+
     Args:
         response: HTTP response with stream
         first_token_timeout: First token wait timeout
         enable_thinking_parser: Whether to enable thinking block parsing
-    
+
     Returns:
         StreamResult with full content, thinking, tool calls, and usage
     """
     result = StreamResult()
     full_content_for_bracket_tools = ""
-    
-    async for event in parse_kiro_stream(response, first_token_timeout, enable_thinking_parser):
+
+    async for event in parse_kiro_stream(
+        response, first_token_timeout, enable_thinking_parser
+    ):
         if event.type == "content" and event.content:
             result.content += event.content
             full_content_for_bracket_tools += event.content
@@ -319,14 +349,18 @@ async def collect_stream_to_result(
             result.tool_calls.append(event.tool_use)
         elif event.type == "usage" and event.usage:
             result.usage = event.usage
-        elif event.type == "context_usage" and event.context_usage_percentage is not None:
+        elif (
+            event.type == "context_usage" and event.context_usage_percentage is not None
+        ):
             result.context_usage_percentage = event.context_usage_percentage
-    
+
     # Check for bracket-style tool calls in full content
     bracket_tool_calls = parse_bracket_tool_calls(full_content_for_bracket_tools)
     if bracket_tool_calls:
-        result.tool_calls = deduplicate_tool_calls(result.tool_calls + bracket_tool_calls)
-    
+        result.tool_calls = deduplicate_tool_calls(
+            result.tool_calls + bracket_tool_calls
+        )
+
     return result
 
 
@@ -334,21 +368,22 @@ async def collect_stream_to_result(
 # Token Counting Utilities
 # ==================================================================================================
 
+
 def calculate_tokens_from_context_usage(
     context_usage_percentage: Optional[float],
     completion_tokens: int,
     model_cache: "ModelInfoCache",
-    model: str
+    model: str,
 ) -> Tuple[int, int, str, str]:
     """
     Calculate token counts from Kiro's context usage percentage.
-    
+
     Args:
         context_usage_percentage: Context usage percentage from Kiro API
         completion_tokens: Number of completion tokens (counted via tiktoken)
         model_cache: Model cache for getting max input tokens
         model: Model name
-    
+
     Returns:
         Tuple of (prompt_tokens, total_tokens, prompt_source, total_source)
     """
@@ -357,7 +392,7 @@ def calculate_tokens_from_context_usage(
         total_tokens = int((context_usage_percentage / 100) * max_input_tokens)
         prompt_tokens = max(0, total_tokens - completion_tokens)
         return prompt_tokens, total_tokens, "subtraction", "API Kiro"
-    
+
     # Fallback: no context usage data
     return 0, completion_tokens, "unknown", "tiktoken"
 
@@ -365,6 +400,7 @@ def calculate_tokens_from_context_usage(
 # ==================================================================================================
 # First Token Retry Logic
 # ==================================================================================================
+
 
 async def stream_with_first_token_retry(
     make_request: Callable[[], Awaitable[httpx.Response]],
@@ -376,13 +412,13 @@ async def stream_with_first_token_retry(
 ) -> AsyncGenerator[str, None]:
     """
     Generic streaming with automatic retry on first token timeout.
-    
+
     If model doesn't respond within first_token_timeout seconds,
     request is cancelled and a new one is made. Maximum max_retries attempts.
-    
+
     This is seamless for user - they just see a delay,
     but eventually get a response (or error after all attempts).
-    
+
     Args:
         make_request: Function to create new HTTP request (returns httpx.Response)
         stream_processor: Function that processes response and yields SSE strings.
@@ -395,13 +431,13 @@ async def stream_with_first_token_retry(
         on_all_retries_failed: Optional callback to create exception when all retries fail.
                               Receives (max_retries, timeout), returns Exception.
                               If None, raises generic Exception.
-    
+
     Yields:
         Strings in SSE format (format depends on stream_processor)
-    
+
     Raises:
         Exception from on_http_error or on_all_retries_failed callbacks
-    
+
     Example:
         >>> async def make_req():
         ...     return await http_client.request_with_retry("POST", url, payload, stream=True)
@@ -411,80 +447,85 @@ async def stream_with_first_token_retry(
         >>> async for chunk in stream_with_first_token_retry(make_req, process):
         ...     print(chunk)
     """
-    last_error: Optional[Exception] = None
-    
     for attempt in range(max_retries):
         response: Optional[httpx.Response] = None
         try:
             # Make request
             if attempt > 0:
-                logger.warning(f"Retry attempt {attempt + 1}/{max_retries} after first token timeout")
-            
+                logger.warning(
+                    f"Retry attempt {attempt + 1}/{max_retries} after first token timeout"
+                )
+
             response = await make_request()
-            
+
             if response.status_code != 200:
                 # Error from API - close response and raise exception
                 try:
                     error_content = await response.aread()
-                    error_text = error_content.decode('utf-8', errors='replace')
+                    error_text = error_content.decode("utf-8", errors="replace")
                 except Exception:
                     error_text = "Unknown error"
-                
+
                 try:
                     await response.aclose()
                 except Exception:
                     pass
-                
-                logger.error(f"Error from Kiro API: {response.status_code} - {error_text}")
-                
+
+                logger.error(
+                    f"Error from Kiro API: {response.status_code} - {error_text}"
+                )
+
                 if on_http_error:
                     raise on_http_error(response.status_code, error_text)
                 else:
-                    raise Exception(f"Upstream API error ({response.status_code}): {error_text}")
-            
+                    raise Exception(
+                        f"Upstream API error ({response.status_code}): {error_text}"
+                    )
+
             # Try to stream with first token timeout
             async for chunk in stream_processor(response):
                 yield chunk
-            
+
             # Successfully completed - exit
             return
-            
-        except FirstTokenTimeoutError as e:
-            last_error = e
+
+        except FirstTokenTimeoutError:
             logger.warning(
                 f"[FirstTokenTimeout] Attempt {attempt + 1}/{max_retries} failed - "
                 f"model did not respond within {first_token_timeout}s"
             )
-            
+
             # Close current response if open
             if response:
                 try:
                     await response.aclose()
                 except Exception:
                     pass
-            
+
             # Continue to next attempt
             continue
-            
+
         except Exception as e:
             # Other errors - no retry, propagate
             # Use positional argument to avoid loguru interpreting curly braces in error message as format placeholders
             # f-string with repr() doesn't work because loguru still sees {type} inside the string
             error_msg = str(e) if str(e) else "(empty message)"
-            logger.error("Unexpected error during streaming: {}", error_msg, exc_info=True)
+            logger.error(
+                "Unexpected error during streaming: {}", error_msg, exc_info=True
+            )
             if response:
                 try:
                     await response.aclose()
                 except Exception:
                     pass
             raise
-    
+
     # All attempts exhausted - raise error
     logger.error(
         f"[FirstTokenTimeout] All {max_retries} attempts exhausted - "
         f"model never responded within {first_token_timeout}s per attempt"
     )
-    
+
     if on_all_retries_failed:
         raise on_all_retries_failed(max_retries, first_token_timeout)
     else:

--- a/kiro/streaming_openai.py
+++ b/kiro/streaming_openai.py
@@ -49,7 +49,6 @@ from kiro.tokenizer import count_tokens, count_message_tokens, count_tools_token
 from kiro.streaming_core import (
     parse_kiro_stream,
     FirstTokenTimeoutError,
-    KiroEvent,
     calculate_tokens_from_context_usage,
     stream_with_first_token_retry as stream_with_first_token_retry_core,
 )
@@ -66,7 +65,12 @@ except ImportError:
 
 
 # Re-export FirstTokenTimeoutError for backward compatibility
-__all__ = ['FirstTokenTimeoutError', 'stream_kiro_to_openai', 'stream_with_first_token_retry', 'collect_stream_response']
+__all__ = [
+    "FirstTokenTimeoutError",
+    "stream_kiro_to_openai",
+    "stream_with_first_token_retry",
+    "collect_stream_response",
+]
 
 
 async def stream_kiro_to_openai_internal(
@@ -77,17 +81,17 @@ async def stream_kiro_to_openai_internal(
     auth_manager: "KiroAuthManager",
     first_token_timeout: float = FIRST_TOKEN_TIMEOUT,
     request_messages: Optional[list] = None,
-    request_tools: Optional[list] = None
+    request_tools: Optional[list] = None,
 ) -> AsyncGenerator[str, None]:
     """
     Internal generator for converting Kiro stream to OpenAI format.
-    
+
     Parses AWS SSE stream and converts events to OpenAI chat.completion.chunk.
     Supports tool calls and usage calculation.
-    
+
     IMPORTANT: This function raises FirstTokenTimeoutError if first token
     is not received within first_token_timeout seconds.
-    
+
     Args:
         client: HTTP client (for connection management)
         response: HTTP response with data stream
@@ -97,32 +101,32 @@ async def stream_kiro_to_openai_internal(
         first_token_timeout: First token wait timeout (seconds)
         request_messages: Original request messages (for fallback token counting)
         request_tools: Original request tools (for fallback token counting)
-    
+
     Yields:
         Strings in SSE format: "data: {...}\\n\\n" or "data: [DONE]\\n\\n"
-    
+
     Raises:
         FirstTokenTimeoutError: If first token not received within timeout
-    
+
     Example:
         >>> async for chunk in stream_kiro_to_openai_internal(client, response, "claude-sonnet-4", cache, auth):
         ...     print(chunk)
         data: {"id":"chatcmpl-...","object":"chat.completion.chunk",...}
-        
+
         data: [DONE]
     """
     completion_id = generate_completion_id()
     created_time = int(time.time())
     first_chunk = True
-    
+
     metering_data = None
     context_usage_percentage = None
     full_content = ""
     full_thinking_content = ""  # Accumulated thinking content for non-streaming
-    
+
     streaming_error_occurred = False
     tool_calls_from_stream = []
-    
+
     try:
         # Use streaming_core.parse_kiro_stream for unified event parsing
         # This handles AWS SSE parsing, first token timeout, and thinking parser
@@ -130,100 +134,111 @@ async def stream_kiro_to_openai_internal(
             if event.type == "content" and event.content:
                 # Accumulate content for bracket tool call detection
                 full_content += event.content
-                
+
                 # Format as OpenAI chunk
                 delta = {"content": event.content}
                 if first_chunk:
                     delta["role"] = "assistant"
                     first_chunk = False
-                
+
                 openai_chunk = {
                     "id": completion_id,
                     "object": "chat.completion.chunk",
                     "created": created_time,
                     "model": model,
-                    "choices": [{"index": 0, "delta": delta, "finish_reason": None}]
+                    "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
                 }
-                
+
                 chunk_text = f"data: {json.dumps(openai_chunk, ensure_ascii=False)}\n\n"
-                
+
                 if debug_logger:
-                    debug_logger.log_modified_chunk(chunk_text.encode('utf-8'))
-                
+                    debug_logger.log_modified_chunk(chunk_text.encode("utf-8"))
+
                 yield chunk_text
-            
+
             elif event.type == "thinking" and event.thinking_content:
                 # Accumulate thinking content
                 full_thinking_content += event.thinking_content
-                
+
                 # Send as reasoning_content or content based on mode
                 if FAKE_REASONING_HANDLING == "as_reasoning_content":
                     delta = {"reasoning_content": event.thinking_content}
                 else:
                     delta = {"content": event.thinking_content}
-                
+
                 if first_chunk:
                     delta["role"] = "assistant"
                     first_chunk = False
-                
+
                 openai_chunk = {
                     "id": completion_id,
                     "object": "chat.completion.chunk",
                     "created": created_time,
                     "model": model,
-                    "choices": [{"index": 0, "delta": delta, "finish_reason": None}]
+                    "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
                 }
-                
+
                 chunk_text = f"data: {json.dumps(openai_chunk, ensure_ascii=False)}\n\n"
-                
+
                 if debug_logger:
-                    debug_logger.log_modified_chunk(chunk_text.encode('utf-8'))
-                
+                    debug_logger.log_modified_chunk(chunk_text.encode("utf-8"))
+
                 yield chunk_text
-            
+
             elif event.type == "tool_use" and event.tool_use:
                 # Collect tool calls from stream
                 tool_calls_from_stream.append(event.tool_use)
-            
+
             elif event.type == "usage" and event.usage:
                 metering_data = event.usage
-            
-            elif event.type == "context_usage" and event.context_usage_percentage is not None:
+
+            elif (
+                event.type == "context_usage"
+                and event.context_usage_percentage is not None
+            ):
                 context_usage_percentage = event.context_usage_percentage
-        
+
         # Check bracket-style tool calls in full content
         bracket_tool_calls = parse_bracket_tool_calls(full_content)
         all_tool_calls = tool_calls_from_stream + bracket_tool_calls
         all_tool_calls = deduplicate_tool_calls(all_tool_calls)
-        
+
         # Determine finish_reason
         finish_reason = "tool_calls" if all_tool_calls else "stop"
-        
+
         # Count completion_tokens (output) using tiktoken
         completion_tokens = count_tokens(full_content + full_thinking_content)
-        
+
         # Calculate total_tokens based on context_usage_percentage from Kiro API
         # context_usage shows TOTAL percentage of context usage (input + output)
-        prompt_tokens, total_tokens, prompt_source, total_source = calculate_tokens_from_context_usage(
-            context_usage_percentage, completion_tokens, model_cache, model
+        prompt_tokens, total_tokens, prompt_source, total_source = (
+            calculate_tokens_from_context_usage(
+                context_usage_percentage, completion_tokens, model_cache, model
+            )
         )
-        
+
         # Fallback: Kiro API didn't return context_usage, use tiktoken
         # Count prompt_tokens from original messages
         # IMPORTANT: Don't apply correction coefficient for prompt_tokens,
         # as it was calibrated for completion_tokens
         if prompt_source == "unknown" and request_messages:
-            prompt_tokens = count_message_tokens(request_messages, apply_claude_correction=False)
+            prompt_tokens = count_message_tokens(
+                request_messages, apply_claude_correction=False
+            )
             if request_tools:
-                prompt_tokens += count_tools_tokens(request_tools, apply_claude_correction=False)
+                prompt_tokens += count_tools_tokens(
+                    request_tools, apply_claude_correction=False
+                )
             total_tokens = prompt_tokens + completion_tokens
             prompt_source = "tiktoken"
             total_source = "tiktoken"
-        
+
         # Send tool calls if present
         if all_tool_calls:
-            logger.debug(f"Processing {len(all_tool_calls)} tool calls for streaming response")
-            
+            logger.debug(
+                f"Processing {len(all_tool_calls)} tool calls for streaming response"
+            )
+
             # Add required index field to each tool_call
             # according to OpenAI API specification for streaming
             indexed_tool_calls = []
@@ -233,33 +248,34 @@ async def stream_kiro_to_openai_internal(
                 # Use "or" for protection against explicit None in values
                 tool_name = func.get("name") or ""
                 tool_args = func.get("arguments") or "{}"
-                
-                logger.debug(f"Tool call [{idx}] '{tool_name}': id={tc.get('id')}, args_length={len(tool_args)}")
-                
+
+                logger.debug(
+                    f"Tool call [{idx}] '{tool_name}': id={tc.get('id')}, args_length={len(tool_args)}"
+                )
+
                 indexed_tc = {
                     "index": idx,
                     "id": tc.get("id"),
                     "type": tc.get("type", "function"),
-                    "function": {
-                        "name": tool_name,
-                        "arguments": tool_args
-                    }
+                    "function": {"name": tool_name, "arguments": tool_args},
                 }
                 indexed_tool_calls.append(indexed_tc)
-            
+
             tool_calls_chunk = {
                 "id": completion_id,
                 "object": "chat.completion.chunk",
                 "created": created_time,
                 "model": model,
-                "choices": [{
-                    "index": 0,
-                    "delta": {"tool_calls": indexed_tool_calls},
-                    "finish_reason": None
-                }]
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"tool_calls": indexed_tool_calls},
+                        "finish_reason": None,
+                    }
+                ],
             }
             yield f"data: {json.dumps(tool_calls_chunk, ensure_ascii=False)}\n\n"
-        
+
         # Final chunk with usage
         final_chunk = {
             "id": completion_id,
@@ -271,12 +287,12 @@ async def stream_kiro_to_openai_internal(
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": completion_tokens,
                 "total_tokens": total_tokens,
-            }
+            },
         }
-        
+
         if metering_data:
             final_chunk["usage"]["credits_used"] = metering_data
-        
+
         # Log final token values being sent to client
         logger.debug(
             f"[Usage] {model}: "
@@ -284,10 +300,10 @@ async def stream_kiro_to_openai_internal(
             f"completion_tokens={completion_tokens} (tiktoken), "
             f"total_tokens={total_tokens} ({total_source})"
         )
-        
+
         yield f"data: {json.dumps(final_chunk, ensure_ascii=False)}\n\n"
         yield "data: [DONE]\n\n"
-        
+
     except FirstTokenTimeoutError:
         # Propagate timeout up for retry
         raise
@@ -301,8 +317,7 @@ async def stream_kiro_to_openai_internal(
         error_type = type(e).__name__
         error_msg = str(e) if str(e) else "(empty message)"
         logger.error(
-            f"Error during streaming: [{error_type}] {error_msg}",
-            exc_info=True
+            f"Error during streaming: [{error_type}] {error_msg}", exc_info=True
         )
         # Propagate error up for proper handling in routes_openai.py
         raise
@@ -312,7 +327,7 @@ async def stream_kiro_to_openai_internal(
             await response.aclose()
         except Exception as close_error:
             logger.debug(f"Error closing response: {close_error}")
-        
+
         if streaming_error_occurred:
             logger.debug("Streaming completed with error")
         else:
@@ -326,14 +341,14 @@ async def stream_kiro_to_openai(
     model_cache: "ModelInfoCache",
     auth_manager: "KiroAuthManager",
     request_messages: Optional[list] = None,
-    request_tools: Optional[list] = None
+    request_tools: Optional[list] = None,
 ) -> AsyncGenerator[str, None]:
     """
     Generator for converting Kiro stream to OpenAI format.
-    
+
     This is a wrapper over stream_kiro_to_openai_internal that does NOT retry.
     Retry logic is implemented in stream_with_first_token_retry.
-    
+
     Args:
         client: HTTP client (for connection management)
         response: HTTP response with data stream
@@ -342,14 +357,18 @@ async def stream_kiro_to_openai(
         auth_manager: Authentication manager
         request_messages: Original request messages (for fallback token counting)
         request_tools: Original request tools (for fallback token counting)
-    
+
     Yields:
         Strings in SSE format: "data: {...}\\n\\n" or "data: [DONE]\\n\\n"
     """
     async for chunk in stream_kiro_to_openai_internal(
-        client, response, model, model_cache, auth_manager,
+        client,
+        response,
+        model,
+        model_cache,
+        auth_manager,
         request_messages=request_messages,
-        request_tools=request_tools
+        request_tools=request_tools,
     ):
         yield chunk
 
@@ -363,19 +382,19 @@ async def stream_with_first_token_retry(
     max_retries: int = FIRST_TOKEN_MAX_RETRIES,
     first_token_timeout: float = FIRST_TOKEN_TIMEOUT,
     request_messages: Optional[list] = None,
-    request_tools: Optional[list] = None
+    request_tools: Optional[list] = None,
 ) -> AsyncGenerator[str, None]:
     """
     Streaming with automatic retry on first token timeout.
-    
+
     If model doesn't respond within first_token_timeout seconds,
     request is cancelled and a new one is made. Maximum max_retries attempts.
-    
+
     This is seamless for user - they just see a delay,
     but eventually get a response (or error after all attempts).
-    
+
     Uses generic stream_with_first_token_retry from streaming_core.py.
-    
+
     Args:
         make_request: Function to create new HTTP request
         client: HTTP client
@@ -386,33 +405,33 @@ async def stream_with_first_token_retry(
         first_token_timeout: First token wait timeout (seconds)
         request_messages: Original request messages (for fallback token counting)
         request_tools: Original request tools (for fallback token counting)
-    
+
     Yields:
         Strings in SSE format
-    
+
     Raises:
         HTTPException: After exhausting all attempts
-    
+
     Example:
         >>> async def make_req():
         ...     return await http_client.request_with_retry("POST", url, payload, stream=True)
         >>> async for chunk in stream_with_first_token_retry(make_req, client, model, cache, auth):
         ...     print(chunk)
     """
+
     def create_http_error(status_code: int, error_text: str) -> HTTPException:
         """Create HTTPException for HTTP errors."""
         return HTTPException(
-            status_code=status_code,
-            detail=f"Upstream API error: {error_text}"
+            status_code=status_code, detail=f"Upstream API error: {error_text}"
         )
-    
+
     def create_timeout_error(retries: int, timeout: float) -> HTTPException:
         """Create HTTPException for timeout errors."""
         return HTTPException(
             status_code=504,
-            detail=f"Model did not respond within {timeout}s after {retries} attempts. Please try again."
+            detail=f"Model did not respond within {timeout}s after {retries} attempts. Please try again.",
         )
-    
+
     async def stream_processor(response: httpx.Response) -> AsyncGenerator[str, None]:
         """Process response and yield OpenAI SSE chunks."""
         async for chunk in stream_kiro_to_openai_internal(
@@ -423,10 +442,10 @@ async def stream_with_first_token_retry(
             auth_manager,
             first_token_timeout=first_token_timeout,
             request_messages=request_messages,
-            request_tools=request_tools
+            request_tools=request_tools,
         ):
             yield chunk
-    
+
     async for chunk in stream_with_first_token_retry_core(
         make_request=make_request,
         stream_processor=stream_processor,
@@ -445,14 +464,14 @@ async def collect_stream_response(
     model_cache: "ModelInfoCache",
     auth_manager: "KiroAuthManager",
     request_messages: Optional[list] = None,
-    request_tools: Optional[list] = None
+    request_tools: Optional[list] = None,
 ) -> dict:
     """
     Collect full response from streaming stream.
-    
+
     Used for non-streaming mode - collects all chunks
     and forms a single response.
-    
+
     Args:
         client: HTTP client
         response: HTTP response with stream
@@ -461,7 +480,7 @@ async def collect_stream_response(
         auth_manager: Authentication manager
         request_messages: Original request messages (for fallback token counting)
         request_tools: Original request tools (for fallback token counting)
-    
+
     Returns:
         Dictionary with full response in OpenAI chat.completion format
     """
@@ -470,7 +489,7 @@ async def collect_stream_response(
     final_usage = None
     tool_calls = []
     completion_id = generate_completion_id()
-    
+
     async for chunk_str in stream_kiro_to_openai(
         client,
         response,
@@ -478,18 +497,18 @@ async def collect_stream_response(
         model_cache,
         auth_manager,
         request_messages=request_messages,
-        request_tools=request_tools
+        request_tools=request_tools,
     ):
         if not chunk_str.startswith("data:"):
             continue
-        
-        data_str = chunk_str[len("data:"):].strip()
+
+        data_str = chunk_str[len("data:") :].strip()
         if not data_str or data_str == "[DONE]":
             continue
-        
+
         try:
             chunk_data = json.loads(data_str)
-            
+
             # Extract data from chunk
             delta = chunk_data.get("choices", [{}])[0].get("delta", {})
             if "content" in delta:
@@ -498,14 +517,14 @@ async def collect_stream_response(
                 full_reasoning_content += delta["reasoning_content"]
             if "tool_calls" in delta:
                 tool_calls.extend(delta["tool_calls"])
-            
+
             # Save usage from last chunk
             if "usage" in chunk_data:
                 final_usage = chunk_data["usage"]
-                
+
         except (json.JSONDecodeError, IndexError):
             continue
-    
+
     # Form final response
     message = {"role": "assistant", "content": full_content}
     if full_reasoning_content:
@@ -522,28 +541,28 @@ async def collect_stream_response(
                 "type": tc.get("type", "function"),
                 "function": {
                     "name": func.get("name", ""),
-                    "arguments": func.get("arguments", "{}")
-                }
+                    "arguments": func.get("arguments", "{}"),
+                },
             }
             cleaned_tool_calls.append(cleaned_tc)
         message["tool_calls"] = cleaned_tool_calls
-    
+
     finish_reason = "tool_calls" if tool_calls else "stop"
-    
+
     # Form usage for response
-    usage = final_usage or {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
-    
+    usage = final_usage or {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+    }
+
     # Log token info for debugging (non-streaming uses same logs from streaming)
-    
+
     return {
         "id": completion_id,
         "object": "chat.completion",
         "created": int(time.time()),
         "model": model,
-        "choices": [{
-            "index": 0,
-            "message": message,
-            "finish_reason": finish_reason
-        }],
-        "usage": usage
+        "choices": [{"index": 0, "message": message, "finish_reason": finish_reason}],
+        "usage": usage,
     }

--- a/kiro/thinking_parser.py
+++ b/kiro/thinking_parser.py
@@ -33,7 +33,7 @@ Key features:
 
 from enum import IntEnum
 from typing import Optional, List
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from loguru import logger
 
@@ -47,11 +47,12 @@ from kiro.config import (
 class ParserState(IntEnum):
     """
     States of the thinking block parser FSM.
-    
+
     PRE_CONTENT: Initial state, buffering to detect opening tag
     IN_THINKING: Inside thinking block, buffering until closing tag
     STREAMING: Regular streaming, no more thinking block detection
     """
+
     PRE_CONTENT = 0
     IN_THINKING = 1
     STREAMING = 2
@@ -61,7 +62,7 @@ class ParserState(IntEnum):
 class ThinkingParseResult:
     """
     Result of processing a content chunk through the parser.
-    
+
     Attributes:
         thinking_content: Content to be sent as reasoning_content (or processed per mode)
         regular_content: Regular content to be sent as delta.content
@@ -69,6 +70,7 @@ class ThinkingParseResult:
         is_last_thinking_chunk: True if thinking block just closed
         state_changed: True if parser state changed during this feed
     """
+
     thinking_content: Optional[str] = None
     regular_content: Optional[str] = None
     is_first_thinking_chunk: bool = False
@@ -79,15 +81,15 @@ class ThinkingParseResult:
 class ThinkingParser:
     """
     Finite state machine parser for thinking blocks in streaming responses.
-    
+
     The parser detects thinking tags ONLY at the start of the response.
     Once a thinking block is found and closed, all subsequent content
     is treated as regular content (even if it contains thinking tags).
-    
+
     This implements "cautious" buffering to handle tags split across chunks:
     - In PRE_CONTENT: buffer until tag found or buffer exceeds limit
     - In IN_THINKING: buffer last MAX_TAG_LENGTH chars to avoid splitting closing tag
-    
+
     Example:
         >>> parser = ThinkingParser()
         >>> result = parser.feed("<think")
@@ -98,7 +100,7 @@ class ThinkingParser:
         >>> result.thinking_content  # remaining thinking content
         >>> result.regular_content  # "World"
     """
-    
+
     def __init__(
         self,
         handling_mode: Optional[str] = None,
@@ -107,7 +109,7 @@ class ThinkingParser:
     ):
         """
         Initialize the thinking parser.
-        
+
         Args:
             handling_mode: How to handle thinking blocks. One of:
                 - "as_reasoning_content": Extract to reasoning_content field
@@ -121,11 +123,11 @@ class ThinkingParser:
         self.handling_mode = handling_mode or FAKE_REASONING_HANDLING
         self.open_tags = open_tags or FAKE_REASONING_OPEN_TAGS
         self.initial_buffer_size = initial_buffer_size
-        
+
         # Calculate max tag length for cautious buffering
         # We need to buffer enough to not split a closing tag
         self.max_tag_length = max(len(tag) for tag in self.open_tags) * 2
-        
+
         # State
         self.state = ParserState.PRE_CONTENT
         self.initial_buffer = ""
@@ -134,51 +136,51 @@ class ThinkingParser:
         self.close_tag: Optional[str] = None
         self.is_first_thinking_chunk = True
         self._thinking_block_found = False
-    
+
     def feed(self, content: str) -> ThinkingParseResult:
         """
         Process a chunk of content through the parser.
-        
+
         Args:
             content: New content from delta.content
-        
+
         Returns:
             ThinkingParseResult with processed content
         """
         result = ThinkingParseResult()
-        
+
         if not content:
             return result
-        
+
         # Handle based on current state
         if self.state == ParserState.PRE_CONTENT:
             result = self._handle_pre_content(content)
-        
+
         # If state changed to IN_THINKING, process remaining content
         if self.state == ParserState.IN_THINKING and result.state_changed:
             # Content after tag is already in thinking_buffer from _handle_pre_content
             pass
         elif self.state == ParserState.IN_THINKING and not result.state_changed:
             result = self._handle_in_thinking(content)
-        
+
         # If state changed to STREAMING, regular_content is already set
         if self.state == ParserState.STREAMING and not result.state_changed:
             result.regular_content = content
-        
+
         return result
-    
+
     def _handle_pre_content(self, content: str) -> ThinkingParseResult:
         """
         Handle content in PRE_CONTENT state.
-        
+
         Buffers content and looks for opening tag at the start.
         """
         result = ThinkingParseResult()
         self.initial_buffer += content
-        
+
         # Strip leading whitespace for tag detection
         stripped = self.initial_buffer.lstrip()
-        
+
         # Check if buffer starts with any of the opening tags
         for tag in self.open_tags:
             if stripped.startswith(tag):
@@ -188,151 +190,163 @@ class ThinkingParser:
                 self.close_tag = f"</{tag[1:]}"  # <thinking> -> </thinking>
                 self._thinking_block_found = True
                 result.state_changed = True
-                
-                logger.debug(f"Thinking tag '{tag}' detected. Transitioning to IN_THINKING.")
-                
+
+                logger.debug(
+                    f"Thinking tag '{tag}' detected. Transitioning to IN_THINKING."
+                )
+
                 # Content after the tag goes to thinking buffer
-                content_after_tag = stripped[len(tag):]
+                content_after_tag = stripped[len(tag) :]
                 self.thinking_buffer = content_after_tag
                 self.initial_buffer = ""
-                
+
                 # Now process the thinking buffer for potential closing tag
                 thinking_result = self._process_thinking_buffer()
                 if thinking_result.thinking_content:
                     result.thinking_content = thinking_result.thinking_content
-                    result.is_first_thinking_chunk = thinking_result.is_first_thinking_chunk
+                    result.is_first_thinking_chunk = (
+                        thinking_result.is_first_thinking_chunk
+                    )
                 if thinking_result.is_last_thinking_chunk:
                     result.is_last_thinking_chunk = True
                 if thinking_result.regular_content:
                     result.regular_content = thinking_result.regular_content
-                
+
                 return result
-        
+
         # Check if we might still be receiving the tag
         # (buffer is shorter than longest tag and could be a prefix)
         for tag in self.open_tags:
             if tag.startswith(stripped) and len(stripped) < len(tag):
                 # Could still be receiving the tag, keep buffering
                 return result
-        
+
         # No tag found and buffer is either:
         # 1. Too long (exceeds initial_buffer_size)
         # 2. Doesn't match any tag prefix
-        if len(self.initial_buffer) > self.initial_buffer_size or not self._could_be_tag_prefix(stripped):
+        if len(
+            self.initial_buffer
+        ) > self.initial_buffer_size or not self._could_be_tag_prefix(stripped):
             # No thinking block, transition to STREAMING
             self.state = ParserState.STREAMING
             result.state_changed = True
             result.regular_content = self.initial_buffer
             self.initial_buffer = ""
-            
+
             logger.debug("No thinking tag detected. Transitioning to STREAMING.")
-        
+
         return result
-    
+
     def _could_be_tag_prefix(self, text: str) -> bool:
         """Check if text could be the start of any opening tag."""
         if not text:
             return True  # Empty could be anything
-        
+
         for tag in self.open_tags:
             if tag.startswith(text):
                 return True
         return False
-    
+
     def _handle_in_thinking(self, content: str) -> ThinkingParseResult:
         """
         Handle content in IN_THINKING state.
-        
+
         Buffers content and looks for closing tag.
         Uses "cautious" sending to avoid splitting the closing tag.
         """
         self.thinking_buffer += content
         return self._process_thinking_buffer()
-    
+
     def _process_thinking_buffer(self) -> ThinkingParseResult:
         """
         Process the thinking buffer, looking for closing tag.
-        
+
         Implements "cautious" sending - keeps last max_tag_length chars
         in buffer to avoid splitting the closing tag across chunks.
         """
         result = ThinkingParseResult()
-        
+
         if not self.close_tag:
             return result
-        
+
         # Check for closing tag
         if self.close_tag in self.thinking_buffer:
             # Found closing tag!
             idx = self.thinking_buffer.find(self.close_tag)
             thinking_content = self.thinking_buffer[:idx]
-            after_tag = self.thinking_buffer[idx + len(self.close_tag):]
-            
+            after_tag = self.thinking_buffer[idx + len(self.close_tag) :]
+
             # Send all thinking content
             if thinking_content:
                 result.thinking_content = thinking_content
                 result.is_first_thinking_chunk = self.is_first_thinking_chunk
                 self.is_first_thinking_chunk = False
-            
+
             result.is_last_thinking_chunk = True
-            
+
             # Transition to STREAMING
             self.state = ParserState.STREAMING
             result.state_changed = True
             self.thinking_buffer = ""
-            
-            logger.debug(f"Closing tag '{self.close_tag}' found. Transitioning to STREAMING.")
-            
+
+            logger.debug(
+                f"Closing tag '{self.close_tag}' found. Transitioning to STREAMING."
+            )
+
             # Content after closing tag is regular content
             # Strip leading whitespace/newlines that often follow the closing tag
             if after_tag:
                 stripped_after = after_tag.lstrip()
                 if stripped_after:
                     result.regular_content = stripped_after
-            
+
             return result
-        
+
         # No closing tag yet - use "cautious" sending
         # Keep last max_tag_length chars in buffer to avoid splitting tag
         if len(self.thinking_buffer) > self.max_tag_length:
-            send_part = self.thinking_buffer[:-self.max_tag_length]
-            self.thinking_buffer = self.thinking_buffer[-self.max_tag_length:]
-            
+            send_part = self.thinking_buffer[: -self.max_tag_length]
+            self.thinking_buffer = self.thinking_buffer[-self.max_tag_length :]
+
             result.thinking_content = send_part
             result.is_first_thinking_chunk = self.is_first_thinking_chunk
             self.is_first_thinking_chunk = False
-        
+
         return result
-    
+
     def finalize(self) -> ThinkingParseResult:
         """
         Finalize parsing when stream ends.
-        
+
         Flushes any remaining buffered content.
-        
+
         Returns:
             ThinkingParseResult with any remaining content
         """
         result = ThinkingParseResult()
-        
+
         # Flush thinking buffer if we're still in thinking state
         if self.thinking_buffer:
             if self.state == ParserState.IN_THINKING:
                 result.thinking_content = self.thinking_buffer
                 result.is_first_thinking_chunk = self.is_first_thinking_chunk
                 result.is_last_thinking_chunk = True
-                logger.warning("Stream ended while still in thinking block. Flushing remaining content.")
+                logger.warning(
+                    "Stream ended while still in thinking block. Flushing remaining content."
+                )
             else:
                 result.regular_content = self.thinking_buffer
             self.thinking_buffer = ""
-        
+
         # Flush initial buffer if we never found a tag
         if self.initial_buffer:
-            result.regular_content = (result.regular_content or "") + self.initial_buffer
+            result.regular_content = (
+                result.regular_content or ""
+            ) + self.initial_buffer
             self.initial_buffer = ""
-        
+
         return result
-    
+
     def reset(self) -> None:
         """Reset parser to initial state."""
         self.state = ParserState.PRE_CONTENT
@@ -342,12 +356,12 @@ class ThinkingParser:
         self.close_tag = None
         self.is_first_thinking_chunk = True
         self._thinking_block_found = False
-    
+
     @property
     def found_thinking_block(self) -> bool:
         """Returns True if a thinking block was detected in this response."""
         return self._thinking_block_found
-    
+
     def process_for_output(
         self,
         thinking_content: Optional[str],
@@ -356,30 +370,30 @@ class ThinkingParser:
     ) -> Optional[str]:
         """
         Process thinking content according to handling mode.
-        
+
         Args:
             thinking_content: Raw thinking content
             is_first: True if this is the first thinking chunk
             is_last: True if this is the last thinking chunk
-        
+
         Returns:
             Processed content string or None (for "remove" mode)
         """
         if not thinking_content:
             return None
-        
+
         if self.handling_mode == "remove":
             return None
-        
+
         if self.handling_mode == "pass":
             # Add tags back
             prefix = self.open_tag if is_first and self.open_tag else ""
             suffix = self.close_tag if is_last and self.close_tag else ""
             return f"{prefix}{thinking_content}{suffix}"
-        
+
         if self.handling_mode == "strip_tags":
             # Return content without tags
             return thinking_content
-        
+
         # "as_reasoning_content" - return as-is, caller will put in reasoning_content field
         return thinking_content

--- a/kiro/tokenizer.py
+++ b/kiro/tokenizer.py
@@ -47,10 +47,10 @@ CLAUDE_CORRECTION_FACTOR = 1.15
 def _get_encoding():
     """
     Lazy initialization of tokenizer.
-    
+
     Uses cl100k_base - encoding for GPT-4/ChatGPT,
     which is close enough to Claude tokenization.
-    
+
     Returns:
         tiktoken.Encoding or None if tiktoken is unavailable
     """
@@ -58,6 +58,7 @@ def _get_encoding():
     if _encoding is None:
         try:
             import tiktoken
+
             _encoding = tiktoken.get_encoding("cl100k_base")
             logger.debug("[Tokenizer] Initialized tiktoken with cl100k_base encoding")
         except ImportError:
@@ -76,17 +77,17 @@ def _get_encoding():
 def count_tokens(text: str, apply_claude_correction: bool = True) -> int:
     """
     Counts the number of tokens in text.
-    
+
     Args:
         text: Text to count tokens for
         apply_claude_correction: Apply correction coefficient for Claude (default True)
-    
+
     Returns:
         Number of tokens (approximate, with Claude correction)
     """
     if not text:
         return 0
-    
+
     encoding = _get_encoding()
     if encoding:
         try:
@@ -96,7 +97,7 @@ def count_tokens(text: str, apply_claude_correction: bool = True) -> int:
             return base_tokens
         except Exception as e:
             logger.warning(f"[Tokenizer] Error encoding text: {e}")
-    
+
     # Fallback: rough estimate ~4 characters per token for English,
     # ~2-3 characters for other languages (taking average ~3.5)
     # For Claude we add correction
@@ -106,35 +107,37 @@ def count_tokens(text: str, apply_claude_correction: bool = True) -> int:
     return base_estimate
 
 
-def count_message_tokens(messages: List[Dict[str, Any]], apply_claude_correction: bool = True) -> int:
+def count_message_tokens(
+    messages: List[Dict[str, Any]], apply_claude_correction: bool = True
+) -> int:
     """
     Counts tokens in a list of chat messages.
-    
+
     Accounts for OpenAI/Claude message structure:
     - role: ~1 token
     - content: text tokens
     - Service tokens between messages: ~3-4 tokens
-    
+
     Args:
         messages: List of messages in OpenAI format
         apply_claude_correction: Apply correction coefficient for Claude
-    
+
     Returns:
         Approximate number of tokens (with Claude correction)
     """
     if not messages:
         return 0
-    
+
     total_tokens = 0
-    
+
     for message in messages:
         # Base tokens per message (role, delimiters)
         total_tokens += 4  # ~4 tokens for service information
-        
+
         # Role tokens (without correction, these are short strings)
         role = message.get("role", "")
         total_tokens += count_tokens(role, apply_claude_correction=False)
-        
+
         # Content tokens
         content = message.get("content")
         if content:
@@ -145,68 +148,83 @@ def count_message_tokens(messages: List[Dict[str, Any]], apply_claude_correction
                 for item in content:
                     if isinstance(item, dict):
                         if item.get("type") == "text":
-                            total_tokens += count_tokens(item.get("text", ""), apply_claude_correction=False)
+                            total_tokens += count_tokens(
+                                item.get("text", ""), apply_claude_correction=False
+                            )
                         elif item.get("type") == "image_url":
                             # Images take ~85-170 tokens depending on size
                             total_tokens += 100  # Average estimate
-        
+
         # tool_calls tokens (if present)
         tool_calls = message.get("tool_calls")
         if tool_calls:
             for tc in tool_calls:
                 total_tokens += 4  # Service tokens
                 func = tc.get("function", {})
-                total_tokens += count_tokens(func.get("name", ""), apply_claude_correction=False)
-                total_tokens += count_tokens(func.get("arguments", ""), apply_claude_correction=False)
-        
+                total_tokens += count_tokens(
+                    func.get("name", ""), apply_claude_correction=False
+                )
+                total_tokens += count_tokens(
+                    func.get("arguments", ""), apply_claude_correction=False
+                )
+
         # tool_call_id tokens (for tool responses)
         if message.get("tool_call_id"):
-            total_tokens += count_tokens(message["tool_call_id"], apply_claude_correction=False)
-    
+            total_tokens += count_tokens(
+                message["tool_call_id"], apply_claude_correction=False
+            )
+
     # Final service tokens
     total_tokens += 3
-    
+
     # Apply correction to total count
     if apply_claude_correction:
         return int(total_tokens * CLAUDE_CORRECTION_FACTOR)
     return total_tokens
 
 
-def count_tools_tokens(tools: Optional[List[Dict[str, Any]]], apply_claude_correction: bool = True) -> int:
+def count_tools_tokens(
+    tools: Optional[List[Dict[str, Any]]], apply_claude_correction: bool = True
+) -> int:
     """
     Counts tokens in tool definitions.
-    
+
     Args:
         tools: List of tools in OpenAI format
         apply_claude_correction: Apply correction coefficient for Claude
-    
+
     Returns:
         Approximate number of tokens (with Claude correction)
     """
     if not tools:
         return 0
-    
+
     total_tokens = 0
-    
+
     for tool in tools:
         total_tokens += 4  # Service tokens
-        
+
         if tool.get("type") == "function":
             func = tool.get("function", {})
-            
+
             # Function name
-            total_tokens += count_tokens(func.get("name", ""), apply_claude_correction=False)
-            
+            total_tokens += count_tokens(
+                func.get("name", ""), apply_claude_correction=False
+            )
+
             # Function description
-            total_tokens += count_tokens(func.get("description", ""), apply_claude_correction=False)
-            
+            total_tokens += count_tokens(
+                func.get("description", ""), apply_claude_correction=False
+            )
+
             # Parameters (JSON schema)
             params = func.get("parameters")
             if params:
                 import json
+
                 params_str = json.dumps(params, ensure_ascii=False)
                 total_tokens += count_tokens(params_str, apply_claude_correction=False)
-    
+
     # Apply correction to total count
     if apply_claude_correction:
         return int(total_tokens * CLAUDE_CORRECTION_FACTOR)
@@ -216,16 +234,16 @@ def count_tools_tokens(tools: Optional[List[Dict[str, Any]]], apply_claude_corre
 def estimate_request_tokens(
     messages: List[Dict[str, Any]],
     tools: Optional[List[Dict[str, Any]]] = None,
-    system_prompt: Optional[str] = None
+    system_prompt: Optional[str] = None,
 ) -> Dict[str, int]:
     """
     Estimates total number of tokens in request.
-    
+
     Args:
         messages: List of messages
         tools: List of tools (optional)
         system_prompt: System prompt (optional, if not in messages)
-    
+
     Returns:
         Dictionary with token breakdown:
         - messages_tokens: message tokens
@@ -236,10 +254,10 @@ def estimate_request_tokens(
     messages_tokens = count_message_tokens(messages)
     tools_tokens = count_tools_tokens(tools)
     system_tokens = count_tokens(system_prompt) if system_prompt else 0
-    
+
     return {
         "messages_tokens": messages_tokens,
         "tools_tokens": tools_tokens,
         "system_tokens": system_tokens,
-        "total_tokens": messages_tokens + tools_tokens + system_tokens
+        "total_tokens": messages_tokens + tools_tokens + system_tokens,
     }

--- a/kiro/utils.py
+++ b/kiro/utils.py
@@ -37,20 +37,20 @@ if TYPE_CHECKING:
 def get_machine_fingerprint() -> str:
     """
     Generates a unique machine fingerprint based on hostname and username.
-    
+
     Used for User-Agent formation to identify a specific gateway installation.
-    
+
     Returns:
         SHA256 hash of the string "{hostname}-{username}-kiro-gateway"
     """
     try:
         import socket
         import getpass
-        
+
         hostname = socket.gethostname()
         username = getpass.getuser()
         unique_string = f"{hostname}-{username}-kiro-gateway"
-        
+
         return hashlib.sha256(unique_string.encode()).hexdigest()
     except Exception as e:
         logger.warning(f"Failed to get machine fingerprint: {e}")
@@ -60,26 +60,29 @@ def get_machine_fingerprint() -> str:
 def get_kiro_headers(auth_manager: "KiroAuthManager", token: str) -> dict:
     """
     Builds headers for Kiro API requests.
-    
+
     Includes all necessary headers for authentication and identification:
     - Authorization with Bearer token
     - User-Agent with fingerprint
     - AWS CodeWhisperer specific headers
-    
+
+    UPDATED: Headers updated to match AWS Q / Kiro migration (Jan 2026).
+    See MY_INSPECTIONS.MD for source.
+
     Args:
         auth_manager: Authentication manager for obtaining fingerprint
         token: Access token for authorization
-    
+
     Returns:
         Dictionary with headers for HTTP request
     """
     fingerprint = auth_manager.fingerprint
-    
+
     return {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
-        "User-Agent": f"aws-sdk-js/1.0.27 ua/2.1 os/win32#10.0.19044 lang/js md/nodejs#22.21.1 api/codewhispererstreaming#1.0.27 m/E KiroIDE-0.7.45-{fingerprint}",
-        "x-amz-user-agent": f"aws-sdk-js/1.0.27 KiroIDE-0.7.45-{fingerprint}",
+        "User-Agent": f"aws-sdk-js/1.0.0 ua/2.1 os/win32#10.0.19045 lang/js md/nodejs#22.21.1 api/codewhispererruntime#1.0.0 m/N,E KiroIDE-0.8.86-{fingerprint}",
+        "x-amz-user-agent": f"aws-sdk-js/1.0.0 KiroIDE-0.8.86-{fingerprint}",
         "x-amzn-codewhisperer-optout": "true",
         "x-amzn-kiro-agent-mode": "vibe",
         "amz-sdk-invocation-id": str(uuid.uuid4()),
@@ -90,7 +93,7 @@ def get_kiro_headers(auth_manager: "KiroAuthManager", token: str) -> dict:
 def generate_completion_id() -> str:
     """
     Generates a unique ID for chat completion.
-    
+
     Returns:
         ID in format "chatcmpl-{uuid_hex}"
     """
@@ -100,7 +103,7 @@ def generate_completion_id() -> str:
 def generate_conversation_id() -> str:
     """
     Generates a unique ID for conversation.
-    
+
     Returns:
         UUID in string format
     """
@@ -110,7 +113,7 @@ def generate_conversation_id() -> str:
 def generate_tool_call_id() -> str:
     """
     Generates a unique ID for tool call.
-    
+
     Returns:
         ID in format "call_{uuid_hex[:8]}"
     """

--- a/main.py
+++ b/main.py
@@ -25,14 +25,14 @@ Application entry point. Creates FastAPI app and connects routes.
 Usage:
     # Using default settings (host: 0.0.0.0, port: 8000)
     python main.py
-    
+
     # With CLI arguments (highest priority)
     python main.py --port 9000
     python main.py --host 127.0.0.1 --port 9000
-    
+
     # With environment variables (medium priority)
     SERVER_PORT=9000 python main.py
-    
+
     # Using uvicorn directly (uvicorn handles its own CLI args)
     uvicorn main:app --host 0.0.0.0 --port 8000
 
@@ -60,7 +60,6 @@ from kiro.config import (
     REGION,
     KIRO_CREDS_FILE,
     KIRO_CLI_DB_FILE,
-    PROXY_API_KEY,
     LOG_LEVEL,
     SERVER_HOST,
     SERVER_PORT,
@@ -86,28 +85,28 @@ logger.add(
     sys.stderr,
     level=LOG_LEVEL,
     colorize=True,
-    format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>"
+    format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>",
 )
 
 
 class InterceptHandler(logging.Handler):
     """
     Intercepts logs from standard logging and redirects them to loguru.
-    
+
     This allows capturing logs from uvicorn, FastAPI and other libraries
     that use standard logging instead of loguru.
-    
+
     Also filters out noisy shutdown-related exceptions (CancelledError, KeyboardInterrupt)
     that are normal during Ctrl+C but uvicorn logs as ERROR.
     """
-    
+
     # Exceptions that are normal during shutdown and should not be logged as errors
     SHUTDOWN_EXCEPTIONS = (
         "CancelledError",
         "KeyboardInterrupt",
         "asyncio.exceptions.CancelledError",
     )
-    
+
     def emit(self, record: logging.LogRecord) -> None:
         # Filter out shutdown-related exceptions that uvicorn logs as ERROR
         # These are normal during Ctrl+C and don't need to spam the console
@@ -119,31 +118,33 @@ class InterceptHandler(logging.Handler):
                     # Suppress the full traceback, just log a simple message
                     logger.info("Server shutdown in progress...")
                     return
-        
+
         # Also filter by message content for cases where exc_info is not set
         msg = record.getMessage()
         if any(exc in msg for exc in self.SHUTDOWN_EXCEPTIONS):
             return
-        
+
         # Get the corresponding loguru level
         try:
             level = logger.level(record.levelname).name
         except ValueError:
             level = record.levelno
-        
+
         # Find the caller frame for correct source display
         frame, depth = logging.currentframe(), 2
         while frame.f_code.co_filename == logging.__file__:
             frame = frame.f_back
             depth += 1
-        
-        logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
+
+        logger.opt(depth=depth, exception=record.exc_info).log(
+            level, record.getMessage()
+        )
 
 
 def setup_logging_intercept():
     """
     Configures log interception from standard logging to loguru.
-    
+
     Intercepts logs from:
     - uvicorn (access logs, error logs)
     - uvicorn.error
@@ -157,7 +158,7 @@ def setup_logging_intercept():
         "uvicorn.access",
         "fastapi",
     ]
-    
+
     for logger_name in loggers_to_intercept:
         logging_logger = logging.getLogger(logger_name)
         logging_logger.handlers = [InterceptHandler()]
@@ -172,20 +173,19 @@ setup_logging_intercept()
 def validate_configuration() -> None:
     """
     Validates that required configuration is present.
-    
+
     Checks:
     - .env file exists
     - Either REFRESH_TOKEN or KIRO_CREDS_FILE is configured
-    
+
     Raises:
         SystemExit: If critical configuration is missing
     """
     errors = []
-    
+
     # Check if .env file exists
     env_file = Path(".env")
-    env_example = Path(".env.example")
-    
+
     if not env_file.exists():
         errors.append(
             ".env file not found!\n"
@@ -207,21 +207,21 @@ def validate_configuration() -> None:
         has_refresh_token = bool(REFRESH_TOKEN)
         has_creds_file = bool(KIRO_CREDS_FILE)
         has_cli_db = bool(KIRO_CLI_DB_FILE)
-        
+
         # Check if creds file actually exists
         if KIRO_CREDS_FILE:
             creds_path = Path(KIRO_CREDS_FILE).expanduser()
             if not creds_path.exists():
                 has_creds_file = False
                 logger.warning(f"KIRO_CREDS_FILE not found: {KIRO_CREDS_FILE}")
-        
+
         # Check if CLI database file actually exists
         if KIRO_CLI_DB_FILE:
             cli_db_path = Path(KIRO_CLI_DB_FILE).expanduser()
             if not cli_db_path.exists():
                 has_cli_db = False
                 logger.warning(f"KIRO_CLI_DB_FILE not found: {KIRO_CLI_DB_FILE}")
-        
+
         if not has_refresh_token and not has_creds_file and not has_cli_db:
             errors.append(
                 "No Kiro credentials configured!\n"
@@ -229,20 +229,20 @@ def validate_configuration() -> None:
                 "   Configure one of the following in your .env file:\n"
                 "\n"
                 "Set you super-secret password as PROXY_API_KEY\n"
-                "   PROXY_API_KEY=\"my-super-secret-password-123\"\n"
+                '   PROXY_API_KEY="my-super-secret-password-123"\n'
                 "\n"
                 "   Option 1 (Recommended): JSON credentials file\n"
-                "      KIRO_CREDS_FILE=\"path/to/your/kiro-credentials.json\"\n"
+                '      KIRO_CREDS_FILE="path/to/your/kiro-credentials.json"\n'
                 "\n"
                 "   Option 2: Refresh token\n"
-                "      REFRESH_TOKEN=\"your_refresh_token_here\"\n"
+                '      REFRESH_TOKEN="your_refresh_token_here"\n'
                 "\n"
                 "   Option 3: kiro-cli SQLite database (AWS SSO)\n"
-                "      KIRO_CLI_DB_FILE=\"~/.local/share/kiro-cli/data.sqlite3\"\n"
+                '      KIRO_CLI_DB_FILE="~/.local/share/kiro-cli/data.sqlite3"\n'
                 "\n"
                 "   See README.md for how to obtain credentials."
             )
-    
+
     # Print errors and exit if any
     if errors:
         logger.error("")
@@ -250,12 +250,12 @@ def validate_configuration() -> None:
         logger.error("  CONFIGURATION ERROR")
         logger.error("=" * 60)
         for error in errors:
-            for line in error.split('\n'):
+            for line in error.split("\n"):
                 logger.error(f"  {line}")
         logger.error("=" * 60)
         logger.error("")
         sys.exit(1)
-    
+
     # Note: Credential loading details are logged by KiroAuthManager
 
 
@@ -274,40 +274,38 @@ _warn_timeout_configuration()
 async def lifespan(app: FastAPI):
     """
     Manages the application lifecycle.
-    
+
     Creates and initializes:
     - Shared HTTP client with connection pooling
     - KiroAuthManager for token management
     - ModelInfoCache for model caching
-    
+
     The shared HTTP client is used by all requests to reduce memory usage
     and enable connection reuse. This is especially important for handling
     concurrent requests efficiently (fixes issue #24).
     """
     logger.info("Starting application... Creating state managers.")
-    
+
     # Create shared HTTP client with connection pooling
     # This reduces memory usage and enables connection reuse across requests
     # Limits: max 100 total connections, max 20 keep-alive connections
     limits = httpx.Limits(
         max_connections=100,
         max_keepalive_connections=20,
-        keepalive_expiry=30.0  # Close idle connections after 30 seconds
+        keepalive_expiry=30.0,  # Close idle connections after 30 seconds
     )
     # Timeout configuration for streaming (long read timeout for model "thinking")
     timeout = httpx.Timeout(
         connect=30.0,
         read=STREAMING_READ_TIMEOUT,  # 300 seconds for streaming
         write=30.0,
-        pool=30.0
+        pool=30.0,
     )
     app.state.http_client = httpx.AsyncClient(
-        limits=limits,
-        timeout=timeout,
-        follow_redirects=True
+        limits=limits, timeout=timeout, follow_redirects=True
     )
     logger.info("Shared HTTP client created with connection pooling")
-    
+
     # Create AuthManager
     # Priority: SQLite DB > JSON file > environment variables
     app.state.auth_manager = KiroAuthManager(
@@ -317,10 +315,10 @@ async def lifespan(app: FastAPI):
         creds_file=KIRO_CREDS_FILE if KIRO_CREDS_FILE else None,
         sqlite_db=KIRO_CLI_DB_FILE if KIRO_CLI_DB_FILE else None,
     )
-    
+
     # Create model cache
     app.state.model_cache = ModelInfoCache()
-    
+
     # === BLOCKING: Load models from Kiro API at startup ===
     # This ensures the cache is populated BEFORE accepting any requests.
     # No race conditions - requests only start after yield.
@@ -329,52 +327,59 @@ async def lifespan(app: FastAPI):
         token = await app.state.auth_manager.get_access_token()
         from kiro.utils import get_kiro_headers
         from kiro.auth import AuthType
+
         headers = get_kiro_headers(app.state.auth_manager, token)
-        
+
         # Build params - profileArn is only needed for Kiro Desktop auth
         params = {"origin": "AI_EDITOR"}
-        if app.state.auth_manager.auth_type == AuthType.KIRO_DESKTOP and app.state.auth_manager.profile_arn:
+        if (
+            app.state.auth_manager.auth_type == AuthType.KIRO_DESKTOP
+            and app.state.auth_manager.profile_arn
+        ):
             params["profileArn"] = app.state.auth_manager.profile_arn
-        
+
         async with httpx.AsyncClient(timeout=30) as client:
             response = await client.get(
                 f"{app.state.auth_manager.q_host}/ListAvailableModels",
                 headers=headers,
-                params=params
+                params=params,
             )
-            
+
             if response.status_code == 200:
                 data = response.json()
                 models_list = data.get("models", [])
                 await app.state.model_cache.update(models_list)
-                logger.debug(f"Loaded {len(models_list)} models from Kiro API: {[m.get('modelId') for m in models_list]}")
+                logger.debug(
+                    f"Loaded {len(models_list)} models from Kiro API: {[m.get('modelId') for m in models_list]}"
+                )
             else:
-                logger.warning(f"Failed to load models from API: HTTP {response.status_code}")
+                logger.warning(
+                    f"Failed to load models from API: HTTP {response.status_code}"
+                )
                 logger.warning("Server will start with hidden models only")
     except Exception as e:
         logger.warning(f"Failed to fetch models from Kiro API: {e}")
         logger.warning("Server will start with hidden models only (fallback mode)")
-    
+
     # Add hidden models to cache (they appear in /v1/models but not in Kiro API)
     for display_name, internal_id in HIDDEN_MODELS.items():
         app.state.model_cache.add_hidden_model(display_name, internal_id)
-    
+
     if HIDDEN_MODELS:
         logger.debug(f"Added {len(HIDDEN_MODELS)} hidden models to cache")
-    
+
     # Log final cache state
     all_models = app.state.model_cache.get_all_model_ids()
     logger.info(f"Model cache ready: {len(all_models)} models total")
-    
+
     # Create model resolver (uses cache + hidden models for resolution)
     app.state.model_resolver = ModelResolver(
-        cache=app.state.model_cache,
-        hidden_models=HIDDEN_MODELS
+        cache=app.state.model_cache, hidden_models=HIDDEN_MODELS
     )
     logger.info("Model resolver initialized")
-    
+
     yield
-    
+
     # Graceful shutdown
     logger.info("Shutting down application...")
     try:
@@ -386,10 +391,7 @@ async def lifespan(app: FastAPI):
 
 # --- FastAPI Application ---
 app = FastAPI(
-    title=APP_TITLE,
-    description=APP_DESCRIPTION,
-    version=APP_VERSION,
-    lifespan=lifespan
+    title=APP_TITLE, description=APP_DESCRIPTION, version=APP_VERSION, lifespan=lifespan
 )
 
 
@@ -437,7 +439,11 @@ UVICORN_LOG_CONFIG = {
     "loggers": {
         "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
         "uvicorn.error": {"handlers": ["default"], "level": "INFO", "propagate": False},
-        "uvicorn.access": {"handlers": ["default"], "level": "INFO", "propagate": False},
+        "uvicorn.access": {
+            "handlers": ["default"],
+            "level": "INFO",
+            "propagate": False,
+        },
     },
 }
 
@@ -445,10 +451,10 @@ UVICORN_LOG_CONFIG = {
 def parse_cli_args() -> argparse.Namespace:
     """
     Parse command-line arguments for server configuration.
-    
+
     CLI arguments have the highest priority, overriding both
     environment variables and default values.
-    
+
     Returns:
         Parsed arguments namespace with host and port values
     """
@@ -469,46 +475,46 @@ Examples:
   
   SERVER_PORT=9000 python main.py         # Via environment
   uvicorn main:app --port 9000            # Via uvicorn directly
-        """
+        """,
     )
-    
+
     parser.add_argument(
-        "-H", "--host",
+        "-H",
+        "--host",
         type=str,
         default=None,  # None means "use env or default"
         metavar="HOST",
-        help=f"Server host address (default: {DEFAULT_SERVER_HOST}, env: SERVER_HOST)"
+        help=f"Server host address (default: {DEFAULT_SERVER_HOST}, env: SERVER_HOST)",
     )
-    
+
     parser.add_argument(
-        "-p", "--port",
+        "-p",
+        "--port",
         type=int,
         default=None,  # None means "use env or default"
         metavar="PORT",
-        help=f"Server port (default: {DEFAULT_SERVER_PORT}, env: SERVER_PORT)"
+        help=f"Server port (default: {DEFAULT_SERVER_PORT}, env: SERVER_PORT)",
     )
-    
+
     parser.add_argument(
-        "-v", "--version",
-        action="version",
-        version=f"%(prog)s {APP_VERSION}"
+        "-v", "--version", action="version", version=f"%(prog)s {APP_VERSION}"
     )
-    
+
     return parser.parse_args()
 
 
 def resolve_server_config(args: argparse.Namespace) -> tuple[str, int]:
     """
     Resolve final server configuration using priority hierarchy.
-    
+
     Priority (highest to lowest):
     1. CLI arguments (--host, --port)
     2. Environment variables (SERVER_HOST, SERVER_PORT)
     3. Default values (0.0.0.0:8000)
-    
+
     Args:
         args: Parsed CLI arguments
-        
+
     Returns:
         Tuple of (host, port) with resolved values
     """
@@ -522,7 +528,7 @@ def resolve_server_config(args: argparse.Namespace) -> tuple[str, int]:
     else:
         final_host = DEFAULT_SERVER_HOST
         host_source = "default"
-    
+
     # Port resolution: CLI > ENV > Default
     if args.port is not None:
         final_port = args.port
@@ -533,18 +539,18 @@ def resolve_server_config(args: argparse.Namespace) -> tuple[str, int]:
     else:
         final_port = DEFAULT_SERVER_PORT
         port_source = "default"
-    
+
     # Log configuration sources for transparency
     logger.debug(f"Host: {final_host} (from {host_source})")
     logger.debug(f"Port: {final_port} (from {port_source})")
-    
+
     return final_host, final_port
 
 
 def print_startup_banner(host: str, port: int) -> None:
     """
     Print a startup banner with server information.
-    
+
     Args:
         host: Server host address
         port: Server port
@@ -555,11 +561,11 @@ def print_startup_banner(host: str, port: int) -> None:
     BOLD = "\033[1m"
     DIM = "\033[2m"
     RESET = "\033[0m"
-    
+
     # Determine display URL
     display_host = "localhost" if host == "0.0.0.0" else host
     url = f"http://{display_host}:{port}"
-    
+
     print()
     print(f"  {WHITE}{BOLD}👻 {APP_TITLE} v{APP_VERSION}{RESET}")
     print()
@@ -574,18 +580,18 @@ def print_startup_banner(host: str, port: int) -> None:
 # --- Entry Point ---
 if __name__ == "__main__":
     import uvicorn
-    
+
     # Parse CLI arguments
     args = parse_cli_args()
-    
+
     # Resolve final configuration with priority hierarchy
     final_host, final_port = resolve_server_config(args)
-    
+
     # Print startup banner
     print_startup_banner(final_host, final_port)
-    
+
     logger.info(f"Starting Uvicorn server on {final_host}:{final_port}...")
-    
+
     # Use string reference to avoid double module import
     uvicorn.run(
         "main:app",

--- a/manual_api_test.py
+++ b/manual_api_test.py
@@ -35,6 +35,7 @@ load_dotenv()
 
 class AuthType(Enum):
     """Type of authentication mechanism."""
+
     KIRO_DESKTOP = "kiro_desktop"
     AWS_SSO_OIDC = "aws_sso_oidc"
 
@@ -51,7 +52,9 @@ SSO_REGION = None
 AWS_SSO_OIDC_TOKEN_URL = None  # Will be set when SSO_REGION is known
 
 REFRESH_TOKEN = os.getenv("REFRESH_TOKEN")
-PROFILE_ARN = os.getenv("PROFILE_ARN", "arn:aws:codewhisperer:us-east-1:699475941385:profile/EHGA3GRVQMUK")
+PROFILE_ARN = os.getenv(
+    "PROFILE_ARN", "arn:aws:codewhisperer:us-east-1:699475941385:profile/EHGA3GRVQMUK"
+)
 KIRO_CREDS_FILE = os.getenv("KIRO_CREDS_FILE", "")
 KIRO_CLI_DB_FILE = os.getenv("KIRO_CLI_DB_FILE", "")
 
@@ -67,46 +70,48 @@ def load_credentials_from_json(file_path: str) -> bool:
     """Load credentials from JSON file."""
     global REFRESH_TOKEN, PROFILE_ARN, CLIENT_ID, CLIENT_SECRET, AUTH_TYPE
     global SSO_REGION, AWS_SSO_OIDC_TOKEN_URL
-    
+
     try:
         creds_path = Path(file_path).expanduser()
         if not creds_path.exists():
             logger.warning(f"Credentials file not found: {file_path}")
             return False
-        
-        with open(creds_path, 'r', encoding='utf-8') as f:
+
+        with open(creds_path, "r", encoding="utf-8") as f:
             creds_data = json.load(f)
-        
+
         # Load common fields
-        if 'refreshToken' in creds_data:
-            REFRESH_TOKEN = creds_data['refreshToken']
-        if 'profileArn' in creds_data:
-            PROFILE_ARN = creds_data['profileArn']
-        if 'region' in creds_data:
+        if "refreshToken" in creds_data:
+            REFRESH_TOKEN = creds_data["refreshToken"]
+        if "profileArn" in creds_data:
+            PROFILE_ARN = creds_data["profileArn"]
+        if "region" in creds_data:
             # Store as SSO region for OIDC token refresh only
             # IMPORTANT: CodeWhisperer API is only available in us-east-1,
             # so we don't update KIRO_API_HOST here
-            SSO_REGION = creds_data['region']
+            SSO_REGION = creds_data["region"]
             AWS_SSO_OIDC_TOKEN_URL = f"https://oidc.{SSO_REGION}.amazonaws.com/token"
-            logger.debug(f"SSO region from JSON: {SSO_REGION} (API stays at {API_REGION})")
-        
+            logger.debug(
+                f"SSO region from JSON: {SSO_REGION} (API stays at {API_REGION})"
+            )
+
         # Load AWS SSO OIDC specific fields
-        if 'clientId' in creds_data:
-            CLIENT_ID = creds_data['clientId']
-        if 'clientSecret' in creds_data:
-            CLIENT_SECRET = creds_data['clientSecret']
-        
+        if "clientId" in creds_data:
+            CLIENT_ID = creds_data["clientId"]
+        if "clientSecret" in creds_data:
+            CLIENT_SECRET = creds_data["clientSecret"]
+
         # Detect auth type
         if CLIENT_ID and CLIENT_SECRET:
             AUTH_TYPE = AuthType.AWS_SSO_OIDC
-            logger.info(f"Detected auth type: AWS SSO OIDC")
+            logger.info("Detected auth type: AWS SSO OIDC")
         else:
             AUTH_TYPE = AuthType.KIRO_DESKTOP
-            logger.info(f"Detected auth type: Kiro Desktop")
-        
+            logger.info("Detected auth type: Kiro Desktop")
+
         logger.info(f"Credentials loaded from {file_path}")
         return True
-        
+
     except Exception as e:
         logger.error(f"Error loading credentials from file: {e}")
         return False
@@ -116,73 +121,92 @@ def load_credentials_from_sqlite(db_path: str) -> bool:
     """Load credentials from kiro-cli SQLite database."""
     global REFRESH_TOKEN, CLIENT_ID, CLIENT_SECRET, AUTH_TYPE, SCOPES, AUTH_TOKEN
     global SSO_REGION, AWS_SSO_OIDC_TOKEN_URL
-    
+
     try:
         path = Path(db_path).expanduser()
         if not path.exists():
             logger.warning(f"SQLite database not found: {db_path}")
             return False
-        
+
         conn = sqlite3.connect(str(path))
         cursor = conn.cursor()
-        
+
         # Load token data (try both kiro-cli and codewhisperer key formats)
-        cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:token",))
+        cursor.execute(
+            "SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:token",)
+        )
         token_row = cursor.fetchone()
         if not token_row:
-            cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("codewhisperer:odic:token",))
+            cursor.execute(
+                "SELECT value FROM auth_kv WHERE key = ?", ("codewhisperer:odic:token",)
+            )
             token_row = cursor.fetchone()
-        
+
         if token_row:
             token_data = json.loads(token_row[0])
             if token_data:
                 # Check if we have a valid access token
-                if 'access_token' in token_data and 'expires_at' in token_data:
+                if "access_token" in token_data and "expires_at" in token_data:
                     from datetime import datetime
-                    expires_at = datetime.fromisoformat(token_data['expires_at'].replace('Z', '+00:00'))
+
+                    expires_at = datetime.fromisoformat(
+                        token_data["expires_at"].replace("Z", "+00:00")
+                    )
                     if expires_at > datetime.now().astimezone():
-                        AUTH_TOKEN = token_data['access_token']
-                        logger.info("Found valid access token in database (will use after HEADERS init)")
-                if 'refresh_token' in token_data:
-                    REFRESH_TOKEN = token_data['refresh_token']
-                if 'scopes' in token_data:
-                    SCOPES = token_data['scopes']
-                if 'region' in token_data:
+                        AUTH_TOKEN = token_data["access_token"]
+                        logger.info(
+                            "Found valid access token in database (will use after HEADERS init)"
+                        )
+                if "refresh_token" in token_data:
+                    REFRESH_TOKEN = token_data["refresh_token"]
+                if "scopes" in token_data:
+                    SCOPES = token_data["scopes"]
+                if "region" in token_data:
                     # Store as SSO region for OIDC token refresh only
                     # IMPORTANT: CodeWhisperer API is only available in us-east-1,
                     # so we don't update KIRO_API_HOST here
-                    SSO_REGION = token_data['region']
-                    AWS_SSO_OIDC_TOKEN_URL = f"https://oidc.{SSO_REGION}.amazonaws.com/token"
-                    logger.debug(f"SSO region from SQLite: {SSO_REGION} (API stays at {API_REGION})")
-        
+                    SSO_REGION = token_data["region"]
+                    AWS_SSO_OIDC_TOKEN_URL = (
+                        f"https://oidc.{SSO_REGION}.amazonaws.com/token"
+                    )
+                    logger.debug(
+                        f"SSO region from SQLite: {SSO_REGION} (API stays at {API_REGION})"
+                    )
+
         # Load device registration (client_id, client_secret) - try both key formats
-        cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:device-registration",))
+        cursor.execute(
+            "SELECT value FROM auth_kv WHERE key = ?",
+            ("kirocli:odic:device-registration",),
+        )
         registration_row = cursor.fetchone()
         if not registration_row:
-            cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("codewhisperer:odic:device-registration",))
+            cursor.execute(
+                "SELECT value FROM auth_kv WHERE key = ?",
+                ("codewhisperer:odic:device-registration",),
+            )
             registration_row = cursor.fetchone()
-        
+
         if registration_row:
             registration_data = json.loads(registration_row[0])
             if registration_data:
-                if 'client_id' in registration_data:
-                    CLIENT_ID = registration_data['client_id']
-                if 'client_secret' in registration_data:
-                    CLIENT_SECRET = registration_data['client_secret']
-        
+                if "client_id" in registration_data:
+                    CLIENT_ID = registration_data["client_id"]
+                if "client_secret" in registration_data:
+                    CLIENT_SECRET = registration_data["client_secret"]
+
         conn.close()
-        
+
         # Detect auth type
         if CLIENT_ID and CLIENT_SECRET:
             AUTH_TYPE = AuthType.AWS_SSO_OIDC
-            logger.info(f"Detected auth type: AWS SSO OIDC (from SQLite)")
+            logger.info("Detected auth type: AWS SSO OIDC (from SQLite)")
         else:
             AUTH_TYPE = AuthType.KIRO_DESKTOP
-            logger.info(f"Detected auth type: Kiro Desktop (from SQLite)")
-        
+            logger.info("Detected auth type: Kiro Desktop (from SQLite)")
+
         logger.info(f"Credentials loaded from SQLite: {db_path}")
         return True
-        
+
     except sqlite3.Error as e:
         logger.error(f"SQLite error: {e}")
         return False
@@ -203,7 +227,9 @@ elif KIRO_CREDS_FILE:
 
 # --- Validate required credentials ---
 if not REFRESH_TOKEN:
-    logger.error("No credentials configured. Set REFRESH_TOKEN, KIRO_CREDS_FILE, or KIRO_CLI_DB_FILE. Exiting.")
+    logger.error(
+        "No credentials configured. Set REFRESH_TOKEN, KIRO_CREDS_FILE, or KIRO_CLI_DB_FILE. Exiting."
+    )
     sys.exit(1)
 
 # Additional validation for AWS SSO OIDC
@@ -226,7 +252,7 @@ HEADERS = {
 def refresh_auth_token():
     """Refreshes AUTH_TOKEN via appropriate endpoint based on auth type."""
     global AUTH_TOKEN, HEADERS
-    
+
     if AUTH_TYPE == AuthType.AWS_SSO_OIDC:
         return refresh_auth_token_aws_sso_oidc()
     else:
@@ -237,33 +263,35 @@ def refresh_auth_token_kiro_desktop():
     """Refreshes AUTH_TOKEN via Kiro Desktop Auth endpoint."""
     global AUTH_TOKEN, HEADERS
     logger.info("Refreshing Kiro token via Kiro Desktop Auth...")
-    
+
     payload = {"refreshToken": REFRESH_TOKEN}
     headers = {
         "Content-Type": "application/json",
         "User-Agent": "KiroIDE-0.7.45-31c325a0ff0a9c8dec5d13048f4257462d751fe5b8af4cb1088f1fca45856c64",
     }
-    
+
     try:
         response = requests.post(KIRO_DESKTOP_TOKEN_URL, json=payload, headers=headers)
         response.raise_for_status()
         data = response.json()
-        
+
         new_token = data.get("accessToken")
         expires_in = data.get("expiresIn")
-        
+
         if not new_token:
             logger.error("Failed to get accessToken from response")
             return False
 
-        logger.success(f"Token refreshed via Kiro Desktop Auth. Expires in: {expires_in}s")
+        logger.success(
+            f"Token refreshed via Kiro Desktop Auth. Expires in: {expires_in}s"
+        )
         AUTH_TOKEN = new_token
-        HEADERS['Authorization'] = f"Bearer {AUTH_TOKEN}"
+        HEADERS["Authorization"] = f"Bearer {AUTH_TOKEN}"
         return True
-        
+
     except requests.exceptions.RequestException as e:
         logger.error(f"Error refreshing token via Kiro Desktop Auth: {e}")
-        if hasattr(e, 'response') and e.response:
+        if hasattr(e, "response") and e.response:
             logger.error(f"Server response: {e.response.status_code} {e.response.text}")
         return False
 
@@ -272,11 +300,13 @@ def refresh_auth_token_aws_sso_oidc():
     """Refreshes AUTH_TOKEN via AWS SSO OIDC endpoint."""
     global AUTH_TOKEN, HEADERS
     logger.info("Refreshing Kiro token via AWS SSO OIDC...")
-    
+
     # Determine SSO OIDC URL (use SSO_REGION if set, otherwise fall back to API_REGION)
     sso_region = SSO_REGION or API_REGION
-    oidc_url = AWS_SSO_OIDC_TOKEN_URL or f"https://oidc.{sso_region}.amazonaws.com/token"
-    
+    oidc_url = (
+        AWS_SSO_OIDC_TOKEN_URL or f"https://oidc.{sso_region}.amazonaws.com/token"
+    )
+
     # AWS SSO OIDC uses form-urlencoded data
     data = {
         "grant_type": "refresh_token",
@@ -284,21 +314,23 @@ def refresh_auth_token_aws_sso_oidc():
         "client_secret": CLIENT_SECRET,
         "refresh_token": REFRESH_TOKEN,
     }
-    
+
     # Note: scope parameter is NOT sent during refresh per OAuth 2.0 RFC 6749 Section 6
     # AWS SSO OIDC uses the originally granted scopes automatically
     headers = {
         "Content-Type": "application/x-www-form-urlencoded",
     }
-    
+
     # Log request details (without secrets) for debugging
-    logger.debug(f"AWS SSO OIDC refresh request: url={oidc_url}, "
-                 f"sso_region={sso_region}, api_region={API_REGION}, "
-                 f"client_id={CLIENT_ID[:8] if CLIENT_ID else 'None'}...")
-    
+    logger.debug(
+        f"AWS SSO OIDC refresh request: url={oidc_url}, "
+        f"sso_region={sso_region}, api_region={API_REGION}, "
+        f"client_id={CLIENT_ID[:8] if CLIENT_ID else 'None'}..."
+    )
+
     try:
         response = requests.post(oidc_url, data=data, headers=headers)
-        
+
         # Log response details for debugging (especially on errors)
         if response.status_code != 200:
             logger.error(f"AWS SSO OIDC refresh failed: status={response.status_code}")
@@ -308,29 +340,33 @@ def refresh_auth_token_aws_sso_oidc():
                 error_json = response.json()
                 error_code = error_json.get("error", "unknown")
                 error_desc = error_json.get("error_description", "no description")
-                logger.error(f"AWS SSO OIDC error details: error={error_code}, "
-                             f"description={error_desc}")
+                logger.error(
+                    f"AWS SSO OIDC error details: error={error_code}, "
+                    f"description={error_desc}"
+                )
             except Exception:
                 pass  # Body wasn't JSON, already logged as text
             response.raise_for_status()
-        
+
         result = response.json()
-        
+
         new_token = result.get("accessToken")
         expires_in = result.get("expiresIn", 3600)
-        
+
         if not new_token:
-            logger.error(f"Failed to get accessToken from AWS SSO OIDC response: {result}")
+            logger.error(
+                f"Failed to get accessToken from AWS SSO OIDC response: {result}"
+            )
             return False
 
         logger.success(f"Token refreshed via AWS SSO OIDC. Expires in: {expires_in}s")
         AUTH_TOKEN = new_token
-        HEADERS['Authorization'] = f"Bearer {AUTH_TOKEN}"
+        HEADERS["Authorization"] = f"Bearer {AUTH_TOKEN}"
         return True
-        
+
     except requests.exceptions.RequestException as e:
         logger.error(f"Error refreshing token via AWS SSO OIDC: {e}")
-        if hasattr(e, 'response') and e.response is not None:
+        if hasattr(e, "response") and e.response is not None:
             logger.error(f"Server response: {e.response.status_code} {e.response.text}")
         return False
 
@@ -340,12 +376,12 @@ def get_profile_arn():
     global PROFILE_ARN
     logger.info("Getting profile ARN from /ListAvailableProfiles...")
     url = f"{KIRO_API_HOST}/ListAvailableProfiles"
-    
+
     try:
         response = requests.get(url, headers=HEADERS)
         response.raise_for_status()
         data = response.json()
-        
+
         profiles = data.get("profiles", [])
         if profiles:
             # Use the first available profile
@@ -357,7 +393,7 @@ def get_profile_arn():
             return False
     except requests.exceptions.RequestException as e:
         logger.error(f"ListAvailableProfiles failed: {e}")
-        if hasattr(e, 'response') and e.response is not None:
+        if hasattr(e, "response") and e.response is not None:
             logger.error(f"Server response: {e.response.status_code} {e.response.text}")
         return False
 
@@ -366,17 +402,16 @@ def test_get_models():
     """Tests the ListAvailableModels endpoint."""
     logger.info("Testing /ListAvailableModels...")
     url = f"{KIRO_API_HOST}/ListAvailableModels"
-    params = {
-        "origin": "AI_EDITOR",
-        "profileArn": PROFILE_ARN
-    }
+    params = {"origin": "AI_EDITOR", "profileArn": PROFILE_ARN}
 
     try:
         response = requests.get(url, headers=HEADERS, params=params)
         response.raise_for_status()
 
         logger.info(f"Response status: {response.status_code}")
-        logger.debug(f"Response (JSON):\n{json.dumps(response.json(), indent=2, ensure_ascii=False)}")
+        logger.debug(
+            f"Response (JSON):\n{json.dumps(response.json(), indent=2, ensure_ascii=False)}"
+        )
         logger.success("ListAvailableModels test COMPLETED SUCCESSFULLY")
         return True
     except requests.exceptions.RequestException as e:
@@ -388,7 +423,7 @@ def test_generate_content():
     """Tests the generateAssistantResponse endpoint."""
     logger.info("Testing /generateAssistantResponse...")
     url = f"{KIRO_API_HOST}/generateAssistantResponse"
-    
+
     payload = {
         "conversationState": {
             "agentContinuationId": str(uuid.uuid4()),
@@ -400,15 +435,13 @@ def test_generate_content():
                     "content": "Hello! Say something short.",
                     "modelId": "claude-haiku-4.5",
                     "origin": "AI_EDITOR",
-                    "userInputMessageContext": {
-                        "tools": []
-                    }
+                    "userInputMessageContext": {"tools": []},
                 }
             },
-            "history": []
+            "history": [],
         }
     }
-    
+
     # Only add profileArn if it's set and not AWS SSO OIDC
     # AWS SSO OIDC (Builder ID) users don't need profileArn and it causes 403 if sent
     if PROFILE_ARN and AUTH_TYPE != AuthType.AWS_SSO_OIDC:
@@ -423,7 +456,7 @@ def test_generate_content():
             for chunk in response.iter_content(chunk_size=1024):
                 if chunk:
                     # Try to decode and find JSON
-                    chunk_str = chunk.decode('utf-8', errors='ignore')
+                    chunk_str = chunk.decode("utf-8", errors="ignore")
                     logger.debug(f"Chunk: {chunk_str[:200]}...")
 
         logger.success("generateAssistantResponse test COMPLETED")
@@ -434,7 +467,7 @@ def test_generate_content():
 
 
 if __name__ == "__main__":
-    logger.info(f"Starting Kiro API tests...")
+    logger.info("Starting Kiro API tests...")
     logger.info(f"  Credentials source: {cred_source}")
     logger.info(f"  Auth type: {AUTH_TYPE.value}")
     logger.info(f"  API Region: {API_REGION}")
@@ -443,7 +476,7 @@ if __name__ == "__main__":
 
     # Check if we already have a valid token from the database
     if AUTH_TOKEN:
-        HEADERS['Authorization'] = f"Bearer {AUTH_TOKEN}"
+        HEADERS["Authorization"] = f"Bearer {AUTH_TOKEN}"
         logger.info("Using existing valid access token from database")
         token_ok = True
     else:
@@ -453,19 +486,23 @@ if __name__ == "__main__":
         # Get profile ARN dynamically for AWS SSO OIDC users
         if AUTH_TYPE == AuthType.AWS_SSO_OIDC:
             get_profile_arn()
-        
+
         models_ok = test_get_models()
         generate_ok = test_generate_content()
 
         if models_ok and generate_ok:
-            logger.success(f"All tests passed successfully!")
+            logger.success("All tests passed successfully!")
             logger.success(f"  Auth type: {AUTH_TYPE.value}")
             logger.success(f"  Credentials: {cred_source}")
         else:
-            logger.warning(f"One or more tests failed.")
+            logger.warning("One or more tests failed.")
     else:
         logger.error("Failed to refresh token. Tests not started.")
         logger.error(f"  Auth type: {AUTH_TYPE.value}")
         sso_region = SSO_REGION or API_REGION
-        oidc_url = AWS_SSO_OIDC_TOKEN_URL or f"https://oidc.{sso_region}.amazonaws.com/token"
-        logger.error(f"  Token URL: {oidc_url if AUTH_TYPE == AuthType.AWS_SSO_OIDC else KIRO_DESKTOP_TOKEN_URL}")
+        oidc_url = (
+            AWS_SSO_OIDC_TOKEN_URL or f"https://oidc.{sso_region}.amazonaws.com/token"
+        )
+        logger.error(
+            f"  Token URL: {oidc_url if AUTH_TYPE == AuthType.AWS_SSO_OIDC else KIRO_DESKTOP_TOKEN_URL}"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,9 +10,8 @@ All tests MUST be completely isolated from the network.
 import asyncio
 import json
 import pytest
-import time
-from typing import AsyncGenerator, Dict, Any, List
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from typing import Dict, Any
+from unittest.mock import AsyncMock, Mock, patch
 from datetime import datetime, timezone
 
 import httpx
@@ -22,6 +21,7 @@ from fastapi.testclient import TestClient
 # =============================================================================
 # Event Loop Fixtures
 # =============================================================================
+
 
 @pytest.fixture(scope="session")
 def event_loop():
@@ -40,6 +40,7 @@ def event_loop():
 # Environment Fixtures
 # =============================================================================
 
+
 @pytest.fixture
 def mock_env_vars(monkeypatch):
     """
@@ -48,19 +49,22 @@ def mock_env_vars(monkeypatch):
     print("Setting up mocked environment variables...")
     monkeypatch.setenv("REFRESH_TOKEN", "test_refresh_token_abcdef")
     monkeypatch.setenv("PROXY_API_KEY", "test_proxy_key_12345")
-    monkeypatch.setenv("PROFILE_ARN", "arn:aws:codewhisperer:us-east-1:123456789:profile/test")
+    monkeypatch.setenv(
+        "PROFILE_ARN", "arn:aws:codewhisperer:us-east-1:123456789:profile/test"
+    )
     monkeypatch.setenv("KIRO_REGION", "us-east-1")
     return {
         "REFRESH_TOKEN": "test_refresh_token_abcdef",
         "PROXY_API_KEY": "test_proxy_key_12345",
         "PROFILE_ARN": "arn:aws:codewhisperer:us-east-1:123456789:profile/test",
-        "KIRO_REGION": "us-east-1"
+        "KIRO_REGION": "us-east-1",
     }
 
 
 # =============================================================================
 # Token and Authentication Fixtures
 # =============================================================================
+
 
 @pytest.fixture
 def valid_kiro_token():
@@ -73,13 +77,15 @@ def mock_kiro_token_response(valid_kiro_token):
     """
     Factory for creating mock Kiro token refresh endpoint responses.
     """
+
     def _create_response(expires_in: int = 3600, token: str = None):
         return {
             "accessToken": token or valid_kiro_token,
             "refreshToken": "new_refresh_token_xyz",
             "expiresIn": expires_in,
-            "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test"
+            "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test",
         }
+
     return _create_response
 
 
@@ -100,18 +106,20 @@ def auth_headers(valid_proxy_api_key):
     """
     Factory for creating valid and invalid Authorization headers.
     """
+
     def _create_headers(api_key: str = None, invalid: bool = False):
         if invalid:
             return {"Authorization": "Bearer wrong_key_123"}
         key = api_key or valid_proxy_api_key
         return {"Authorization": f"Bearer {key}"}
-    
+
     return _create_headers
 
 
 # =============================================================================
 # Kiro Models Fixtures
 # =============================================================================
+
 
 @pytest.fixture
 def mock_kiro_models_response():
@@ -123,27 +131,18 @@ def mock_kiro_models_response():
             {
                 "modelId": "claude-sonnet-4.5",
                 "displayName": "Claude Sonnet 4.5",
-                "tokenLimits": {
-                    "maxInputTokens": 200000,
-                    "maxOutputTokens": 8192
-                }
+                "tokenLimits": {"maxInputTokens": 200000, "maxOutputTokens": 8192},
             },
             {
                 "modelId": "claude-opus-4.5",
                 "displayName": "Claude Opus 4.5",
-                "tokenLimits": {
-                    "maxInputTokens": 200000,
-                    "maxOutputTokens": 8192
-                }
+                "tokenLimits": {"maxInputTokens": 200000, "maxOutputTokens": 8192},
             },
             {
                 "modelId": "claude-haiku-4.5",
                 "displayName": "Claude Haiku 4.5",
-                "tokenLimits": {
-                    "maxInputTokens": 200000,
-                    "maxOutputTokens": 8192
-                }
-            }
+                "tokenLimits": {"maxInputTokens": 200000, "maxOutputTokens": 8192},
+            },
         ]
     }
 
@@ -151,6 +150,7 @@ def mock_kiro_models_response():
 # =============================================================================
 # Kiro Streaming Response Fixtures
 # =============================================================================
+
 
 @pytest.fixture
 def mock_kiro_streaming_chunks():
@@ -174,6 +174,7 @@ def mock_kiro_streaming_chunks():
         # Chunk 7: Context usage
         b'{"contextUsagePercentage":25.5}',
     ]
+
 
 @pytest.fixture
 def mock_kiro_simple_text_chunks():
@@ -203,11 +204,13 @@ def mock_kiro_stream_with_usage():
 # OpenAI Request Fixtures
 # =============================================================================
 
+
 @pytest.fixture
 def sample_openai_chat_request():
     """
     Factory for creating valid OpenAI chat completion requests.
     """
+
     def _create_request(
         model: str = "claude-sonnet-4-5",
         messages: list = None,
@@ -215,27 +218,23 @@ def sample_openai_chat_request():
         temperature: float = None,
         max_tokens: int = None,
         tools: list = None,
-        **kwargs
+        **kwargs,
     ):
         if messages is None:
             messages = [{"role": "user", "content": "Hello, AI!"}]
-        
-        request = {
-            "model": model,
-            "messages": messages,
-            "stream": stream
-        }
-        
+
+        request = {"model": model, "messages": messages, "stream": stream}
+
         if temperature is not None:
             request["temperature"] = temperature
         if max_tokens is not None:
             request["max_tokens"] = max_tokens
         if tools is not None:
             request["tools"] = tools
-        
+
         request.update(kwargs)
         return request
-    
+
     return _create_request
 
 
@@ -254,15 +253,16 @@ def sample_tool_definition():
                 "properties": {
                     "location": {"type": "string", "description": "City name"}
                 },
-                "required": ["location"]
-            }
-        }
+                "required": ["location"],
+            },
+        },
     }
 
 
 # =============================================================================
 # HTTP Client Fixtures
 # =============================================================================
+
 
 @pytest.fixture
 async def mock_httpx_client():
@@ -271,7 +271,7 @@ async def mock_httpx_client():
     """
     print("Creating mocked httpx.AsyncClient...")
     mock_client = AsyncMock(spec=httpx.AsyncClient)
-    
+
     # Mock methods
     mock_client.post = AsyncMock()
     mock_client.get = AsyncMock()
@@ -279,7 +279,7 @@ async def mock_httpx_client():
     mock_client.build_request = Mock()
     mock_client.send = AsyncMock()
     mock_client.is_closed = False
-    
+
     return mock_client
 
 
@@ -288,37 +288,38 @@ def mock_httpx_response():
     """
     Factory for creating mocked httpx.Response objects.
     """
+
     def _create_response(
         status_code: int = 200,
         json_data: Dict[str, Any] = None,
         text: str = None,
-        stream_chunks: list = None
+        stream_chunks: list = None,
     ):
         print(f"Creating mock httpx.Response (status={status_code})...")
         mock_response = AsyncMock(spec=httpx.Response)
         mock_response.status_code = status_code
-        
+
         if json_data is not None:
             mock_response.json = Mock(return_value=json_data)
-        
+
         if text is not None:
             mock_response.text = text
             mock_response.content = text.encode()
-        
+
         if stream_chunks is not None:
             # For streaming responses
             async def mock_aiter_bytes():
                 for chunk in stream_chunks:
                     yield chunk
-            
+
             mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         mock_response.raise_for_status = Mock()
         mock_response.aclose = AsyncMock()
         mock_response.aread = AsyncMock(return_value=b'{"error": "mocked error"}')
-        
+
         return mock_response
-    
+
     return _create_response
 
 
@@ -326,13 +327,14 @@ def mock_httpx_response():
 # Global Network Blocking
 # =============================================================================
 
+
 @pytest.fixture(scope="session", autouse=True)
 def block_all_network_calls():
     """
     CRITICAL FIXTURE: Globally blocks ALL network calls.
     Ensures that NO test can make a real network request.
     """
-    
+
     # Create a mock that will be used for all AsyncClient instances
     mock_async_client = AsyncMock(spec=httpx.AsyncClient)
 
@@ -346,7 +348,7 @@ def block_all_network_calls():
     mock_async_client.post.side_effect = network_call_error
     mock_async_client.get.side_effect = network_call_error
     mock_async_client.send.side_effect = network_call_error
-    
+
     # Mock context manager
     mock_async_client.__aenter__ = AsyncMock(return_value=mock_async_client)
     mock_async_client.__aexit__ = AsyncMock()
@@ -355,29 +357,32 @@ def block_all_network_calls():
 
     # Patch AsyncClient in modules where it's used
     patchers = [
-        patch('kiro.auth.httpx.AsyncClient', return_value=mock_async_client),
-        patch('kiro.http_client.httpx.AsyncClient', return_value=mock_async_client),
-        patch('kiro.streaming_openai.httpx.AsyncClient', return_value=mock_async_client),
+        patch("kiro.auth.httpx.AsyncClient", return_value=mock_async_client),
+        patch("kiro.http_client.httpx.AsyncClient", return_value=mock_async_client),
+        patch(
+            "kiro.streaming_openai.httpx.AsyncClient", return_value=mock_async_client
+        ),
     ]
-    
+
     # Start patchers
     for patcher in patchers:
         patcher.start()
-    
+
     print("🛡️ GLOBAL NETWORK BLOCKING ACTIVATED")
-    
+
     yield
 
     # Stop patchers
     for patcher in patchers:
         patcher.stop()
-    
+
     print("🛡️ GLOBAL NETWORK BLOCKING DEACTIVATED")
 
 
 # =============================================================================
 # Application Fixtures
 # =============================================================================
+
 
 @pytest.fixture
 def clean_app():
@@ -386,6 +391,7 @@ def clean_app():
     """
     print("Importing application for test...")
     from main import app
+
     # Reset all dependency overrides before test
     app.dependency_overrides = {}
     return app
@@ -410,11 +416,11 @@ async def async_test_client(clean_app):
     """
     print("Creating async test client...")
     from httpx import AsyncClient, ASGITransport
-    
+
     transport = ASGITransport(app=clean_app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         yield client
-    
+
     print("Closing async test client...")
 
 
@@ -422,25 +428,26 @@ async def async_test_client(clean_app):
 # KiroAuthManager Fixtures
 # =============================================================================
 
+
 @pytest.fixture
 def mock_auth_manager():
     """
     Creates a mocked KiroAuthManager for tests.
     """
     from kiro.auth import KiroAuthManager
-    
+
     manager = KiroAuthManager(
         refresh_token="test_refresh_token",
         profile_arn="arn:aws:codewhisperer:us-east-1:123456789:profile/test",
-        region="us-east-1"
+        region="us-east-1",
     )
-    
+
     # Set valid token
     manager._access_token = "test_access_token"
     manager._expires_at = datetime.now(timezone.utc).replace(
         year=2099  # Far in the future
     )
-    
+
     return manager
 
 
@@ -450,25 +457,26 @@ def expired_auth_manager():
     Creates a KiroAuthManager with an expired token.
     """
     from kiro.auth import KiroAuthManager
-    
+
     manager = KiroAuthManager(
         refresh_token="test_refresh_token",
         profile_arn="arn:aws:codewhisperer:us-east-1:123456789:profile/test",
-        region="us-east-1"
+        region="us-east-1",
     )
-    
+
     # Set expired token
     manager._access_token = "expired_token"
     manager._expires_at = datetime.now(timezone.utc).replace(
         year=2020  # In the past
     )
-    
+
     return manager
 
 
 # =============================================================================
 # ModelInfoCache Fixtures
 # =============================================================================
+
 
 @pytest.fixture
 def sample_models_data():
@@ -479,27 +487,18 @@ def sample_models_data():
         {
             "modelId": "claude-sonnet-4",
             "displayName": "Claude Sonnet 4",
-            "tokenLimits": {
-                "maxInputTokens": 200000,
-                "maxOutputTokens": 8192
-            }
+            "tokenLimits": {"maxInputTokens": 200000, "maxOutputTokens": 8192},
         },
         {
             "modelId": "claude-opus-4.5",
             "displayName": "Claude Opus 4.5",
-            "tokenLimits": {
-                "maxInputTokens": 200000,
-                "maxOutputTokens": 8192
-            }
+            "tokenLimits": {"maxInputTokens": 200000, "maxOutputTokens": 8192},
         },
         {
             "modelId": "claude-haiku-4.5",
             "displayName": "Claude Haiku 4.5",
-            "tokenLimits": {
-                "maxInputTokens": 100000,
-                "maxOutputTokens": 4096
-            }
-        }
+            "tokenLimits": {"maxInputTokens": 100000, "maxOutputTokens": 4096},
+        },
     ]
 
 
@@ -509,6 +508,7 @@ def empty_model_cache():
     Creates an empty ModelInfoCache.
     """
     from kiro.cache import ModelInfoCache
+
     return ModelInfoCache()
 
 
@@ -518,7 +518,7 @@ async def populated_model_cache(mock_kiro_models_response):
     Creates a ModelInfoCache with pre-populated data.
     """
     from kiro.cache import ModelInfoCache
-    
+
     cache = ModelInfoCache()
     await cache.update(mock_kiro_models_response["models"])
     return cache
@@ -528,12 +528,13 @@ async def populated_model_cache(mock_kiro_models_response):
 # Time Fixtures
 # =============================================================================
 
+
 @pytest.fixture
 def mock_time():
     """
     Mocks time.time() for predictable behavior in tests.
     """
-    with patch('time.time') as mock:
+    with patch("time.time") as mock:
         # Fixed point in time: 2024-01-01 12:00:00
         mock.return_value = 1704110400.0
         yield mock
@@ -545,8 +546,8 @@ def mock_datetime():
     Mocks datetime.now() for predictable behavior.
     """
     fixed_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-    
-    with patch('kiro.auth.datetime') as mock_dt:
+
+    with patch("kiro.auth.datetime") as mock_dt:
         mock_dt.now.return_value = fixed_time
         mock_dt.fromisoformat = datetime.fromisoformat
         mock_dt.fromtimestamp = datetime.fromtimestamp
@@ -556,6 +557,7 @@ def mock_datetime():
 # =============================================================================
 # Temporary File Fixtures
 # =============================================================================
+
 
 @pytest.fixture
 def temp_creds_file(tmp_path):
@@ -568,7 +570,7 @@ def temp_creds_file(tmp_path):
         "refreshToken": "file_refresh_token",
         "expiresAt": "2099-01-01T00:00:00.000Z",
         "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test",
-        "region": "us-east-1"
+        "region": "us-east-1",
     }
     creds_file.write_text(json.dumps(creds_data))
     return str(creds_file)
@@ -587,7 +589,7 @@ def temp_aws_sso_creds_file(tmp_path):
         "expiresAt": "2099-01-01T00:00:00.000Z",
         "region": "us-east-1",
         "clientId": "test_client_id_12345",
-        "clientSecret": "test_client_secret_67890"
+        "clientSecret": "test_client_secret_67890",
     }
     creds_file.write_text(json.dumps(creds_data))
     return str(creds_file)
@@ -597,17 +599,17 @@ def temp_aws_sso_creds_file(tmp_path):
 def temp_sqlite_db(tmp_path):
     """
     Creates a temporary SQLite database for tests (kiro-cli format).
-    
+
     Contains auth_kv table with keys:
     - 'codewhisperer:odic:token': JSON with access_token, refresh_token, expires_at, region
     - 'codewhisperer:odic:device-registration': JSON with client_id, client_secret
     """
     import sqlite3
-    
+
     db_file = tmp_path / "data.sqlite3"
     conn = sqlite3.connect(str(db_file))
     cursor = conn.cursor()
-    
+
     # Create auth_kv table
     cursor.execute("""
         CREATE TABLE auth_kv (
@@ -615,33 +617,33 @@ def temp_sqlite_db(tmp_path):
             value TEXT
         )
     """)
-    
+
     # Insert token data
     token_data = {
         "access_token": "sqlite_access_token",
         "refresh_token": "sqlite_refresh_token",
         "expires_at": "2099-01-01T00:00:00Z",
-        "region": "eu-west-1"
+        "region": "eu-west-1",
     }
     cursor.execute(
         "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("codewhisperer:odic:token", json.dumps(token_data))
+        ("codewhisperer:odic:token", json.dumps(token_data)),
     )
-    
+
     # Insert device registration data
     registration_data = {
         "client_id": "sqlite_client_id",
         "client_secret": "sqlite_client_secret",
-        "region": "eu-west-1"
+        "region": "eu-west-1",
     }
     cursor.execute(
         "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("codewhisperer:odic:device-registration", json.dumps(registration_data))
+        ("codewhisperer:odic:device-registration", json.dumps(registration_data)),
     )
-    
+
     conn.commit()
     conn.close()
-    
+
     return str(db_file)
 
 
@@ -652,31 +654,31 @@ def temp_sqlite_db_token_only(tmp_path):
     Used for testing partial loading.
     """
     import sqlite3
-    
+
     db_file = tmp_path / "data_token_only.sqlite3"
     conn = sqlite3.connect(str(db_file))
     cursor = conn.cursor()
-    
+
     cursor.execute("""
         CREATE TABLE auth_kv (
             key TEXT PRIMARY KEY,
             value TEXT
         )
     """)
-    
+
     token_data = {
         "access_token": "partial_access_token",
         "refresh_token": "partial_refresh_token",
-        "region": "ap-southeast-1"
+        "region": "ap-southeast-1",
     }
     cursor.execute(
         "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("codewhisperer:odic:token", json.dumps(token_data))
+        ("codewhisperer:odic:token", json.dumps(token_data)),
     )
-    
+
     conn.commit()
     conn.close()
-    
+
     return str(db_file)
 
 
@@ -687,27 +689,27 @@ def temp_sqlite_db_invalid_json(tmp_path):
     Used for testing error handling.
     """
     import sqlite3
-    
+
     db_file = tmp_path / "data_invalid.sqlite3"
     conn = sqlite3.connect(str(db_file))
     cursor = conn.cursor()
-    
+
     cursor.execute("""
         CREATE TABLE auth_kv (
             key TEXT PRIMARY KEY,
             value TEXT
         )
     """)
-    
+
     # Insert invalid JSON
     cursor.execute(
         "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("codewhisperer:odic:token", "not a valid json {{{")
+        ("codewhisperer:odic:token", "not a valid json {{{"),
     )
-    
+
     conn.commit()
     conn.close()
-    
+
     return str(db_file)
 
 
@@ -716,17 +718,19 @@ def mock_aws_sso_oidc_token_response():
     """
     Factory for creating mock AWS SSO OIDC token endpoint responses.
     """
+
     def _create_response(
         access_token: str = "new_aws_sso_access_token",
         refresh_token: str = "new_aws_sso_refresh_token",
-        expires_in: int = 3600
+        expires_in: int = 3600,
     ):
         return {
             "accessToken": access_token,
             "refreshToken": refresh_token,
             "expiresIn": expires_in,
-            "tokenType": "Bearer"
+            "tokenType": "Bearer",
         }
+
     return _create_response
 
 
@@ -744,18 +748,21 @@ def temp_debug_dir(tmp_path):
 # Parser Fixtures
 # =============================================================================
 
+
 @pytest.fixture
 def aws_event_parser():
     """
     Creates an AwsEventStreamParser instance for tests.
     """
     from kiro.parsers import AwsEventStreamParser
+
     return AwsEventStreamParser()
 
 
 # =============================================================================
 # Test Utilities
 # =============================================================================
+
 
 def create_kiro_content_chunk(content: str) -> bytes:
     """Utility for creating a Kiro SSE chunk with content."""

--- a/tests/integration/test_full_flow.py
+++ b/tests/integration/test_full_flow.py
@@ -5,20 +5,12 @@ Integration tests for complete end-to-end flow.
 Checks interaction of all system components.
 """
 
-import pytest
-import json
-from unittest.mock import AsyncMock, Mock, patch, MagicMock
-from datetime import datetime, timezone, timedelta
-
-from fastapi.testclient import TestClient
-import httpx
-
-from kiro.config import PROXY_API_KEY
+from unittest.mock import AsyncMock, patch
 
 
 class TestFullChatCompletionFlow:
     """Integration tests for complete chat completions flow."""
-    
+
     def test_full_flow_health_to_models_to_chat(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks complete flow from health check to chat completions.
@@ -29,16 +21,15 @@ class TestFullChatCompletionFlow:
         assert health_response.status_code == 200
         assert health_response.json()["status"] == "healthy"
         print(f"Health: {health_response.json()}")
-        
+
         print("Step 2: Getting models list...")
         models_response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
+            "/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
         )
         assert models_response.status_code == 200
         assert len(models_response.json()["data"]) > 0
         print(f"Models: {[m['id'] for m in models_response.json()['data']]}")
-        
+
         print("Step 3: Validating chat completions request...")
         # This request will pass validation but fail on HTTP due to network blocking
         chat_response = test_client.post(
@@ -46,14 +37,16 @@ class TestFullChatCompletionFlow:
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
             json={
                 "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
         # Request should pass validation (not 422)
         assert chat_response.status_code != 422
         print(f"Chat response status: {chat_response.status_code}")
-    
-    def test_authentication_flow(self, test_client, valid_proxy_api_key, invalid_proxy_api_key):
+
+    def test_authentication_flow(
+        self, test_client, valid_proxy_api_key, invalid_proxy_api_key
+    ):
         """
         What it does: Checks authentication flow.
         Goal: Ensure protected endpoints require authorization.
@@ -62,23 +55,21 @@ class TestFullChatCompletionFlow:
         no_auth_response = test_client.get("/v1/models")
         assert no_auth_response.status_code == 401
         print(f"Without authorization: {no_auth_response.status_code}")
-        
+
         print("Step 2: Request with invalid key...")
         wrong_auth_response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {invalid_proxy_api_key}"}
+            "/v1/models", headers={"Authorization": f"Bearer {invalid_proxy_api_key}"}
         )
         assert wrong_auth_response.status_code == 401
         print(f"Invalid key: {wrong_auth_response.status_code}")
-        
+
         print("Step 3: Request with valid key...")
         valid_auth_response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
+            "/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
         )
         assert valid_auth_response.status_code == 200
         print(f"Valid key: {valid_auth_response.status_code}")
-    
+
     def test_openai_compatibility_format(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks response format compatibility with OpenAI API.
@@ -86,19 +77,18 @@ class TestFullChatCompletionFlow:
         """
         print("Checking /v1/models format...")
         models_response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
+            "/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
         )
-        
+
         assert models_response.status_code == 200
         data = models_response.json()
-        
+
         # Check OpenAI response structure
         assert "object" in data
         assert data["object"] == "list"
         assert "data" in data
         assert isinstance(data["data"], list)
-        
+
         # Check structure of each model
         for model in data["data"]:
             assert "id" in model
@@ -106,14 +96,16 @@ class TestFullChatCompletionFlow:
             assert model["object"] == "model"
             assert "owned_by" in model
             assert "created" in model
-        
+
         print(f"Format conforms to OpenAI API: {len(data['data'])} models")
 
 
 class TestRequestValidationFlow:
     """Integration tests for request validation."""
-    
-    def test_chat_completions_request_validation(self, test_client, valid_proxy_api_key):
+
+    def test_chat_completions_request_validation(
+        self, test_client, valid_proxy_api_key
+    ):
         """
         What it does: Checks validation of various request formats.
         Goal: Ensure validation works correctly.
@@ -122,42 +114,42 @@ class TestRequestValidationFlow:
         empty_messages = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={"model": "claude-sonnet-4-5", "messages": []}
+            json={"model": "claude-sonnet-4-5", "messages": []},
         )
         assert empty_messages.status_code == 422
         print(f"Empty messages: {empty_messages.status_code}")
-        
+
         print("Test 2: Missing model...")
         no_model = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={"messages": [{"role": "user", "content": "Hello"}]}
+            json={"messages": [{"role": "user", "content": "Hello"}]},
         )
         assert no_model.status_code == 422
         print(f"Without model: {no_model.status_code}")
-        
+
         print("Test 3: Missing messages...")
         no_messages = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={"model": "claude-sonnet-4-5"}
+            json={"model": "claude-sonnet-4-5"},
         )
         assert no_messages.status_code == 422
         print(f"Without messages: {no_messages.status_code}")
-        
+
         print("Test 4: Valid request...")
         valid_request = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
             json={
                 "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
         # Validation should pass (not 422)
         assert valid_request.status_code != 422
         print(f"Valid request: {valid_request.status_code}")
-    
+
     def test_complex_message_formats(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks handling of complex message formats.
@@ -171,13 +163,13 @@ class TestRequestValidationFlow:
                 "model": "claude-sonnet-4-5",
                 "messages": [
                     {"role": "system", "content": "You are helpful"},
-                    {"role": "user", "content": "Hello"}
-                ]
-            }
+                    {"role": "user", "content": "Hello"},
+                ],
+            },
         )
         assert system_user.status_code != 422
         print(f"System + User: {system_user.status_code}")
-        
+
         print("Test 2: Multi-turn conversation...")
         multi_turn = test_client.post(
             "/v1/chat/completions",
@@ -187,13 +179,13 @@ class TestRequestValidationFlow:
                 "messages": [
                     {"role": "user", "content": "Hello"},
                     {"role": "assistant", "content": "Hi there!"},
-                    {"role": "user", "content": "How are you?"}
-                ]
-            }
+                    {"role": "user", "content": "How are you?"},
+                ],
+            },
         )
         assert multi_turn.status_code != 422
         print(f"Multi-turn: {multi_turn.status_code}")
-        
+
         print("Test 3: With tools...")
         with_tools = test_client.post(
             "/v1/chat/completions",
@@ -201,15 +193,17 @@ class TestRequestValidationFlow:
             json={
                 "model": "claude-sonnet-4-5",
                 "messages": [{"role": "user", "content": "What's the weather?"}],
-                "tools": [{
-                    "type": "function",
-                    "function": {
-                        "name": "get_weather",
-                        "description": "Get weather",
-                        "parameters": {"type": "object", "properties": {}}
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "description": "Get weather",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
                     }
-                }]
-            }
+                ],
+            },
         )
         assert with_tools.status_code != 422
         print(f"With tools: {with_tools.status_code}")
@@ -217,7 +211,7 @@ class TestRequestValidationFlow:
 
 class TestErrorHandlingFlow:
     """Integration tests for error handling."""
-    
+
     def test_invalid_json_handling(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks handling of invalid JSON.
@@ -228,14 +222,14 @@ class TestErrorHandlingFlow:
             "/v1/chat/completions",
             headers={
                 "Authorization": f"Bearer {valid_proxy_api_key}",
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
             },
-            content=b"not valid json"
+            content=b"not valid json",
         )
-        
+
         assert response.status_code == 422
         print(f"Invalid JSON: {response.status_code}")
-    
+
     def test_wrong_content_type_handling(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks handling of wrong Content-Type.
@@ -246,11 +240,11 @@ class TestErrorHandlingFlow:
             "/v1/chat/completions",
             headers={
                 "Authorization": f"Bearer {valid_proxy_api_key}",
-                "Content-Type": "text/plain"
+                "Content-Type": "text/plain",
             },
-            content=b"Hello"
+            content=b"Hello",
         )
-        
+
         # Should be validation error
         assert response.status_code == 422
         print(f"Wrong Content-Type: {response.status_code}")
@@ -258,27 +252,28 @@ class TestErrorHandlingFlow:
 
 class TestModelsEndpointIntegration:
     """Integration tests for /v1/models endpoint."""
-    
-    def test_models_returns_all_available_models(self, test_client, valid_proxy_api_key):
+
+    def test_models_returns_all_available_models(
+        self, test_client, valid_proxy_api_key
+    ):
         """
         What it does: Checks that all models from config are returned.
         Goal: Ensure completeness of models list.
         """
         print("Getting models list...")
         response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
+            "/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
         )
-        
+
         assert response.status_code == 200
-        
+
         returned_ids = {m["id"] for m in response.json()["data"]}
-        
+
         print(f"Returned models: {returned_ids}")
-        
+
         # At minimum, hidden models should be available
         assert len(returned_ids) >= 1, "Expected at least one model (hidden models)"
-    
+
     def test_models_caching_behavior(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks models caching behavior.
@@ -286,18 +281,16 @@ class TestModelsEndpointIntegration:
         """
         print("First models request...")
         response1 = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
+            "/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
         )
         assert response1.status_code == 200
-        
+
         print("Second models request...")
         response2 = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
+            "/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
         )
         assert response2.status_code == 200
-        
+
         # Responses should be identical
         assert response1.json()["data"] == response2.json()["data"]
         print("Caching works correctly")
@@ -305,50 +298,52 @@ class TestModelsEndpointIntegration:
 
 class TestStreamingFlagHandling:
     """Integration tests for stream flag handling."""
-    
+
     def test_stream_true_accepted(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks that stream=true is accepted.
         Goal: Ensure streaming mode is available.
-        
+
         Note: Streaming mode requires HTTP client mock,
         as request is executed inside generator.
         """
         print("Request with stream=true...")
-        
+
         # Create mock response for streaming
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         async def mock_aiter_bytes():
             yield b'{"content":"Hello"}'
             yield b'{"usage":0.5}'
-        
+
         mock_response.aiter_bytes = mock_aiter_bytes
         mock_response.aclose = AsyncMock()
-        
+
         # Mock request_with_retry to return our mock response
-        with patch('kiro.routes_openai.KiroHttpClient') as MockHttpClient:
+        with patch("kiro.routes_openai.KiroHttpClient") as MockHttpClient:
             mock_client_instance = AsyncMock()
-            mock_client_instance.request_with_retry = AsyncMock(return_value=mock_response)
+            mock_client_instance.request_with_retry = AsyncMock(
+                return_value=mock_response
+            )
             mock_client_instance.client = AsyncMock()
             mock_client_instance.close = AsyncMock()
             MockHttpClient.return_value = mock_client_instance
-            
+
             response = test_client.post(
                 "/v1/chat/completions",
                 headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
                 json={
                     "model": "claude-sonnet-4-5",
                     "messages": [{"role": "user", "content": "Hello"}],
-                    "stream": True
-                }
+                    "stream": True,
+                },
             )
-        
+
         # Validation should pass and streaming should work
         assert response.status_code == 200
         print(f"stream=true: {response.status_code}")
-    
+
     def test_stream_false_accepted(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks that stream=false is accepted.
@@ -361,10 +356,10 @@ class TestStreamingFlagHandling:
             json={
                 "model": "claude-sonnet-4-5",
                 "messages": [{"role": "user", "content": "Hello"}],
-                "stream": False
-            }
+                "stream": False,
+            },
         )
-        
+
         # Validation should pass
         assert response.status_code != 422
         print(f"stream=false: {response.status_code}")
@@ -372,7 +367,7 @@ class TestStreamingFlagHandling:
 
 class TestHealthEndpointIntegration:
     """Integration tests for health endpoints."""
-    
+
     def test_root_and_health_consistency(self, test_client):
         """
         What it does: Checks consistency of / and /health.
@@ -380,18 +375,18 @@ class TestHealthEndpointIntegration:
         """
         print("Request to /...")
         root_response = test_client.get("/")
-        
+
         print("Request to /health...")
         health_response = test_client.get("/health")
-        
+
         assert root_response.status_code == 200
         assert health_response.status_code == 200
-        
+
         # Both should show "ok" status
         assert root_response.json()["status"] == "ok"
         assert health_response.json()["status"] == "healthy"
-        
+
         # Versions should match
         assert root_response.json()["version"] == health_response.json()["version"]
-        
+
         print("Health endpoints are consistent")

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -12,12 +12,12 @@ from unittest.mock import AsyncMock, Mock, patch
 import httpx
 
 from kiro.auth import KiroAuthManager, AuthType
-from kiro.config import TOKEN_REFRESH_THRESHOLD, get_aws_sso_oidc_url
+from kiro.config import TOKEN_REFRESH_THRESHOLD
 
 
 class TestKiroAuthManagerInitialization:
     """Tests for KiroAuthManager initialization."""
-    
+
     def test_initialization_stores_credentials(self):
         """
         What it does: Verifies correct storage of credentials during initialization.
@@ -27,44 +27,52 @@ class TestKiroAuthManagerInitialization:
         manager = KiroAuthManager(
             refresh_token="test_refresh_123",
             profile_arn="arn:aws:codewhisperer:us-east-1:123456789:profile/test",
-            region="us-east-1"
+            region="us-east-1",
         )
-        
+
         print("Verification: All credentials stored correctly...")
-        print(f"Comparing refresh_token: Expected 'test_refresh_123', Got '{manager._refresh_token}'")
+        print(
+            f"Comparing refresh_token: Expected 'test_refresh_123', Got '{manager._refresh_token}'"
+        )
         assert manager._refresh_token == "test_refresh_123"
-        
-        print(f"Comparing profile_arn: Expected 'arn:aws:...', Got '{manager._profile_arn}'")
-        assert manager._profile_arn == "arn:aws:codewhisperer:us-east-1:123456789:profile/test"
-        
+
+        print(
+            f"Comparing profile_arn: Expected 'arn:aws:...', Got '{manager._profile_arn}'"
+        )
+        assert (
+            manager._profile_arn
+            == "arn:aws:codewhisperer:us-east-1:123456789:profile/test"
+        )
+
         print(f"Comparing region: Expected 'us-east-1', Got '{manager._region}'")
         assert manager._region == "us-east-1"
-        
+
         print("Verification: Token is initially empty...")
         assert manager._access_token is None
         assert manager._expires_at is None
-    
+
     def test_initialization_sets_correct_urls_for_region(self):
         """
         What it does: Verifies URL formation based on region.
         Purpose: Ensure URLs are dynamically formed with the correct region.
         """
         print("Setup: Creating KiroAuthManager with region eu-west-1...")
-        manager = KiroAuthManager(
-            refresh_token="test_token",
-            region="eu-west-1"
-        )
-        
+        manager = KiroAuthManager(refresh_token="test_token", region="eu-west-1")
+
         print("Verification: URLs contain correct region...")
-        print(f"Comparing refresh_url: Expected 'eu-west-1' in URL, Got '{manager._refresh_url}'")
+        print(
+            f"Comparing refresh_url: Expected 'eu-west-1' in URL, Got '{manager._refresh_url}'"
+        )
         assert "eu-west-1" in manager._refresh_url
-        
-        print(f"Comparing api_host: Expected 'eu-west-1' in URL, Got '{manager._api_host}'")
+
+        print(
+            f"Comparing api_host: Expected 'eu-west-1' in URL, Got '{manager._api_host}'"
+        )
         assert "eu-west-1" in manager._api_host
-        
+
         print(f"Comparing q_host: Expected 'eu-west-1' in URL, Got '{manager._q_host}'")
         assert "eu-west-1" in manager._q_host
-    
+
     def test_initialization_generates_fingerprint(self):
         """
         What it does: Verifies unique fingerprint generation.
@@ -72,7 +80,7 @@ class TestKiroAuthManagerInitialization:
         """
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(refresh_token="test_token")
-        
+
         print("Verification: Fingerprint generated...")
         print(f"Fingerprint: {manager._fingerprint}")
         assert manager._fingerprint is not None
@@ -81,29 +89,35 @@ class TestKiroAuthManagerInitialization:
 
 class TestKiroAuthManagerCredentialsFile:
     """Tests for loading credentials from file."""
-    
+
     def test_load_credentials_from_file(self, temp_creds_file):
         """
         What it does: Verifies loading credentials from JSON file.
         Purpose: Ensure data is correctly read from file.
         """
-        print(f"Setup: Creating KiroAuthManager with credentials file: {temp_creds_file}")
+        print(
+            f"Setup: Creating KiroAuthManager with credentials file: {temp_creds_file}"
+        )
         manager = KiroAuthManager(creds_file=temp_creds_file)
-        
+
         print("Verification: Data loaded from file...")
-        print(f"Comparing access_token: Expected 'file_access_token', Got '{manager._access_token}'")
+        print(
+            f"Comparing access_token: Expected 'file_access_token', Got '{manager._access_token}'"
+        )
         assert manager._access_token == "file_access_token"
-        
-        print(f"Comparing refresh_token: Expected 'file_refresh_token', Got '{manager._refresh_token}'")
+
+        print(
+            f"Comparing refresh_token: Expected 'file_refresh_token', Got '{manager._refresh_token}'"
+        )
         assert manager._refresh_token == "file_refresh_token"
-        
+
         print(f"Comparing region: Expected 'us-east-1', Got '{manager._region}'")
         assert manager._region == "us-east-1"
-        
+
         print("Verification: expiresAt parsed correctly...")
         assert manager._expires_at is not None
         assert manager._expires_at.year == 2099
-    
+
     def test_load_credentials_file_not_found(self, tmp_path):
         """
         What it does: Verifies handling of missing credentials file.
@@ -111,20 +125,21 @@ class TestKiroAuthManagerCredentialsFile:
         """
         print("Setup: Creating KiroAuthManager with non-existent file...")
         non_existent_file = str(tmp_path / "non_existent.json")
-        
+
         manager = KiroAuthManager(
-            refresh_token="fallback_token",
-            creds_file=non_existent_file
+            refresh_token="fallback_token", creds_file=non_existent_file
         )
-        
+
         print("Verification: Fallback refresh_token is used...")
-        print(f"Comparing refresh_token: Expected 'fallback_token', Got '{manager._refresh_token}'")
+        print(
+            f"Comparing refresh_token: Expected 'fallback_token', Got '{manager._refresh_token}'"
+        )
         assert manager._refresh_token == "fallback_token"
 
 
 class TestKiroAuthManagerTokenExpiration:
     """Tests for token expiration checking."""
-    
+
     def test_is_token_expiring_soon_returns_true_when_no_expires_at(self):
         """
         What it does: Verifies that without expires_at token is considered expiring.
@@ -133,12 +148,12 @@ class TestKiroAuthManagerTokenExpiration:
         print("Setup: Creating KiroAuthManager without expires_at...")
         manager = KiroAuthManager(refresh_token="test_token")
         manager._expires_at = None
-        
+
         print("Verification: is_token_expiring_soon returns True...")
         result = manager.is_token_expiring_soon()
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     def test_is_token_expiring_soon_returns_true_when_expired(self):
         """
         What it does: Verifies that expired token is correctly identified.
@@ -147,12 +162,12 @@ class TestKiroAuthManagerTokenExpiration:
         print("Setup: Creating KiroAuthManager with expired token...")
         manager = KiroAuthManager(refresh_token="test_token")
         manager._expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
-        
+
         print("Verification: is_token_expiring_soon returns True for expired token...")
         result = manager.is_token_expiring_soon()
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     def test_is_token_expiring_soon_returns_true_within_threshold(self):
         """
         What it does: Verifies that token within threshold is considered expiring.
@@ -161,13 +176,15 @@ class TestKiroAuthManagerTokenExpiration:
         print("Setup: Creating KiroAuthManager with token expiring in 5 minutes...")
         manager = KiroAuthManager(refresh_token="test_token")
         manager._expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
-        
+
         print(f"TOKEN_REFRESH_THRESHOLD = {TOKEN_REFRESH_THRESHOLD} seconds")
-        print("Verification: is_token_expiring_soon returns True (5 min < 10 min threshold)...")
+        print(
+            "Verification: is_token_expiring_soon returns True (5 min < 10 min threshold)..."
+        )
         result = manager.is_token_expiring_soon()
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     def test_is_token_expiring_soon_returns_false_when_valid(self):
         """
         What it does: Verifies that valid token is not considered expiring.
@@ -176,7 +193,7 @@ class TestKiroAuthManagerTokenExpiration:
         print("Setup: Creating KiroAuthManager with token expiring in 1 hour...")
         manager = KiroAuthManager(refresh_token="test_token")
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        
+
         print("Verification: is_token_expiring_soon returns False...")
         result = manager.is_token_expiring_soon()
         print(f"Comparing result: Expected False, Got {result}")
@@ -185,45 +202,46 @@ class TestKiroAuthManagerTokenExpiration:
 
 class TestKiroAuthManagerTokenRefresh:
     """Tests for token refresh mechanism."""
-    
+
     @pytest.mark.asyncio
-    async def test_refresh_token_successful(self, valid_kiro_token, mock_kiro_token_response):
+    async def test_refresh_token_successful(
+        self, valid_kiro_token, mock_kiro_token_response
+    ):
         """
         What it does: Tests successful token refresh via Kiro API.
         Purpose: Verify that on successful response token and expiration time are set.
         """
         print("Setup: Creating KiroAuthManager...")
-        manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            region="us-east-1"
-        )
-        
+        manager = KiroAuthManager(refresh_token="test_refresh", region="us-east-1")
+
         print("Setup: Mocking successful response from Kiro...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_kiro_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling _refresh_token_request()...")
             await manager._refresh_token_request()
-            
+
             print("Verification: Token set correctly...")
-            print(f"Comparing access_token: Expected '{valid_kiro_token}', Got '{manager._access_token}'")
+            print(
+                f"Comparing access_token: Expected '{valid_kiro_token}', Got '{manager._access_token}'"
+            )
             assert manager._access_token == valid_kiro_token
-            
+
             print("Verification: Expiration time set...")
             assert manager._expires_at is not None
-            
+
             print("Verification: POST request was made...")
             mock_client.post.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_updates_refresh_token(self, mock_kiro_token_response):
         """
@@ -232,27 +250,29 @@ class TestKiroAuthManagerTokenRefresh:
         """
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(refresh_token="old_refresh_token")
-        
+
         print("Setup: Mocking response with new refresh_token...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_kiro_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Refreshing token...")
             await manager._refresh_token_request()
-            
+
             print("Verification: refresh_token updated...")
-            print(f"Comparing refresh_token: Expected 'new_refresh_token_xyz', Got '{manager._refresh_token}'")
+            print(
+                f"Comparing refresh_token: Expected 'new_refresh_token_xyz', Got '{manager._refresh_token}'"
+            )
             assert manager._refresh_token == "new_refresh_token_xyz"
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_missing_access_token_raises(self):
         """
@@ -261,27 +281,27 @@ class TestKiroAuthManagerTokenRefresh:
         """
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(refresh_token="test_refresh")
-        
+
         print("Setup: Mocking response without accessToken...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value={"expiresIn": 3600})  # No accessToken!
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Attempting token refresh...")
             with pytest.raises(ValueError) as exc_info:
                 await manager._refresh_token_request()
-            
+
             print(f"Verification: ValueError raised with message: {exc_info.value}")
             assert "accessToken" in str(exc_info.value)
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_no_refresh_token_raises(self):
         """
@@ -291,20 +311,22 @@ class TestKiroAuthManagerTokenRefresh:
         print("Setup: Creating KiroAuthManager without refresh_token...")
         manager = KiroAuthManager()
         manager._refresh_token = None
-        
+
         print("Action: Attempting token refresh without refresh_token...")
         with pytest.raises(ValueError) as exc_info:
             await manager._refresh_token_request()
-        
+
         print(f"Verification: ValueError raised: {exc_info.value}")
         assert "Refresh token" in str(exc_info.value)
 
 
 class TestKiroAuthManagerGetAccessToken:
     """Tests for public get_access_token method."""
-    
+
     @pytest.mark.asyncio
-    async def test_get_access_token_refreshes_when_expired(self, valid_kiro_token, mock_kiro_token_response):
+    async def test_get_access_token_refreshes_when_expired(
+        self, valid_kiro_token, mock_kiro_token_response
+    ):
         """
         What it does: Verifies automatic refresh of expired token.
         Purpose: Ensure stale token is refreshed before returning.
@@ -313,33 +335,35 @@ class TestKiroAuthManagerGetAccessToken:
         manager = KiroAuthManager(refresh_token="test_refresh")
         manager._access_token = "old_expired_token"
         manager._expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
-        
+
         print("Setup: Mocking successful refresh...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_kiro_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Requesting token via get_access_token()...")
             token = await manager.get_access_token()
-            
+
             print("Verification: Got new token, not expired one...")
             print(f"Comparing token: Expected '{valid_kiro_token}', Got '{token}'")
             assert token == valid_kiro_token
             assert token != "old_expired_token"
-            
+
             print("Verification: _refresh_token_request was called...")
             mock_client.post.assert_called_once()
-    
+
     @pytest.mark.asyncio
-    async def test_get_access_token_returns_valid_without_refresh(self, valid_kiro_token):
+    async def test_get_access_token_returns_valid_without_refresh(
+        self, valid_kiro_token
+    ):
         """
         What it does: Verifies valid token is returned without refresh.
         Purpose: Ensure no unnecessary requests are made if token is valid.
@@ -348,25 +372,29 @@ class TestKiroAuthManagerGetAccessToken:
         manager = KiroAuthManager(refresh_token="test_refresh")
         manager._access_token = valid_kiro_token
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        
+
         print("Setup: Mocking httpx to track calls...")
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock()
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Requesting valid token...")
             token = await manager.get_access_token()
-            
+
             print("Verification: Existing token returned...")
             print(f"Comparing token: Expected '{valid_kiro_token}', Got '{token}'")
             assert token == valid_kiro_token
-            
-            print("Verification: _refresh_token was NOT called (no network requests)...")
+
+            print(
+                "Verification: _refresh_token was NOT called (no network requests)..."
+            )
             mock_client.post.assert_not_called()
-    
+
     @pytest.mark.asyncio
-    async def test_get_access_token_thread_safety(self, valid_kiro_token, mock_kiro_token_response):
+    async def test_get_access_token_thread_safety(
+        self, valid_kiro_token, mock_kiro_token_response
+    ):
         """
         What it does: Verifies thread safety via asyncio.Lock.
         Purpose: Ensure parallel calls don't cause race conditions.
@@ -375,36 +403,38 @@ class TestKiroAuthManagerGetAccessToken:
         manager = KiroAuthManager(refresh_token="test_refresh")
         manager._access_token = None
         manager._expires_at = None
-        
+
         refresh_call_count = 0
-        
+
         async def mock_refresh():
             nonlocal refresh_call_count
             refresh_call_count += 1
             await asyncio.sleep(0.1)  # Simulate delay
             manager._access_token = valid_kiro_token
             manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        
+
         print("Setup: Patching _refresh_token_request to track calls...")
-        with patch.object(manager, '_refresh_token_request', side_effect=mock_refresh):
+        with patch.object(manager, "_refresh_token_request", side_effect=mock_refresh):
             print("Action: 5 parallel get_access_token() calls...")
-            tokens = await asyncio.gather(*[
-                manager.get_access_token() for _ in range(5)
-            ])
-            
+            tokens = await asyncio.gather(
+                *[manager.get_access_token() for _ in range(5)]
+            )
+
             print("Verification: All calls got the same token...")
             assert all(token == valid_kiro_token for token in tokens)
-            
-            print(f"Verification: _refresh_token called ONLY ONCE (thanks to lock)...")
+
+            print("Verification: _refresh_token called ONLY ONCE (thanks to lock)...")
             print(f"Comparing call count: Expected 1, Got {refresh_call_count}")
             assert refresh_call_count == 1
 
 
 class TestKiroAuthManagerForceRefresh:
     """Tests for forced token refresh."""
-    
+
     @pytest.mark.asyncio
-    async def test_force_refresh_updates_token(self, valid_kiro_token, mock_kiro_token_response):
+    async def test_force_refresh_updates_token(
+        self, valid_kiro_token, mock_kiro_token_response
+    ):
         """
         What it does: Verifies forced token refresh.
         Purpose: Ensure force_refresh always refreshes the token.
@@ -413,34 +443,34 @@ class TestKiroAuthManagerForceRefresh:
         manager = KiroAuthManager(refresh_token="test_refresh")
         manager._access_token = "old_but_valid_token"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        
+
         print("Setup: Mocking refresh...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_kiro_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Force refreshing token...")
             token = await manager.force_refresh()
-            
+
             print("Verification: Token refreshed despite old one being valid...")
             print(f"Comparing token: Expected '{valid_kiro_token}', Got '{token}'")
             assert token == valid_kiro_token
-            
+
             print("Verification: POST request was made...")
             mock_client.post.assert_called_once()
 
 
 class TestKiroAuthManagerProperties:
     """Tests for KiroAuthManager properties."""
-    
+
     def test_profile_arn_property(self):
         """
         What it does: Verifies profile_arn property.
@@ -448,45 +478,40 @@ class TestKiroAuthManagerProperties:
         """
         print("Setup: Creating KiroAuthManager with profile_arn...")
         manager = KiroAuthManager(
-            refresh_token="test",
-            profile_arn="arn:aws:test:profile"
+            refresh_token="test", profile_arn="arn:aws:test:profile"
         )
-        
+
         print("Verification: profile_arn accessible...")
-        print(f"Comparing profile_arn: Expected 'arn:aws:test:profile', Got '{manager.profile_arn}'")
+        print(
+            f"Comparing profile_arn: Expected 'arn:aws:test:profile', Got '{manager.profile_arn}'"
+        )
         assert manager.profile_arn == "arn:aws:test:profile"
-    
+
     def test_region_property(self):
         """
         What it does: Verifies region property.
         Purpose: Ensure region is accessible via property.
         """
         print("Setup: Creating KiroAuthManager with region...")
-        manager = KiroAuthManager(
-            refresh_token="test",
-            region="eu-west-1"
-        )
-        
+        manager = KiroAuthManager(refresh_token="test", region="eu-west-1")
+
         print("Verification: region accessible...")
         print(f"Comparing region: Expected 'eu-west-1', Got '{manager.region}'")
         assert manager.region == "eu-west-1"
-    
+
     def test_api_host_property(self):
         """
         What it does: Verifies api_host property.
         Purpose: Ensure api_host is formed correctly.
         """
         print("Setup: Creating KiroAuthManager...")
-        manager = KiroAuthManager(
-            refresh_token="test",
-            region="us-east-1"
-        )
-        
+        manager = KiroAuthManager(refresh_token="test", region="us-east-1")
+
         print("Verification: api_host contains codewhisperer and region...")
         print(f"api_host: {manager.api_host}")
         assert "codewhisperer" in manager.api_host
         assert "us-east-1" in manager.api_host
-    
+
     def test_fingerprint_property(self):
         """
         What it does: Verifies fingerprint property.
@@ -494,7 +519,7 @@ class TestKiroAuthManagerProperties:
         """
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(refresh_token="test")
-        
+
         print("Verification: fingerprint accessible and has correct length...")
         print(f"fingerprint: {manager.fingerprint}")
         assert len(manager.fingerprint) == 64
@@ -504,9 +529,10 @@ class TestKiroAuthManagerProperties:
 # Tests for AuthType enum
 # =============================================================================
 
+
 class TestAuthTypeEnum:
     """Tests for AuthType enum."""
-    
+
     def test_auth_type_enum_values(self):
         """
         What it does: Verifies AuthType enum values.
@@ -514,10 +540,10 @@ class TestAuthTypeEnum:
         """
         print("Verification: AuthType contains KIRO_DESKTOP...")
         assert AuthType.KIRO_DESKTOP.value == "kiro_desktop"
-        
+
         print("Verification: AuthType contains AWS_SSO_OIDC...")
         assert AuthType.AWS_SSO_OIDC.value == "aws_sso_oidc"
-        
+
         print(f"Comparing value count: Expected 2, Got {len(AuthType)}")
         assert len(AuthType) == 2
 
@@ -526,9 +552,10 @@ class TestAuthTypeEnum:
 # Tests for _detect_auth_type()
 # =============================================================================
 
+
 class TestKiroAuthManagerDetectAuthType:
     """Tests for _detect_auth_type() method."""
-    
+
     def test_detect_auth_type_kiro_desktop_when_no_client_credentials(self):
         """
         What it does: Verifies KIRO_DESKTOP type detection without client credentials.
@@ -536,11 +563,11 @@ class TestKiroAuthManagerDetectAuthType:
         """
         print("Setup: Creating KiroAuthManager without client credentials...")
         manager = KiroAuthManager(refresh_token="test_token")
-        
+
         print("Verification: auth_type = KIRO_DESKTOP...")
         print(f"Comparing auth_type: Expected KIRO_DESKTOP, Got {manager.auth_type}")
         assert manager.auth_type == AuthType.KIRO_DESKTOP
-    
+
     def test_detect_auth_type_aws_sso_oidc_when_client_credentials_present(self):
         """
         What it does: Verifies AWS_SSO_OIDC type detection with client credentials.
@@ -550,13 +577,13 @@ class TestKiroAuthManagerDetectAuthType:
         manager = KiroAuthManager(
             refresh_token="test_token",
             client_id="test_client_id",
-            client_secret="test_client_secret"
+            client_secret="test_client_secret",
         )
-        
+
         print("Verification: auth_type = AWS_SSO_OIDC...")
         print(f"Comparing auth_type: Expected AWS_SSO_OIDC, Got {manager.auth_type}")
         assert manager.auth_type == AuthType.AWS_SSO_OIDC
-    
+
     def test_detect_auth_type_kiro_desktop_when_only_client_id(self):
         """
         What it does: Verifies type detection with only clientId (no secret).
@@ -564,10 +591,9 @@ class TestKiroAuthManagerDetectAuthType:
         """
         print("Setup: Creating KiroAuthManager with only client_id...")
         manager = KiroAuthManager(
-            refresh_token="test_token",
-            client_id="test_client_id"
+            refresh_token="test_token", client_id="test_client_id"
         )
-        
+
         print("Verification: auth_type = KIRO_DESKTOP (both id and secret required)...")
         print(f"Comparing auth_type: Expected KIRO_DESKTOP, Got {manager.auth_type}")
         assert manager.auth_type == AuthType.KIRO_DESKTOP
@@ -577,45 +603,60 @@ class TestKiroAuthManagerDetectAuthType:
 # Tests for loading AWS SSO credentials from JSON file
 # =============================================================================
 
+
 class TestKiroAuthManagerAwsSsoCredentialsFile:
     """Tests for loading AWS SSO OIDC credentials from JSON file."""
-    
-    def test_load_credentials_from_file_with_client_id_and_secret(self, temp_aws_sso_creds_file):
+
+    def test_load_credentials_from_file_with_client_id_and_secret(
+        self, temp_aws_sso_creds_file
+    ):
         """
         What it does: Verifies loading clientId and clientSecret from JSON file.
         Purpose: Ensure AWS SSO fields are correctly read from file.
         """
-        print(f"Setup: Creating KiroAuthManager with AWS SSO file: {temp_aws_sso_creds_file}")
+        print(
+            f"Setup: Creating KiroAuthManager with AWS SSO file: {temp_aws_sso_creds_file}"
+        )
         manager = KiroAuthManager(creds_file=temp_aws_sso_creds_file)
-        
+
         print("Verification: clientId loaded...")
-        print(f"Comparing client_id: Expected 'test_client_id_12345', Got '{manager._client_id}'")
+        print(
+            f"Comparing client_id: Expected 'test_client_id_12345', Got '{manager._client_id}'"
+        )
         assert manager._client_id == "test_client_id_12345"
-        
+
         print("Verification: clientSecret loaded...")
-        print(f"Comparing client_secret: Expected 'test_client_secret_67890', Got '{manager._client_secret}'")
+        print(
+            f"Comparing client_secret: Expected 'test_client_secret_67890', Got '{manager._client_secret}'"
+        )
         assert manager._client_secret == "test_client_secret_67890"
-    
-    def test_load_credentials_from_file_auto_detects_aws_sso_oidc(self, temp_aws_sso_creds_file):
+
+    def test_load_credentials_from_file_auto_detects_aws_sso_oidc(
+        self, temp_aws_sso_creds_file
+    ):
         """
         What it does: Verifies auto-detection of auth type after loading from file.
         Purpose: Ensure auth_type automatically becomes AWS_SSO_OIDC.
         """
-        print(f"Setup: Creating KiroAuthManager with AWS SSO file: {temp_aws_sso_creds_file}")
+        print(
+            f"Setup: Creating KiroAuthManager with AWS SSO file: {temp_aws_sso_creds_file}"
+        )
         manager = KiroAuthManager(creds_file=temp_aws_sso_creds_file)
-        
+
         print("Verification: auth_type automatically detected as AWS_SSO_OIDC...")
         print(f"Comparing auth_type: Expected AWS_SSO_OIDC, Got {manager.auth_type}")
         assert manager.auth_type == AuthType.AWS_SSO_OIDC
-    
+
     def test_load_kiro_desktop_file_stays_kiro_desktop(self, temp_creds_file):
         """
         What it does: Verifies that Kiro Desktop file doesn't change type to AWS SSO.
         Purpose: Ensure file without clientId/clientSecret stays KIRO_DESKTOP.
         """
-        print(f"Setup: Creating KiroAuthManager with Kiro Desktop file: {temp_creds_file}")
+        print(
+            f"Setup: Creating KiroAuthManager with Kiro Desktop file: {temp_creds_file}"
+        )
         manager = KiroAuthManager(creds_file=temp_creds_file)
-        
+
         print("Verification: auth_type stays KIRO_DESKTOP...")
         print(f"Comparing auth_type: Expected KIRO_DESKTOP, Got {manager.auth_type}")
         assert manager.auth_type == AuthType.KIRO_DESKTOP
@@ -625,9 +666,10 @@ class TestKiroAuthManagerAwsSsoCredentialsFile:
 # Tests for loading credentials from SQLite
 # =============================================================================
 
+
 class TestKiroAuthManagerSqliteCredentials:
     """Tests for loading credentials from SQLite database (kiro-cli format)."""
-    
+
     def test_load_credentials_from_sqlite_success(self, temp_sqlite_db):
         """
         What it does: Verifies successful loading of credentials from SQLite.
@@ -635,15 +677,19 @@ class TestKiroAuthManagerSqliteCredentials:
         """
         print(f"Setup: Creating KiroAuthManager with SQLite: {temp_sqlite_db}")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: access_token loaded...")
-        print(f"Comparing access_token: Expected 'sqlite_access_token', Got '{manager._access_token}'")
+        print(
+            f"Comparing access_token: Expected 'sqlite_access_token', Got '{manager._access_token}'"
+        )
         assert manager._access_token == "sqlite_access_token"
-        
+
         print("Verification: refresh_token loaded...")
-        print(f"Comparing refresh_token: Expected 'sqlite_refresh_token', Got '{manager._refresh_token}'")
+        print(
+            f"Comparing refresh_token: Expected 'sqlite_refresh_token', Got '{manager._refresh_token}'"
+        )
         assert manager._refresh_token == "sqlite_refresh_token"
-    
+
     def test_load_credentials_from_sqlite_file_not_found(self, tmp_path):
         """
         What it does: Verifies handling of missing SQLite file.
@@ -651,16 +697,17 @@ class TestKiroAuthManagerSqliteCredentials:
         """
         print("Setup: Creating KiroAuthManager with non-existent SQLite file...")
         non_existent_db = str(tmp_path / "non_existent.sqlite3")
-        
+
         manager = KiroAuthManager(
-            refresh_token="fallback_token",
-            sqlite_db=non_existent_db
+            refresh_token="fallback_token", sqlite_db=non_existent_db
         )
-        
+
         print("Verification: Fallback refresh_token is used...")
-        print(f"Comparing refresh_token: Expected 'fallback_token', Got '{manager._refresh_token}'")
+        print(
+            f"Comparing refresh_token: Expected 'fallback_token', Got '{manager._refresh_token}'"
+        )
         assert manager._refresh_token == "fallback_token"
-    
+
     def test_load_credentials_from_sqlite_loads_token_data(self, temp_sqlite_db):
         """
         What it does: Verifies loading token data from SQLite.
@@ -670,98 +717,118 @@ class TestKiroAuthManagerSqliteCredentials:
         """
         print(f"Setup: Creating KiroAuthManager with SQLite: {temp_sqlite_db}")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: SSO region loaded from SQLite...")
-        print(f"Comparing sso_region: Expected 'eu-west-1', Got '{manager._sso_region}'")
+        print(
+            f"Comparing sso_region: Expected 'eu-west-1', Got '{manager._sso_region}'"
+        )
         assert manager._sso_region == "eu-west-1"
-        
+
         print("Verification: API region stays at us-east-1...")
         print(f"Comparing region: Expected 'us-east-1', Got '{manager._region}'")
         assert manager._region == "us-east-1"
-        
+
         print("Verification: expires_at parsed...")
         assert manager._expires_at is not None
         assert manager._expires_at.year == 2099
-    
-    def test_load_credentials_from_sqlite_loads_device_registration(self, temp_sqlite_db):
+
+    def test_load_credentials_from_sqlite_loads_device_registration(
+        self, temp_sqlite_db
+    ):
         """
         What it does: Verifies loading device registration from SQLite.
         Purpose: Ensure client_id and client_secret are loaded.
         """
         print(f"Setup: Creating KiroAuthManager with SQLite: {temp_sqlite_db}")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: client_id loaded...")
-        print(f"Comparing client_id: Expected 'sqlite_client_id', Got '{manager._client_id}'")
+        print(
+            f"Comparing client_id: Expected 'sqlite_client_id', Got '{manager._client_id}'"
+        )
         assert manager._client_id == "sqlite_client_id"
-        
+
         print("Verification: client_secret loaded...")
-        print(f"Comparing client_secret: Expected 'sqlite_client_secret', Got '{manager._client_secret}'")
+        print(
+            f"Comparing client_secret: Expected 'sqlite_client_secret', Got '{manager._client_secret}'"
+        )
         assert manager._client_secret == "sqlite_client_secret"
-    
-    def test_load_credentials_from_sqlite_auto_detects_aws_sso_oidc(self, temp_sqlite_db):
+
+    def test_load_credentials_from_sqlite_auto_detects_aws_sso_oidc(
+        self, temp_sqlite_db
+    ):
         """
         What it does: Verifies auto-detection of auth type after loading from SQLite.
         Purpose: Ensure auth_type automatically becomes AWS_SSO_OIDC.
         """
         print(f"Setup: Creating KiroAuthManager with SQLite: {temp_sqlite_db}")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: auth_type automatically detected as AWS_SSO_OIDC...")
         print(f"Comparing auth_type: Expected AWS_SSO_OIDC, Got {manager.auth_type}")
         assert manager.auth_type == AuthType.AWS_SSO_OIDC
-    
-    def test_load_credentials_from_sqlite_handles_missing_registration_key(self, temp_sqlite_db_token_only):
+
+    def test_load_credentials_from_sqlite_handles_missing_registration_key(
+        self, temp_sqlite_db_token_only
+    ):
         """
         What it does: Verifies handling of missing device-registration key.
         Purpose: Ensure application doesn't crash without device-registration.
         """
-        print(f"Setup: Creating KiroAuthManager with SQLite without device-registration...")
+        print(
+            "Setup: Creating KiroAuthManager with SQLite without device-registration..."
+        )
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db_token_only)
-        
+
         print("Verification: refresh_token loaded...")
         assert manager._refresh_token == "partial_refresh_token"
-        
+
         print("Verification: client_id stayed None...")
         assert manager._client_id is None
-        
+
         print("Verification: auth_type = KIRO_DESKTOP (no client credentials)...")
         assert manager.auth_type == AuthType.KIRO_DESKTOP
-    
-    def test_load_credentials_from_sqlite_handles_invalid_json(self, temp_sqlite_db_invalid_json):
+
+    def test_load_credentials_from_sqlite_handles_invalid_json(
+        self, temp_sqlite_db_invalid_json
+    ):
         """
         What it does: Verifies handling of invalid JSON in SQLite.
         Purpose: Ensure application doesn't crash on invalid JSON.
         """
         print("Setup: Creating KiroAuthManager with SQLite with invalid JSON...")
         manager = KiroAuthManager(
-            refresh_token="fallback_token",
-            sqlite_db=temp_sqlite_db_invalid_json
+            refresh_token="fallback_token", sqlite_db=temp_sqlite_db_invalid_json
         )
-        
+
         print("Verification: Fallback refresh_token is used...")
-        print(f"Comparing refresh_token: Expected 'fallback_token', Got '{manager._refresh_token}'")
+        print(
+            f"Comparing refresh_token: Expected 'fallback_token', Got '{manager._refresh_token}'"
+        )
         assert manager._refresh_token == "fallback_token"
-    
-    def test_sqlite_takes_priority_over_json_file(self, temp_sqlite_db, temp_creds_file):
+
+    def test_sqlite_takes_priority_over_json_file(
+        self, temp_sqlite_db, temp_creds_file
+    ):
         """
         What it does: Verifies SQLite priority over JSON file.
         Purpose: Ensure SQLite is loaded instead of JSON when both specified.
         """
         print("Setup: Creating KiroAuthManager with SQLite and JSON file...")
-        manager = KiroAuthManager(
-            sqlite_db=temp_sqlite_db,
-            creds_file=temp_creds_file
-        )
-        
+        manager = KiroAuthManager(sqlite_db=temp_sqlite_db, creds_file=temp_creds_file)
+
         print("Verification: Data from SQLite (not from JSON)...")
-        print(f"Comparing access_token: Expected 'sqlite_access_token', Got '{manager._access_token}'")
+        print(
+            f"Comparing access_token: Expected 'sqlite_access_token', Got '{manager._access_token}'"
+        )
         assert manager._access_token == "sqlite_access_token"
-        
+
         print("Verification: SSO region from SQLite...")
-        print(f"Comparing sso_region: Expected 'eu-west-1', Got '{manager._sso_region}'")
+        print(
+            f"Comparing sso_region: Expected 'eu-west-1', Got '{manager._sso_region}'"
+        )
         assert manager._sso_region == "eu-west-1"
-        
+
         print("Verification: API region stays at us-east-1...")
         print(f"Comparing region: Expected 'us-east-1', Got '{manager._region}'")
         assert manager._region == "us-east-1"
@@ -771,9 +838,10 @@ class TestKiroAuthManagerSqliteCredentials:
 # Tests for _refresh_token_request() routing
 # =============================================================================
 
+
 class TestKiroAuthManagerRefreshTokenRouting:
     """Tests for _refresh_token_request() routing based on auth_type."""
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_request_routes_to_kiro_desktop(self):
         """
@@ -783,18 +851,22 @@ class TestKiroAuthManagerRefreshTokenRouting:
         print("Setup: Creating KiroAuthManager with KIRO_DESKTOP...")
         manager = KiroAuthManager(refresh_token="test_refresh")
         assert manager.auth_type == AuthType.KIRO_DESKTOP
-        
+
         print("Setup: Mocking _refresh_token_kiro_desktop...")
-        with patch.object(manager, '_refresh_token_kiro_desktop', new_callable=AsyncMock) as mock_desktop:
-            with patch.object(manager, '_refresh_token_aws_sso_oidc', new_callable=AsyncMock) as mock_sso:
+        with patch.object(
+            manager, "_refresh_token_kiro_desktop", new_callable=AsyncMock
+        ) as mock_desktop:
+            with patch.object(
+                manager, "_refresh_token_aws_sso_oidc", new_callable=AsyncMock
+            ) as mock_sso:
                 await manager._refresh_token_request()
-                
+
                 print("Verification: _refresh_token_kiro_desktop was called...")
                 mock_desktop.assert_called_once()
-                
+
                 print("Verification: _refresh_token_aws_sso_oidc was NOT called...")
                 mock_sso.assert_not_called()
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_request_routes_to_aws_sso_oidc(self):
         """
@@ -805,18 +877,22 @@ class TestKiroAuthManagerRefreshTokenRouting:
         manager = KiroAuthManager(
             refresh_token="test_refresh",
             client_id="test_client_id",
-            client_secret="test_client_secret"
+            client_secret="test_client_secret",
         )
         assert manager.auth_type == AuthType.AWS_SSO_OIDC
-        
+
         print("Setup: Mocking _refresh_token_aws_sso_oidc...")
-        with patch.object(manager, '_refresh_token_kiro_desktop', new_callable=AsyncMock) as mock_desktop:
-            with patch.object(manager, '_refresh_token_aws_sso_oidc', new_callable=AsyncMock) as mock_sso:
+        with patch.object(
+            manager, "_refresh_token_kiro_desktop", new_callable=AsyncMock
+        ) as mock_desktop:
+            with patch.object(
+                manager, "_refresh_token_aws_sso_oidc", new_callable=AsyncMock
+            ) as mock_sso:
                 await manager._refresh_token_request()
-                
+
                 print("Verification: _refresh_token_aws_sso_oidc was called...")
                 mock_sso.assert_called_once()
-                
+
                 print("Verification: _refresh_token_kiro_desktop was NOT called...")
                 mock_desktop.assert_not_called()
 
@@ -825,11 +901,14 @@ class TestKiroAuthManagerRefreshTokenRouting:
 # Tests for _refresh_token_aws_sso_oidc()
 # =============================================================================
 
+
 class TestKiroAuthManagerAwsSsoOidcRefresh:
     """Tests for _refresh_token_aws_sso_oidc() method."""
-    
+
     @pytest.mark.asyncio
-    async def test_refresh_token_aws_sso_oidc_success(self, mock_aws_sso_oidc_token_response):
+    async def test_refresh_token_aws_sso_oidc_success(
+        self, mock_aws_sso_oidc_token_response
+    ):
         """
         What it does: Tests successful token refresh via AWS SSO OIDC.
         Purpose: Verify that on successful response token and expiration time are set.
@@ -839,32 +918,34 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
             refresh_token="test_refresh",
             client_id="test_client_id",
             client_secret="test_client_secret",
-            region="us-east-1"
+            region="us-east-1",
         )
-        
+
         print("Setup: Mocking successful response from AWS SSO OIDC...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling _refresh_token_aws_sso_oidc()...")
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: Token set correctly...")
-            print(f"Comparing access_token: Expected 'new_aws_sso_access_token', Got '{manager._access_token}'")
+            print(
+                f"Comparing access_token: Expected 'new_aws_sso_access_token', Got '{manager._access_token}'"
+            )
             assert manager._access_token == "new_aws_sso_access_token"
-            
+
             print("Verification: Expiration time set...")
             assert manager._expires_at is not None
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_raises_without_refresh_token(self):
         """
@@ -873,18 +954,17 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         """
         print("Setup: Creating KiroAuthManager without refresh_token...")
         manager = KiroAuthManager(
-            client_id="test_client_id",
-            client_secret="test_client_secret"
+            client_id="test_client_id", client_secret="test_client_secret"
         )
         manager._refresh_token = None
-        
+
         print("Action: Attempting token refresh without refresh_token...")
         with pytest.raises(ValueError) as exc_info:
             await manager._refresh_token_aws_sso_oidc()
-        
+
         print(f"Verification: ValueError raised: {exc_info.value}")
         assert "Refresh token" in str(exc_info.value)
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_raises_without_client_id(self):
         """
@@ -893,19 +973,18 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         """
         print("Setup: Creating KiroAuthManager without client_id...")
         manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            client_secret="test_client_secret"
+            refresh_token="test_refresh", client_secret="test_client_secret"
         )
         manager._client_id = None
         manager._auth_type = AuthType.AWS_SSO_OIDC
-        
+
         print("Action: Attempting token refresh without client_id...")
         with pytest.raises(ValueError) as exc_info:
             await manager._refresh_token_aws_sso_oidc()
-        
+
         print(f"Verification: ValueError raised: {exc_info.value}")
         assert "Client ID" in str(exc_info.value)
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_raises_without_client_secret(self):
         """
@@ -914,21 +993,22 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         """
         print("Setup: Creating KiroAuthManager without client_secret...")
         manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            client_id="test_client_id"
+            refresh_token="test_refresh", client_id="test_client_id"
         )
         manager._client_secret = None
         manager._auth_type = AuthType.AWS_SSO_OIDC
-        
+
         print("Action: Attempting token refresh without client_secret...")
         with pytest.raises(ValueError) as exc_info:
             await manager._refresh_token_aws_sso_oidc()
-        
+
         print(f"Verification: ValueError raised: {exc_info.value}")
         assert "Client secret" in str(exc_info.value)
-    
+
     @pytest.mark.asyncio
-    async def test_refresh_token_aws_sso_oidc_uses_correct_endpoint(self, mock_aws_sso_oidc_token_response):
+    async def test_refresh_token_aws_sso_oidc_uses_correct_endpoint(
+        self, mock_aws_sso_oidc_token_response
+    ):
         """
         What it does: Verifies correct endpoint usage.
         Purpose: Ensure request goes to https://oidc.{region}.amazonaws.com/token.
@@ -938,33 +1018,35 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
             refresh_token="test_refresh",
             client_id="test_client_id",
             client_secret="test_client_secret",
-            region="eu-west-1"
+            region="eu-west-1",
         )
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: POST request to correct URL...")
             call_args = mock_client.post.call_args
             url = call_args[0][0]
             expected_url = "https://oidc.eu-west-1.amazonaws.com/token"
             print(f"Comparing URL: Expected '{expected_url}', Got '{url}'")
             assert url == expected_url
-    
+
     @pytest.mark.asyncio
-    async def test_refresh_token_aws_sso_oidc_uses_form_urlencoded(self, mock_aws_sso_oidc_token_response):
+    async def test_refresh_token_aws_sso_oidc_uses_form_urlencoded(
+        self, mock_aws_sso_oidc_token_response
+    ):
         """
         What it does: Verifies form-urlencoded format usage.
         Purpose: Ensure Content-Type = application/x-www-form-urlencoded.
@@ -973,32 +1055,36 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         manager = KiroAuthManager(
             refresh_token="test_refresh",
             client_id="test_client_id",
-            client_secret="test_client_secret"
+            client_secret="test_client_secret",
         )
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: Content-Type = application/x-www-form-urlencoded...")
             call_args = mock_client.post.call_args
-            headers = call_args[1].get('headers', {})
-            print(f"Comparing Content-Type: Expected 'application/x-www-form-urlencoded', Got '{headers.get('Content-Type')}'")
-            assert headers.get('Content-Type') == 'application/x-www-form-urlencoded'
-    
+            headers = call_args[1].get("headers", {})
+            print(
+                f"Comparing Content-Type: Expected 'application/x-www-form-urlencoded', Got '{headers.get('Content-Type')}'"
+            )
+            assert headers.get("Content-Type") == "application/x-www-form-urlencoded"
+
     @pytest.mark.asyncio
-    async def test_refresh_token_aws_sso_oidc_sends_correct_grant_type(self, mock_aws_sso_oidc_token_response):
+    async def test_refresh_token_aws_sso_oidc_sends_correct_grant_type(
+        self, mock_aws_sso_oidc_token_response
+    ):
         """
         What it does: Verifies correct grant_type is sent.
         Purpose: Ensure grant_type=refresh_token.
@@ -1007,32 +1093,36 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         manager = KiroAuthManager(
             refresh_token="test_refresh",
             client_id="test_client_id",
-            client_secret="test_client_secret"
+            client_secret="test_client_secret",
         )
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: grant_type = refresh_token...")
             call_args = mock_client.post.call_args
-            data = call_args[1].get('data', {})
-            print(f"Comparing grant_type: Expected 'refresh_token', Got '{data.get('grant_type')}'")
-            assert data.get('grant_type') == 'refresh_token'
-    
+            data = call_args[1].get("data", {})
+            print(
+                f"Comparing grant_type: Expected 'refresh_token', Got '{data.get('grant_type')}'"
+            )
+            assert data.get("grant_type") == "refresh_token"
+
     @pytest.mark.asyncio
-    async def test_refresh_token_aws_sso_oidc_updates_tokens(self, mock_aws_sso_oidc_token_response):
+    async def test_refresh_token_aws_sso_oidc_updates_tokens(
+        self, mock_aws_sso_oidc_token_response
+    ):
         """
         What it does: Verifies access_token and refresh_token update.
         Purpose: Ensure both tokens are updated from response.
@@ -1041,32 +1131,34 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         manager = KiroAuthManager(
             refresh_token="old_refresh_token",
             client_id="test_client_id",
-            client_secret="test_client_secret"
+            client_secret="test_client_secret",
         )
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: access_token updated...")
             assert manager._access_token == "new_aws_sso_access_token"
-            
+
             print("Verification: refresh_token updated...")
             assert manager._refresh_token == "new_aws_sso_refresh_token"
-    
+
     @pytest.mark.asyncio
-    async def test_refresh_token_aws_sso_oidc_calculates_expiration(self, mock_aws_sso_oidc_token_response):
+    async def test_refresh_token_aws_sso_oidc_calculates_expiration(
+        self, mock_aws_sso_oidc_token_response
+    ):
         """
         What it does: Verifies correct expiration time calculation.
         Purpose: Ensure expires_at is calculated based on expiresIn.
@@ -1075,34 +1167,39 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         manager = KiroAuthManager(
             refresh_token="test_refresh",
             client_id="test_client_id",
-            client_secret="test_client_secret"
+            client_secret="test_client_secret",
         )
-        
+
         print("Setup: Mocking HTTP client with expiresIn=7200...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response(expires_in=7200))
+        mock_response.json = Mock(
+            return_value=mock_aws_sso_oidc_token_response(expires_in=7200)
+        )
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: expires_at set...")
             assert manager._expires_at is not None
-            
+
             print("Verification: expires_at in the future...")
             from datetime import datetime, timezone
+
             now = datetime.now(timezone.utc)
             assert manager._expires_at > now
-    
+
     @pytest.mark.asyncio
-    async def test_refresh_token_aws_sso_oidc_does_not_send_scopes(self, mock_aws_sso_oidc_token_response):
+    async def test_refresh_token_aws_sso_oidc_does_not_send_scopes(
+        self, mock_aws_sso_oidc_token_response
+    ):
         """
         What it does: Verifies that scopes are NOT sent in refresh request.
         Purpose: Per OAuth 2.0 RFC 6749 Section 6, scope is optional in refresh and
@@ -1112,39 +1209,46 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         manager = KiroAuthManager(
             refresh_token="test_refresh",
             client_id="test_client_id",
-            client_secret="test_client_secret"
+            client_secret="test_client_secret",
         )
         # Simulate scopes loaded from SQLite (this is what caused the bug)
         manager._scopes = ["codewhisperer:completions", "codewhisperer:analysis"]
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: scope NOT in request data...")
             call_args = mock_client.post.call_args
-            data = call_args[1].get('data', {})
+            data = call_args[1].get("data", {})
             print(f"Request data keys: {list(data.keys())}")
-            assert 'scope' not in data, "scope should NOT be sent in refresh request"
-            
+            assert "scope" not in data, "scope should NOT be sent in refresh request"
+
             print("Verification: only required fields sent...")
-            expected_keys = {'grant_type', 'client_id', 'client_secret', 'refresh_token'}
+            expected_keys = {
+                "grant_type",
+                "client_id",
+                "client_secret",
+                "refresh_token",
+            }
             print(f"Comparing keys: Expected {expected_keys}, Got {set(data.keys())}")
             assert set(data.keys()) == expected_keys
-    
+
     @pytest.mark.asyncio
-    async def test_refresh_token_aws_sso_oidc_works_without_scopes(self, mock_aws_sso_oidc_token_response):
+    async def test_refresh_token_aws_sso_oidc_works_without_scopes(
+        self, mock_aws_sso_oidc_token_response
+    ):
         """
         What it does: Verifies refresh works when scopes are None.
         Purpose: Ensure backward compatibility with credentials that don't have scopes.
@@ -1153,42 +1257,43 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         manager = KiroAuthManager(
             refresh_token="test_refresh",
             client_id="test_client_id",
-            client_secret="test_client_secret"
+            client_secret="test_client_secret",
         )
         # Explicitly set scopes to None (default state)
         manager._scopes = None
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: Token refreshed successfully...")
             assert manager._access_token == "new_aws_sso_access_token"
-            
+
             print("Verification: scope NOT in request data...")
             call_args = mock_client.post.call_args
-            data = call_args[1].get('data', {})
-            assert 'scope' not in data
+            data = call_args[1].get("data", {})
+            assert "scope" not in data
 
 
 # =============================================================================
 # Tests for auth_type property and constructor with new parameters
 # =============================================================================
 
+
 class TestKiroAuthManagerAuthTypeProperty:
     """Tests for auth_type property and constructor."""
-    
+
     def test_auth_type_property_returns_correct_value(self):
         """
         What it does: Verifies that auth_type property returns correct value.
@@ -1196,20 +1301,18 @@ class TestKiroAuthManagerAuthTypeProperty:
         """
         print("Setup: Creating KiroAuthManager with KIRO_DESKTOP...")
         manager_desktop = KiroAuthManager(refresh_token="test")
-        
+
         print("Verification: auth_type = KIRO_DESKTOP...")
         assert manager_desktop.auth_type == AuthType.KIRO_DESKTOP
-        
+
         print("Setup: Creating KiroAuthManager with AWS_SSO_OIDC...")
         manager_sso = KiroAuthManager(
-            refresh_token="test",
-            client_id="id",
-            client_secret="secret"
+            refresh_token="test", client_id="id", client_secret="secret"
         )
-        
+
         print("Verification: auth_type = AWS_SSO_OIDC...")
         assert manager_sso.auth_type == AuthType.AWS_SSO_OIDC
-    
+
     def test_init_with_client_id_and_secret(self):
         """
         What it does: Verifies initialization with client_id and client_secret.
@@ -1219,15 +1322,15 @@ class TestKiroAuthManagerAuthTypeProperty:
         manager = KiroAuthManager(
             refresh_token="test",
             client_id="my_client_id",
-            client_secret="my_client_secret"
+            client_secret="my_client_secret",
         )
-        
+
         print("Verification: client_id stored...")
         assert manager._client_id == "my_client_id"
-        
+
         print("Verification: client_secret stored...")
         assert manager._client_secret == "my_client_secret"
-    
+
     def test_init_with_sqlite_db_parameter(self, temp_sqlite_db):
         """
         What it does: Verifies initialization with sqlite_db parameter.
@@ -1235,11 +1338,11 @@ class TestKiroAuthManagerAuthTypeProperty:
         """
         print(f"Setup: Creating KiroAuthManager with sqlite_db: {temp_sqlite_db}")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: Data loaded from SQLite...")
         assert manager._access_token == "sqlite_access_token"
         assert manager._refresh_token == "sqlite_refresh_token"
-    
+
     def test_detect_auth_type_kiro_desktop_when_only_client_secret(self):
         """
         What it does: Verifies type detection with only clientSecret (no id).
@@ -1247,10 +1350,9 @@ class TestKiroAuthManagerAuthTypeProperty:
         """
         print("Setup: Creating KiroAuthManager with only client_secret...")
         manager = KiroAuthManager(
-            refresh_token="test_token",
-            client_secret="test_client_secret"
+            refresh_token="test_token", client_secret="test_client_secret"
         )
-        
+
         print("Verification: auth_type = KIRO_DESKTOP (both id and secret required)...")
         print(f"Comparing auth_type: Expected KIRO_DESKTOP, Got {manager.auth_type}")
         assert manager.auth_type == AuthType.KIRO_DESKTOP
@@ -1260,64 +1362,64 @@ class TestKiroAuthManagerAuthTypeProperty:
 # Tests for SSO region separation (Issue #16)
 # =============================================================================
 
+
 class TestKiroAuthManagerSsoRegionSeparation:
     """Tests for SSO region separation from API region (Issue #16 fix).
-    
+
     Background: CodeWhisperer API only exists in us-east-1, but users may have
     SSO credentials from other regions (e.g., ap-southeast-1 for Singapore).
     The fix separates SSO region (for OIDC token refresh) from API region.
     """
-    
+
     def test_api_region_stays_us_east_1_when_loading_from_sqlite(self, temp_sqlite_db):
         """
         What it does: Verifies API region doesn't change when loading from SQLite.
         Purpose: Ensure CodeWhisperer API calls go to us-east-1 regardless of SSO region.
         """
-        print(f"Setup: Creating KiroAuthManager with SQLite (region=eu-west-1)...")
+        print("Setup: Creating KiroAuthManager with SQLite (region=eu-west-1)...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: API region stays at us-east-1...")
         print(f"Comparing _region: Expected 'us-east-1', Got '{manager._region}'")
         assert manager._region == "us-east-1"
-        
+
         print("Verification: api_host contains us-east-1...")
         print(f"api_host: {manager._api_host}")
         assert "us-east-1" in manager._api_host
-        
+
         print("Verification: q_host contains us-east-1...")
         print(f"q_host: {manager._q_host}")
         assert "us-east-1" in manager._q_host
-    
+
     def test_sso_region_stored_separately_from_api_region(self, temp_sqlite_db):
         """
         What it does: Verifies SSO region is stored in _sso_region field.
         Purpose: Ensure SSO region is available for OIDC token refresh.
         """
-        print(f"Setup: Creating KiroAuthManager with SQLite (region=eu-west-1)...")
+        print("Setup: Creating KiroAuthManager with SQLite (region=eu-west-1)...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: SSO region stored in _sso_region...")
-        print(f"Comparing _sso_region: Expected 'eu-west-1', Got '{manager._sso_region}'")
+        print(
+            f"Comparing _sso_region: Expected 'eu-west-1', Got '{manager._sso_region}'"
+        )
         assert manager._sso_region == "eu-west-1"
-        
+
         print("Verification: API region is different from SSO region...")
         assert manager._region != manager._sso_region
-    
+
     def test_sso_region_none_when_not_loaded_from_sqlite(self):
         """
         What it does: Verifies _sso_region is None when not loading from SQLite.
         Purpose: Ensure backward compatibility with direct credential initialization.
         """
         print("Setup: Creating KiroAuthManager with direct credentials...")
-        manager = KiroAuthManager(
-            refresh_token="test_token",
-            region="us-east-1"
-        )
-        
+        manager = KiroAuthManager(refresh_token="test_token", region="us-east-1")
+
         print("Verification: _sso_region is None...")
         print(f"Comparing _sso_region: Expected None, Got '{manager._sso_region}'")
         assert manager._sso_region is None
-    
+
     @pytest.mark.asyncio
     async def test_oidc_refresh_uses_sso_region(self, mock_aws_sso_oidc_token_response):
         """
@@ -1329,26 +1431,26 @@ class TestKiroAuthManagerSsoRegionSeparation:
             refresh_token="test_refresh",
             client_id="test_client_id",
             client_secret="test_client_secret",
-            region="us-east-1"  # API region
+            region="us-east-1",  # API region
         )
         # Simulate SSO region loaded from SQLite
         manager._sso_region = "ap-southeast-1"
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: OIDC request went to SSO region (ap-southeast-1)...")
             call_args = mock_client.post.call_args
             url = call_args[0][0]
@@ -1357,9 +1459,11 @@ class TestKiroAuthManagerSsoRegionSeparation:
             assert url == expected_url
             assert "ap-southeast-1" in url
             assert "us-east-1" not in url
-    
+
     @pytest.mark.asyncio
-    async def test_oidc_refresh_falls_back_to_api_region_when_no_sso_region(self, mock_aws_sso_oidc_token_response):
+    async def test_oidc_refresh_falls_back_to_api_region_when_no_sso_region(
+        self, mock_aws_sso_oidc_token_response
+    ):
         """
         What it does: Verifies OIDC refresh uses API region when SSO region not set.
         Purpose: Ensure backward compatibility when _sso_region is None.
@@ -1369,53 +1473,53 @@ class TestKiroAuthManagerSsoRegionSeparation:
             refresh_token="test_refresh",
             client_id="test_client_id",
             client_secret="test_client_secret",
-            region="eu-west-1"  # API region (also used for OIDC when no SSO region)
+            region="eu-west-1",  # API region (also used for OIDC when no SSO region)
         )
         # Ensure _sso_region is None
         manager._sso_region = None
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: OIDC request fell back to API region (eu-west-1)...")
             call_args = mock_client.post.call_args
             url = call_args[0][0]
             expected_url = "https://oidc.eu-west-1.amazonaws.com/token"
             print(f"Comparing URL: Expected '{expected_url}', Got '{url}'")
             assert url == expected_url
-    
+
     def test_api_hosts_not_updated_when_loading_from_sqlite(self, temp_sqlite_db):
         """
         What it does: Verifies API hosts don't change when loading from SQLite.
         Purpose: Ensure all API calls go to us-east-1 where CodeWhisperer exists.
         """
-        print(f"Setup: Creating KiroAuthManager with SQLite (region=eu-west-1)...")
+        print("Setup: Creating KiroAuthManager with SQLite (region=eu-west-1)...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: _api_host points to us-east-1...")
         assert "us-east-1" in manager._api_host
         assert "eu-west-1" not in manager._api_host
-        
+
         print("Verification: _q_host points to us-east-1...")
         assert "us-east-1" in manager._q_host
         assert "eu-west-1" not in manager._q_host
-        
+
         print("Verification: _refresh_url points to us-east-1...")
         assert "us-east-1" in manager._refresh_url
         assert "eu-west-1" not in manager._refresh_url
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_uses_memory_token_first(
         self, mock_aws_sso_oidc_token_response
@@ -1428,37 +1532,37 @@ class TestKiroAuthManagerSsoRegionSeparation:
         manager = KiroAuthManager(
             refresh_token="memory_refresh_token",
             client_id="test_client_id",
-            client_secret="test_client_secret"
+            client_secret="test_client_secret",
         )
         # Simulate SQLite path being set (but we won't actually use it)
         manager._sqlite_db = "/fake/path/data.sqlite3"
-        
+
         print("Setup: Mocking HTTP client for successful refresh...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             # Patch _load_credentials_from_sqlite to track if it's called
-            with patch.object(manager, '_load_credentials_from_sqlite') as mock_load:
+            with patch.object(manager, "_load_credentials_from_sqlite") as mock_load:
                 await manager._refresh_token_aws_sso_oidc()
-                
+
                 print("Verification: SQLite was NOT reloaded (success on first try)...")
                 mock_load.assert_not_called()
-                
+
                 print("Verification: Request used in-memory token...")
                 call_args = mock_client.post.call_args
-                data = call_args[1].get('data', {})
+                data = call_args[1].get("data", {})
                 print(f"Refresh token sent: {data.get('refresh_token')}")
-                assert data.get('refresh_token') == "memory_refresh_token"
-    
+                assert data.get("refresh_token") == "memory_refresh_token"
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_reloads_sqlite_on_400_error(
         self, tmp_path, mock_aws_sso_oidc_token_response
@@ -1469,127 +1573,129 @@ class TestKiroAuthManagerSsoRegionSeparation:
         """
         import sqlite3
         import json
-        
+
         # Setup: Create initial SQLite database
         db_file = tmp_path / "data.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         # Initial token data (will become stale)
         initial_token_data = {
             "access_token": "old_access_token",
             "refresh_token": "old_refresh_token",
             "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:token", json.dumps(initial_token_data))
+            ("codewhisperer:odic:token", json.dumps(initial_token_data)),
         )
-        
+
         registration_data = {
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:device-registration", json.dumps(registration_data))
+            ("codewhisperer:odic:device-registration", json.dumps(registration_data)),
         )
-        
+
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager with SQLite...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Verification: Initial refresh_token loaded...")
         assert manager._refresh_token == "old_refresh_token"
-        
+
         # Simulate kiro-cli updating the SQLite with fresh tokens
         print("Action: Simulating kiro-cli token refresh (updating SQLite)...")
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         new_token_data = {
             "access_token": "new_access_token",
             "refresh_token": "new_refresh_token_from_kiro_cli",
             "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "UPDATE auth_kv SET value = ? WHERE key = ?",
-            (json.dumps(new_token_data), "codewhisperer:odic:token")
+            (json.dumps(new_token_data), "codewhisperer:odic:token"),
         )
         conn.commit()
         conn.close()
-        
+
         # Manager still has old token in memory
         print("Verification: Manager still has old refresh_token in memory...")
         assert manager._refresh_token == "old_refresh_token"
-        
+
         # Mock HTTP client: first call fails with 400, second succeeds
         print("Setup: Mocking HTTP client (first=400, second=200)...")
-        
+
         # First response: 400 error (stale token)
         mock_error_response = AsyncMock()
         mock_error_response.status_code = 400
-        mock_error_response.text = '{"error":"invalid_request","error_description":"Invalid request"}'
+        mock_error_response.text = (
+            '{"error":"invalid_request","error_description":"Invalid request"}'
+        )
         mock_error_response.json = Mock(return_value={"error": "invalid_request"})
         mock_error_response.raise_for_status = Mock(
             side_effect=httpx.HTTPStatusError(
-                "400 Bad Request",
-                request=Mock(),
-                response=mock_error_response
+                "400 Bad Request", request=Mock(), response=mock_error_response
             )
         )
-        
+
         # Second response: success
         mock_success_response = AsyncMock()
         mock_success_response.status_code = 200
-        mock_success_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
+        mock_success_response.json = Mock(
+            return_value=mock_aws_sso_oidc_token_response()
+        )
         mock_success_response.raise_for_status = Mock()
-        
+
         call_count = 0
         sent_tokens = []
-        
+
         async def mock_post(*args, **kwargs):
             nonlocal call_count
             call_count += 1
-            sent_tokens.append(kwargs.get('data', {}).get('refresh_token'))
+            sent_tokens.append(kwargs.get("data", {}).get("refresh_token"))
             if call_count == 1:
                 return mock_error_response
             return mock_success_response
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = mock_post
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling _refresh_token_aws_sso_oidc...")
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: Two requests were made (retry on 400)...")
             print(f"Call count: {call_count}")
             assert call_count == 2, "Should retry after 400 error"
-            
+
             print("Verification: First request used OLD token from memory...")
             print(f"First token sent: {sent_tokens[0]}")
             assert sent_tokens[0] == "old_refresh_token"
-            
+
             print("Verification: Second request used NEW token from SQLite...")
             print(f"Second token sent: {sent_tokens[1]}")
             assert sent_tokens[1] == "new_refresh_token_from_kiro_cli"
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_no_retry_on_non_400_error(
         self, mock_aws_sso_oidc_token_response
@@ -1602,10 +1708,10 @@ class TestKiroAuthManagerSsoRegionSeparation:
         manager = KiroAuthManager(
             refresh_token="test_refresh",
             client_id="test_client_id",
-            client_secret="test_client_secret"
+            client_secret="test_client_secret",
         )
         manager._sqlite_db = "/fake/path/data.sqlite3"
-        
+
         print("Setup: Mocking HTTP client with 500 error...")
         mock_error_response = AsyncMock()
         mock_error_response.status_code = 500
@@ -1615,28 +1721,30 @@ class TestKiroAuthManagerSsoRegionSeparation:
             side_effect=httpx.HTTPStatusError(
                 "500 Internal Server Error",
                 request=Mock(),
-                response=mock_error_response
+                response=mock_error_response,
             )
         )
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_error_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
-            with patch.object(manager, '_load_credentials_from_sqlite') as mock_load:
-                print("Action: Calling _refresh_token_aws_sso_oidc (expecting 500 error)...")
+
+            with patch.object(manager, "_load_credentials_from_sqlite") as mock_load:
+                print(
+                    "Action: Calling _refresh_token_aws_sso_oidc (expecting 500 error)..."
+                )
                 with pytest.raises(httpx.HTTPStatusError) as exc_info:
                     await manager._refresh_token_aws_sso_oidc()
-                
+
                 print("Verification: 500 error was raised (not retried)...")
                 assert exc_info.value.response.status_code == 500
-                
+
                 print("Verification: SQLite was NOT reloaded (500 != 400)...")
                 mock_load.assert_not_called()
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_no_retry_without_sqlite_db(
         self, mock_aws_sso_oidc_token_response
@@ -1649,11 +1757,11 @@ class TestKiroAuthManagerSsoRegionSeparation:
         manager = KiroAuthManager(
             refresh_token="test_refresh",
             client_id="test_client_id",
-            client_secret="test_client_secret"
+            client_secret="test_client_secret",
         )
         # Explicitly ensure no sqlite_db
         manager._sqlite_db = None
-        
+
         print("Setup: Mocking HTTP client with 400 error...")
         mock_error_response = AsyncMock()
         mock_error_response.status_code = 400
@@ -1661,26 +1769,26 @@ class TestKiroAuthManagerSsoRegionSeparation:
         mock_error_response.json = Mock(return_value={"error": "invalid_request"})
         mock_error_response.raise_for_status = Mock(
             side_effect=httpx.HTTPStatusError(
-                "400 Bad Request",
-                request=Mock(),
-                response=mock_error_response
+                "400 Bad Request", request=Mock(), response=mock_error_response
             )
         )
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_error_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
-            print("Action: Calling _refresh_token_aws_sso_oidc (expecting 400 error)...")
+
+            print(
+                "Action: Calling _refresh_token_aws_sso_oidc (expecting 400 error)..."
+            )
             with pytest.raises(httpx.HTTPStatusError) as exc_info:
                 await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: 400 error was raised (no retry without sqlite_db)...")
             assert exc_info.value.response.status_code == 400
-            
+
             print("Verification: Only one request was made...")
             assert mock_client.post.call_count == 1
 
@@ -1689,13 +1797,14 @@ class TestKiroAuthManagerSsoRegionSeparation:
 # Tests for is_token_expired() method
 # =============================================================================
 
+
 class TestKiroAuthManagerIsTokenExpired:
     """Tests for is_token_expired() method.
-    
+
     This method checks if the token has actually expired (not just expiring soon).
     Used for graceful degradation when refresh fails.
     """
-    
+
     def test_is_token_expired_returns_true_when_no_expires_at(self):
         """
         What it does: Verifies that without expires_at token is considered expired.
@@ -1704,12 +1813,12 @@ class TestKiroAuthManagerIsTokenExpired:
         print("Setup: Creating KiroAuthManager without expires_at...")
         manager = KiroAuthManager(refresh_token="test_token")
         manager._expires_at = None
-        
+
         print("Verification: is_token_expired returns True...")
         result = manager.is_token_expired()
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     def test_is_token_expired_returns_true_when_expired(self):
         """
         What it does: Verifies that expired token is correctly identified.
@@ -1718,12 +1827,12 @@ class TestKiroAuthManagerIsTokenExpired:
         print("Setup: Creating KiroAuthManager with expired token...")
         manager = KiroAuthManager(refresh_token="test_token")
         manager._expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
-        
+
         print("Verification: is_token_expired returns True for expired token...")
         result = manager.is_token_expired()
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     def test_is_token_expired_returns_false_when_valid(self):
         """
         What it does: Verifies that valid token is not considered expired.
@@ -1732,12 +1841,12 @@ class TestKiroAuthManagerIsTokenExpired:
         print("Setup: Creating KiroAuthManager with valid token...")
         manager = KiroAuthManager(refresh_token="test_token")
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        
+
         print("Verification: is_token_expired returns False...")
         result = manager.is_token_expired()
         print(f"Comparing result: Expected False, Got {result}")
         assert result is False
-    
+
     def test_is_token_expired_returns_false_when_expiring_soon_but_not_expired(self):
         """
         What it does: Verifies difference between expiring soon and actually expired.
@@ -1746,10 +1855,10 @@ class TestKiroAuthManagerIsTokenExpired:
         print("Setup: Creating KiroAuthManager with token expiring in 5 minutes...")
         manager = KiroAuthManager(refresh_token="test_token")
         manager._expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
-        
+
         print("Verification: is_token_expiring_soon returns True (within threshold)...")
         assert manager.is_token_expiring_soon() is True
-        
+
         print("Verification: is_token_expired returns False (not actually expired)...")
         result = manager.is_token_expired()
         print(f"Comparing result: Expected False, Got {result}")
@@ -1760,14 +1869,15 @@ class TestKiroAuthManagerIsTokenExpired:
 # Tests for graceful degradation in get_access_token() (SQLite mode)
 # =============================================================================
 
+
 class TestKiroAuthManagerGracefulDegradation:
     """Tests for graceful degradation when refresh fails in SQLite mode.
-    
+
     Background: When kiro-cli refreshes tokens in memory without persisting to SQLite,
     the refresh_token in SQLite becomes stale. The gateway should gracefully fall back
     to using the access_token directly until it actually expires.
     """
-    
+
     @pytest.mark.asyncio
     async def test_get_access_token_reloads_sqlite_when_expiring_soon(self, tmp_path):
         """
@@ -1776,59 +1886,59 @@ class TestKiroAuthManagerGracefulDegradation:
         """
         import sqlite3
         import json
-        
+
         print("Setup: Creating SQLite database with fresh token...")
         db_file = tmp_path / "data.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         # Token that expires in 1 hour (fresh)
         fresh_token_data = {
             "access_token": "fresh_access_token",
             "refresh_token": "fresh_refresh_token",
             "expires_at": (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:token", json.dumps(fresh_token_data))
+            ("codewhisperer:odic:token", json.dumps(fresh_token_data)),
         )
-        
+
         registration_data = {
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:device-registration", json.dumps(registration_data))
+            ("codewhisperer:odic:device-registration", json.dumps(registration_data)),
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager with expiring token...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
         # Simulate token expiring soon (within threshold)
         manager._access_token = "old_expiring_token"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
-        
+
         print("Verification: Token is expiring soon...")
         assert manager.is_token_expiring_soon() is True
-        
+
         print("Action: Calling get_access_token()...")
         token = await manager.get_access_token()
-        
+
         print("Verification: Got fresh token from SQLite reload...")
         print(f"Comparing token: Expected 'fresh_access_token', Got '{token}'")
         assert token == "fresh_access_token"
-    
+
     @pytest.mark.asyncio
     async def test_get_access_token_graceful_fallback_when_refresh_fails_but_token_valid(
         self, tmp_path
@@ -1839,50 +1949,52 @@ class TestKiroAuthManagerGracefulDegradation:
         """
         import sqlite3
         import json
-        
+
         print("Setup: Creating SQLite database...")
         db_file = tmp_path / "data.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         # Token that is expiring soon but NOT expired yet
         token_data = {
             "access_token": "still_valid_access_token",
             "refresh_token": "stale_refresh_token",
-            "expires_at": (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat(),
-            "region": "us-east-1"
+            "expires_at": (
+                datetime.now(timezone.utc) + timedelta(minutes=5)
+            ).isoformat(),
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:token", json.dumps(token_data))
+            ("codewhisperer:odic:token", json.dumps(token_data)),
         )
-        
+
         registration_data = {
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:device-registration", json.dumps(registration_data))
+            ("codewhisperer:odic:device-registration", json.dumps(registration_data)),
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Verification: Token is expiring soon but NOT expired...")
         assert manager.is_token_expiring_soon() is True
         assert manager.is_token_expired() is False
-        
+
         print("Setup: Mocking HTTP client to return 400 twice (stale refresh token)...")
         mock_error_response = AsyncMock()
         mock_error_response.status_code = 400
@@ -1890,26 +2002,26 @@ class TestKiroAuthManagerGracefulDegradation:
         mock_error_response.json = Mock(return_value={"error": "invalid_request"})
         mock_error_response.raise_for_status = Mock(
             side_effect=httpx.HTTPStatusError(
-                "400 Bad Request",
-                request=Mock(),
-                response=mock_error_response
+                "400 Bad Request", request=Mock(), response=mock_error_response
             )
         )
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_error_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling get_access_token() (expecting graceful fallback)...")
             token = await manager.get_access_token()
-            
+
             print("Verification: Got existing access_token (graceful fallback)...")
-            print(f"Comparing token: Expected 'still_valid_access_token', Got '{token}'")
+            print(
+                f"Comparing token: Expected 'still_valid_access_token', Got '{token}'"
+            )
             assert token == "still_valid_access_token"
-    
+
     @pytest.mark.asyncio
     async def test_get_access_token_raises_when_refresh_fails_and_token_expired(
         self, tmp_path
@@ -1920,49 +2032,49 @@ class TestKiroAuthManagerGracefulDegradation:
         """
         import sqlite3
         import json
-        
+
         print("Setup: Creating SQLite database with expired token...")
         db_file = tmp_path / "data.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         # Token that is already expired
         token_data = {
             "access_token": "expired_access_token",
             "refresh_token": "stale_refresh_token",
             "expires_at": (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:token", json.dumps(token_data))
+            ("codewhisperer:odic:token", json.dumps(token_data)),
         )
-        
+
         registration_data = {
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:device-registration", json.dumps(registration_data))
+            ("codewhisperer:odic:device-registration", json.dumps(registration_data)),
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Verification: Token is expired...")
         assert manager.is_token_expired() is True
-        
+
         print("Setup: Mocking HTTP client to return 400 (stale refresh token)...")
         mock_error_response = AsyncMock()
         mock_error_response.status_code = 400
@@ -1970,26 +2082,26 @@ class TestKiroAuthManagerGracefulDegradation:
         mock_error_response.json = Mock(return_value={"error": "invalid_request"})
         mock_error_response.raise_for_status = Mock(
             side_effect=httpx.HTTPStatusError(
-                "400 Bad Request",
-                request=Mock(),
-                response=mock_error_response
+                "400 Bad Request", request=Mock(), response=mock_error_response
             )
         )
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_error_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling get_access_token() (expecting ValueError)...")
             with pytest.raises(ValueError) as exc_info:
                 await manager.get_access_token()
-            
-            print(f"Verification: ValueError raised with helpful message: {exc_info.value}")
+
+            print(
+                f"Verification: ValueError raised with helpful message: {exc_info.value}"
+            )
             assert "kiro-cli login" in str(exc_info.value).lower()
-    
+
     @pytest.mark.asyncio
     async def test_get_access_token_non_sqlite_mode_propagates_400_error(self):
         """
@@ -2000,14 +2112,14 @@ class TestKiroAuthManagerGracefulDegradation:
         manager = KiroAuthManager(
             refresh_token="test_refresh",
             client_id="test_client_id",
-            client_secret="test_client_secret"
+            client_secret="test_client_secret",
         )
         manager._access_token = "expiring_token"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
-        
+
         print("Verification: No sqlite_db set...")
         assert manager._sqlite_db is None
-        
+
         print("Setup: Mocking HTTP client to return 400...")
         mock_error_response = AsyncMock()
         mock_error_response.status_code = 400
@@ -2015,22 +2127,20 @@ class TestKiroAuthManagerGracefulDegradation:
         mock_error_response.json = Mock(return_value={"error": "invalid_request"})
         mock_error_response.raise_for_status = Mock(
             side_effect=httpx.HTTPStatusError(
-                "400 Bad Request",
-                request=Mock(),
-                response=mock_error_response
+                "400 Bad Request", request=Mock(), response=mock_error_response
             )
         )
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_error_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling get_access_token() (expecting HTTPStatusError)...")
             with pytest.raises(httpx.HTTPStatusError) as exc_info:
                 await manager.get_access_token()
-            
+
             print("Verification: 400 error was propagated (no graceful degradation)...")
             assert exc_info.value.response.status_code == 400

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -15,7 +15,7 @@ from kiro.config import DEFAULT_MAX_INPUT_TOKENS
 
 class TestModelInfoCacheInitialization:
     """Тесты инициализации ModelInfoCache."""
-    
+
     def test_initialization_creates_empty_cache(self):
         """
         Что он делает: Проверяет, что кэш создаётся пустым.
@@ -23,14 +23,14 @@ class TestModelInfoCacheInitialization:
         """
         print("Настройка: Создание ModelInfoCache...")
         cache = ModelInfoCache()
-        
+
         print("Проверка: Кэш пуст при создании...")
         print(f"Сравниваем is_empty(): Ожидалось True, Получено {cache.is_empty()}")
         assert cache.is_empty() is True
-        
+
         print(f"Сравниваем size: Ожидалось 0, Получено {cache.size}")
         assert cache.size == 0
-    
+
     def test_initialization_with_custom_ttl(self):
         """
         Что он делает: Проверяет создание кэша с кастомным TTL.
@@ -38,11 +38,11 @@ class TestModelInfoCacheInitialization:
         """
         print("Настройка: Создание ModelInfoCache с TTL=7200...")
         cache = ModelInfoCache(cache_ttl=7200)
-        
+
         print("Проверка: TTL установлен корректно...")
         print(f"Сравниваем _cache_ttl: Ожидалось 7200, Получено {cache._cache_ttl}")
         assert cache._cache_ttl == 7200
-    
+
     def test_initialization_last_update_is_none(self):
         """
         Что он делает: Проверяет, что last_update_time изначально None.
@@ -50,15 +50,17 @@ class TestModelInfoCacheInitialization:
         """
         print("Настройка: Создание ModelInfoCache...")
         cache = ModelInfoCache()
-        
+
         print("Проверка: last_update_time изначально None...")
-        print(f"Сравниваем last_update_time: Ожидалось None, Получено {cache.last_update_time}")
+        print(
+            f"Сравниваем last_update_time: Ожидалось None, Получено {cache.last_update_time}"
+        )
         assert cache.last_update_time is None
 
 
 class TestModelInfoCacheUpdate:
     """Тесты обновления кэша."""
-    
+
     @pytest.mark.asyncio
     async def test_update_populates_cache(self, sample_models_data):
         """
@@ -67,17 +69,19 @@ class TestModelInfoCacheUpdate:
         """
         print("Настройка: Создание ModelInfoCache...")
         cache = ModelInfoCache()
-        
+
         print(f"Действие: Обновление кэша с {len(sample_models_data)} моделями...")
         await cache.update(sample_models_data)
-        
+
         print("Проверка: Кэш заполнен...")
         print(f"Сравниваем is_empty(): Ожидалось False, Получено {cache.is_empty()}")
         assert cache.is_empty() is False
-        
-        print(f"Сравниваем size: Ожидалось {len(sample_models_data)}, Получено {cache.size}")
+
+        print(
+            f"Сравниваем size: Ожидалось {len(sample_models_data)}, Получено {cache.size}"
+        )
         assert cache.size == len(sample_models_data)
-    
+
     @pytest.mark.asyncio
     async def test_update_sets_last_update_time(self, sample_models_data):
         """
@@ -86,17 +90,17 @@ class TestModelInfoCacheUpdate:
         """
         print("Настройка: Создание ModelInfoCache...")
         cache = ModelInfoCache()
-        
+
         before_update = time.time()
         print(f"Действие: Обновление кэша (время до: {before_update})...")
         await cache.update(sample_models_data)
         after_update = time.time()
-        
+
         print("Проверка: last_update_time установлен в разумных пределах...")
         print(f"last_update_time: {cache.last_update_time}")
         assert cache.last_update_time is not None
         assert before_update <= cache.last_update_time <= after_update
-    
+
     @pytest.mark.asyncio
     async def test_update_replaces_existing_data(self, sample_models_data):
         """
@@ -106,21 +110,21 @@ class TestModelInfoCacheUpdate:
         print("Настройка: Создание ModelInfoCache и первое обновление...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Действие: Обновление с новыми данными...")
         new_data = [{"modelId": "new-model", "tokenLimits": {"maxInputTokens": 50000}}]
         await cache.update(new_data)
-        
+
         print("Проверка: Старые данные заменены...")
         print(f"Сравниваем size: Ожидалось 1, Получено {cache.size}")
         assert cache.size == 1
-        
+
         print("Проверка: Старая модель недоступна...")
         assert cache.get("claude-sonnet-4") is None
-        
+
         print("Проверка: Новая модель доступна...")
         assert cache.get("new-model") is not None
-    
+
     @pytest.mark.asyncio
     async def test_update_with_empty_list(self):
         """
@@ -130,10 +134,10 @@ class TestModelInfoCacheUpdate:
         print("Настройка: Создание ModelInfoCache с данными...")
         cache = ModelInfoCache()
         await cache.update([{"modelId": "test-model"}])
-        
+
         print("Действие: Обновление пустым списком...")
         await cache.update([])
-        
+
         print("Проверка: Кэш пуст...")
         print(f"Сравниваем is_empty(): Ожидалось True, Получено {cache.is_empty()}")
         assert cache.is_empty() is True
@@ -141,7 +145,7 @@ class TestModelInfoCacheUpdate:
 
 class TestModelInfoCacheGet:
     """Тесты получения данных из кэша."""
-    
+
     @pytest.mark.asyncio
     async def test_get_returns_model_info(self, sample_models_data):
         """
@@ -151,15 +155,15 @@ class TestModelInfoCacheGet:
         print("Настройка: Создание и заполнение кэша...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Действие: Получение информации о claude-sonnet-4...")
         model_info = cache.get("claude-sonnet-4")
-        
+
         print("Проверка: Информация получена...")
         print(f"model_info: {model_info}")
         assert model_info is not None
         assert model_info["modelId"] == "claude-sonnet-4"
-    
+
     @pytest.mark.asyncio
     async def test_get_returns_none_for_unknown_model(self, sample_models_data):
         """
@@ -169,14 +173,14 @@ class TestModelInfoCacheGet:
         print("Настройка: Создание и заполнение кэша...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Действие: Получение информации о несуществующей модели...")
         model_info = cache.get("non-existent-model")
-        
+
         print("Проверка: Возвращён None...")
         print(f"Сравниваем model_info: Ожидалось None, Получено {model_info}")
         assert model_info is None
-    
+
     def test_get_from_empty_cache(self):
         """
         Что он делает: Проверяет get() из пустого кэша.
@@ -184,10 +188,10 @@ class TestModelInfoCacheGet:
         """
         print("Настройка: Создание пустого кэша...")
         cache = ModelInfoCache()
-        
+
         print("Действие: Получение из пустого кэша...")
         model_info = cache.get("any-model")
-        
+
         print("Проверка: Возвращён None...")
         print(f"Сравниваем model_info: Ожидалось None, Получено {model_info}")
         assert model_info is None
@@ -195,7 +199,7 @@ class TestModelInfoCacheGet:
 
 class TestModelInfoCacheGetMaxInputTokens:
     """Тесты получения maxInputTokens."""
-    
+
     @pytest.mark.asyncio
     async def test_get_max_input_tokens_returns_value(self, sample_models_data):
         """
@@ -205,16 +209,18 @@ class TestModelInfoCacheGetMaxInputTokens:
         print("Настройка: Создание и заполнение кэша...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Действие: Получение maxInputTokens для claude-sonnet-4...")
         max_tokens = cache.get_max_input_tokens("claude-sonnet-4")
-        
+
         print("Проверка: Значение корректно...")
         print(f"Сравниваем max_tokens: Ожидалось 200000, Получено {max_tokens}")
         assert max_tokens == 200000
-    
+
     @pytest.mark.asyncio
-    async def test_get_max_input_tokens_returns_default_for_unknown(self, sample_models_data):
+    async def test_get_max_input_tokens_returns_default_for_unknown(
+        self, sample_models_data
+    ):
         """
         Что он делает: Проверяет возврат дефолта для неизвестной модели.
         Цель: Убедиться, что возвращается DEFAULT_MAX_INPUT_TOKENS.
@@ -222,14 +228,16 @@ class TestModelInfoCacheGetMaxInputTokens:
         print("Настройка: Создание и заполнение кэша...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Действие: Получение maxInputTokens для неизвестной модели...")
         max_tokens = cache.get_max_input_tokens("unknown-model")
-        
+
         print("Проверка: Возвращён дефолт...")
-        print(f"Сравниваем max_tokens: Ожидалось {DEFAULT_MAX_INPUT_TOKENS}, Получено {max_tokens}")
+        print(
+            f"Сравниваем max_tokens: Ожидалось {DEFAULT_MAX_INPUT_TOKENS}, Получено {max_tokens}"
+        )
         assert max_tokens == DEFAULT_MAX_INPUT_TOKENS
-    
+
     @pytest.mark.asyncio
     async def test_get_max_input_tokens_returns_default_when_no_token_limits(self):
         """
@@ -239,14 +247,16 @@ class TestModelInfoCacheGetMaxInputTokens:
         print("Настройка: Создание кэша с моделью без tokenLimits...")
         cache = ModelInfoCache()
         await cache.update([{"modelId": "model-without-limits"}])
-        
+
         print("Действие: Получение maxInputTokens...")
         max_tokens = cache.get_max_input_tokens("model-without-limits")
-        
+
         print("Проверка: Возвращён дефолт...")
-        print(f"Сравниваем max_tokens: Ожидалось {DEFAULT_MAX_INPUT_TOKENS}, Получено {max_tokens}")
+        print(
+            f"Сравниваем max_tokens: Ожидалось {DEFAULT_MAX_INPUT_TOKENS}, Получено {max_tokens}"
+        )
         assert max_tokens == DEFAULT_MAX_INPUT_TOKENS
-    
+
     @pytest.mark.asyncio
     async def test_get_max_input_tokens_returns_default_when_max_input_is_none(self):
         """
@@ -255,22 +265,23 @@ class TestModelInfoCacheGetMaxInputTokens:
         """
         print("Настройка: Создание кэша с моделью с maxInputTokens=None...")
         cache = ModelInfoCache()
-        await cache.update([{
-            "modelId": "model-with-null",
-            "tokenLimits": {"maxInputTokens": None}
-        }])
-        
+        await cache.update(
+            [{"modelId": "model-with-null", "tokenLimits": {"maxInputTokens": None}}]
+        )
+
         print("Действие: Получение maxInputTokens...")
         max_tokens = cache.get_max_input_tokens("model-with-null")
-        
+
         print("Проверка: Возвращён дефолт...")
-        print(f"Сравниваем max_tokens: Ожидалось {DEFAULT_MAX_INPUT_TOKENS}, Получено {max_tokens}")
+        print(
+            f"Сравниваем max_tokens: Ожидалось {DEFAULT_MAX_INPUT_TOKENS}, Получено {max_tokens}"
+        )
         assert max_tokens == DEFAULT_MAX_INPUT_TOKENS
 
 
 class TestModelInfoCacheIsEmpty:
     """Тесты проверки пустоты кэша."""
-    
+
     def test_is_empty_returns_true_for_new_cache(self):
         """
         Что он делает: Проверяет is_empty() для нового кэша.
@@ -278,11 +289,11 @@ class TestModelInfoCacheIsEmpty:
         """
         print("Настройка: Создание нового кэша...")
         cache = ModelInfoCache()
-        
+
         print("Проверка: is_empty() возвращает True...")
         print(f"Сравниваем is_empty(): Ожидалось True, Получено {cache.is_empty()}")
         assert cache.is_empty() is True
-    
+
     @pytest.mark.asyncio
     async def test_is_empty_returns_false_after_update(self, sample_models_data):
         """
@@ -292,7 +303,7 @@ class TestModelInfoCacheIsEmpty:
         print("Настройка: Создание и заполнение кэша...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Проверка: is_empty() возвращает False...")
         print(f"Сравниваем is_empty(): Ожидалось False, Получено {cache.is_empty()}")
         assert cache.is_empty() is False
@@ -300,7 +311,7 @@ class TestModelInfoCacheIsEmpty:
 
 class TestModelInfoCacheIsStale:
     """Тесты проверки устаревания кэша."""
-    
+
     def test_is_stale_returns_true_for_new_cache(self):
         """
         Что он делает: Проверяет is_stale() для нового кэша.
@@ -308,11 +319,11 @@ class TestModelInfoCacheIsStale:
         """
         print("Настройка: Создание нового кэша...")
         cache = ModelInfoCache()
-        
+
         print("Проверка: is_stale() возвращает True...")
         print(f"Сравниваем is_stale(): Ожидалось True, Получено {cache.is_stale()}")
         assert cache.is_stale() is True
-    
+
     @pytest.mark.asyncio
     async def test_is_stale_returns_false_after_recent_update(self, sample_models_data):
         """
@@ -322,11 +333,11 @@ class TestModelInfoCacheIsStale:
         print("Настройка: Создание и заполнение кэша...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Проверка: is_stale() возвращает False...")
         print(f"Сравниваем is_stale(): Ожидалось False, Получено {cache.is_stale()}")
         assert cache.is_stale() is False
-    
+
     @pytest.mark.asyncio
     async def test_is_stale_returns_true_after_ttl_expires(self, sample_models_data):
         """
@@ -336,10 +347,10 @@ class TestModelInfoCacheIsStale:
         print("Настройка: Создание кэша с TTL=0.1 секунды...")
         cache = ModelInfoCache(cache_ttl=0.1)
         await cache.update(sample_models_data)
-        
+
         print("Действие: Ожидание истечения TTL...")
         await asyncio.sleep(0.2)
-        
+
         print("Проверка: is_stale() возвращает True...")
         print(f"Сравниваем is_stale(): Ожидалось True, Получено {cache.is_stale()}")
         assert cache.is_stale() is True
@@ -347,7 +358,7 @@ class TestModelInfoCacheIsStale:
 
 class TestModelInfoCacheGetAllModelIds:
     """Тесты получения списка ID моделей."""
-    
+
     def test_get_all_model_ids_returns_empty_for_new_cache(self):
         """
         Что он делает: Проверяет get_all_model_ids() для пустого кэша.
@@ -355,14 +366,14 @@ class TestModelInfoCacheGetAllModelIds:
         """
         print("Настройка: Создание пустого кэша...")
         cache = ModelInfoCache()
-        
+
         print("Действие: Получение списка ID моделей...")
         model_ids = cache.get_all_model_ids()
-        
+
         print("Проверка: Список пуст...")
         print(f"Сравниваем model_ids: Ожидалось [], Получено {model_ids}")
         assert model_ids == []
-    
+
     @pytest.mark.asyncio
     async def test_get_all_model_ids_returns_all_ids(self, sample_models_data):
         """
@@ -372,10 +383,10 @@ class TestModelInfoCacheGetAllModelIds:
         print("Настройка: Создание и заполнение кэша...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Действие: Получение списка ID моделей...")
         model_ids = cache.get_all_model_ids()
-        
+
         print("Проверка: Все ID присутствуют...")
         expected_ids = [m["modelId"] for m in sample_models_data]
         print(f"Сравниваем model_ids: Ожидалось {expected_ids}, Получено {model_ids}")
@@ -384,7 +395,7 @@ class TestModelInfoCacheGetAllModelIds:
 
 class TestModelInfoCacheThreadSafety:
     """Тесты потокобезопасности кэша."""
-    
+
     @pytest.mark.asyncio
     async def test_concurrent_updates_dont_corrupt_cache(self, sample_models_data):
         """
@@ -393,29 +404,31 @@ class TestModelInfoCacheThreadSafety:
         """
         print("Настройка: Создание кэша...")
         cache = ModelInfoCache()
-        
+
         async def update_with_data(data):
             await cache.update(data)
-        
+
         print("Действие: 10 параллельных обновлений...")
         tasks = []
         for i in range(10):
-            data = [{"modelId": f"model-{i}", "tokenLimits": {"maxInputTokens": 100000 + i}}]
+            data = [
+                {"modelId": f"model-{i}", "tokenLimits": {"maxInputTokens": 100000 + i}}
+            ]
             tasks.append(update_with_data(data))
-        
+
         await asyncio.gather(*tasks)
-        
+
         print("Проверка: Кэш содержит данные последнего обновления...")
         # Из-за race condition, мы не знаем какое обновление было последним,
         # но кэш должен содержать ровно одну модель
         print(f"Сравниваем size: Ожидалось 1, Получено {cache.size}")
         assert cache.size == 1
-        
+
         print("Проверка: Кэш не повреждён...")
         model_ids = cache.get_all_model_ids()
         assert len(model_ids) == 1
         assert model_ids[0].startswith("model-")
-    
+
     @pytest.mark.asyncio
     async def test_concurrent_reads_are_safe(self, sample_models_data):
         """
@@ -425,13 +438,14 @@ class TestModelInfoCacheThreadSafety:
         print("Настройка: Создание и заполнение кэша...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Действие: 100 параллельных чтений...")
+
         async def read_model():
             return cache.get("claude-sonnet-4")
-        
+
         results = await asyncio.gather(*[read_model() for _ in range(100)])
-        
+
         print("Проверка: Все чтения вернули одинаковый результат...")
         assert all(r is not None for r in results)
         assert all(r["modelId"] == "claude-sonnet-4" for r in results)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,286 +5,307 @@ Unit tests for the configuration module.
 Verifies loading settings from environment variables.
 """
 
-import pytest
 import os
 from unittest.mock import patch
 
 
 class TestLogLevelConfig:
     """Tests for LOG_LEVEL configuration."""
-    
+
     def test_default_log_level_is_info(self):
         """
         What it does: Verifies that LOG_LEVEL defaults to INFO.
         Purpose: Ensure that INFO is used when no environment variable is set.
-        
+
         Note: This test verifies the config.py code logic, not the actual
         value from the .env file. We mock os.getenv to simulate
         the absence of the environment variable.
         """
         print("Setup: Mocking os.getenv for LOG_LEVEL...")
-        
+
         # Create a mock that returns None for LOG_LEVEL (simulating missing variable)
         original_getenv = os.getenv
-        
+
         def mock_getenv(key, default=None):
             if key == "LOG_LEVEL":
                 print(f"os.getenv('{key}') -> None (mocked)")
                 return default  # Return default, simulating missing variable
             return original_getenv(key, default)
-        
-        with patch.object(os, 'getenv', side_effect=mock_getenv):
+
+        with patch.object(os, "getenv", side_effect=mock_getenv):
             # Reload config module with mocked getenv
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             print(f"Comparing: Expected 'INFO', Got '{config_module.LOG_LEVEL}'")
             assert config_module.LOG_LEVEL == "INFO"
-        
+
         # Restore module with real values
         import importlib
         import kiro.config as config_module
+
         importlib.reload(config_module)
-    
+
     def test_log_level_from_environment(self):
         """
         What it does: Verifies loading LOG_LEVEL from environment variable.
         Purpose: Ensure that the value from environment is used.
         """
         print("Setup: Setting LOG_LEVEL=DEBUG...")
-        
+
         with patch.dict(os.environ, {"LOG_LEVEL": "DEBUG"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             print(f"Comparing: Expected 'DEBUG', Got '{config_module.LOG_LEVEL}'")
             assert config_module.LOG_LEVEL == "DEBUG"
-    
+
     def test_log_level_uppercase_conversion(self):
         """
         What it does: Verifies LOG_LEVEL conversion to uppercase.
         Purpose: Ensure that lowercase value is converted to uppercase.
         """
         print("Setup: Setting LOG_LEVEL=warning (lowercase)...")
-        
+
         with patch.dict(os.environ, {"LOG_LEVEL": "warning"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             print(f"Comparing: Expected 'WARNING', Got '{config_module.LOG_LEVEL}'")
             assert config_module.LOG_LEVEL == "WARNING"
-    
+
     def test_log_level_trace(self):
         """
         What it does: Verifies setting LOG_LEVEL=TRACE.
         Purpose: Ensure that TRACE level is supported.
         """
         print("Setup: Setting LOG_LEVEL=TRACE...")
-        
+
         with patch.dict(os.environ, {"LOG_LEVEL": "TRACE"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             assert config_module.LOG_LEVEL == "TRACE"
-    
+
     def test_log_level_error(self):
         """
         What it does: Verifies setting LOG_LEVEL=ERROR.
         Purpose: Ensure that ERROR level is supported.
         """
         print("Setup: Setting LOG_LEVEL=ERROR...")
-        
+
         with patch.dict(os.environ, {"LOG_LEVEL": "ERROR"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             assert config_module.LOG_LEVEL == "ERROR"
-    
+
     def test_log_level_critical(self):
         """
         What it does: Verifies setting LOG_LEVEL=CRITICAL.
         Purpose: Ensure that CRITICAL level is supported.
         """
         print("Setup: Setting LOG_LEVEL=CRITICAL...")
-        
+
         with patch.dict(os.environ, {"LOG_LEVEL": "CRITICAL"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             assert config_module.LOG_LEVEL == "CRITICAL"
 
 
 class TestToolDescriptionMaxLengthConfig:
     """Tests for TOOL_DESCRIPTION_MAX_LENGTH configuration."""
-    
+
     def test_default_tool_description_max_length(self):
         """
         What it does: Verifies the default value for TOOL_DESCRIPTION_MAX_LENGTH.
         Purpose: Ensure that 10000 is used by default.
         """
         print("Setup: Removing TOOL_DESCRIPTION_MAX_LENGTH from environment...")
-        
+
         with patch.dict(os.environ, {}, clear=False):
             if "TOOL_DESCRIPTION_MAX_LENGTH" in os.environ:
                 del os.environ["TOOL_DESCRIPTION_MAX_LENGTH"]
-            
+
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
-            print(f"TOOL_DESCRIPTION_MAX_LENGTH: {config_module.TOOL_DESCRIPTION_MAX_LENGTH}")
+
+            print(
+                f"TOOL_DESCRIPTION_MAX_LENGTH: {config_module.TOOL_DESCRIPTION_MAX_LENGTH}"
+            )
             assert config_module.TOOL_DESCRIPTION_MAX_LENGTH == 10000
-    
+
     def test_tool_description_max_length_from_environment(self):
         """
         What it does: Verifies loading TOOL_DESCRIPTION_MAX_LENGTH from environment.
         Purpose: Ensure that the value from environment is used.
         """
         print("Setup: Setting TOOL_DESCRIPTION_MAX_LENGTH=5000...")
-        
+
         with patch.dict(os.environ, {"TOOL_DESCRIPTION_MAX_LENGTH": "5000"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
-            print(f"TOOL_DESCRIPTION_MAX_LENGTH: {config_module.TOOL_DESCRIPTION_MAX_LENGTH}")
+
+            print(
+                f"TOOL_DESCRIPTION_MAX_LENGTH: {config_module.TOOL_DESCRIPTION_MAX_LENGTH}"
+            )
             assert config_module.TOOL_DESCRIPTION_MAX_LENGTH == 5000
-    
+
     def test_tool_description_max_length_zero_disables(self):
         """
         What it does: Verifies that 0 disables the feature.
         Purpose: Ensure that TOOL_DESCRIPTION_MAX_LENGTH=0 works.
         """
         print("Setup: Setting TOOL_DESCRIPTION_MAX_LENGTH=0...")
-        
+
         with patch.dict(os.environ, {"TOOL_DESCRIPTION_MAX_LENGTH": "0"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
-            print(f"TOOL_DESCRIPTION_MAX_LENGTH: {config_module.TOOL_DESCRIPTION_MAX_LENGTH}")
+
+            print(
+                f"TOOL_DESCRIPTION_MAX_LENGTH: {config_module.TOOL_DESCRIPTION_MAX_LENGTH}"
+            )
             assert config_module.TOOL_DESCRIPTION_MAX_LENGTH == 0
 
 
 class TestTimeoutConfigurationWarning:
     """Tests for _warn_timeout_configuration() function."""
-    
+
     def test_no_warning_when_first_token_less_than_streaming(self, capsys):
         """
         What it does: Verifies that warning is NOT shown with correct configuration.
         Purpose: Ensure that no warning when FIRST_TOKEN_TIMEOUT < STREAMING_READ_TIMEOUT.
         """
         print("Setup: FIRST_TOKEN_TIMEOUT=15, STREAMING_READ_TIMEOUT=300...")
-        
-        with patch.dict(os.environ, {
-            "FIRST_TOKEN_TIMEOUT": "15",
-            "STREAMING_READ_TIMEOUT": "300"
-        }):
+
+        with patch.dict(
+            os.environ, {"FIRST_TOKEN_TIMEOUT": "15", "STREAMING_READ_TIMEOUT": "300"}
+        ):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             # Call the warning function
             config_module._warn_timeout_configuration()
-            
+
             captured = capsys.readouterr()
             print(f"Captured stderr: {captured.err}")
-            
+
             # Warning should NOT be shown
             assert "WARNING" not in captured.err
             assert "Suboptimal timeout configuration" not in captured.err
-    
+
     def test_warning_when_first_token_equals_streaming(self, capsys):
         """
         What it does: Verifies that warning is shown when timeouts are equal.
         Purpose: Ensure that warning when FIRST_TOKEN_TIMEOUT == STREAMING_READ_TIMEOUT.
         """
         print("Setup: FIRST_TOKEN_TIMEOUT=300, STREAMING_READ_TIMEOUT=300...")
-        
-        with patch.dict(os.environ, {
-            "FIRST_TOKEN_TIMEOUT": "300",
-            "STREAMING_READ_TIMEOUT": "300"
-        }):
+
+        with patch.dict(
+            os.environ, {"FIRST_TOKEN_TIMEOUT": "300", "STREAMING_READ_TIMEOUT": "300"}
+        ):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             # Call the warning function
             config_module._warn_timeout_configuration()
-            
+
             captured = capsys.readouterr()
             print(f"Captured stderr: {captured.err}")
-            
+
             # Warning SHOULD be shown
-            assert "WARNING" in captured.err or "Suboptimal timeout configuration" in captured.err
-    
+            assert (
+                "WARNING" in captured.err
+                or "Suboptimal timeout configuration" in captured.err
+            )
+
     def test_warning_when_first_token_greater_than_streaming(self, capsys):
         """
         What it does: Verifies that warning is shown when FIRST_TOKEN > STREAMING.
         Purpose: Ensure that warning when FIRST_TOKEN_TIMEOUT > STREAMING_READ_TIMEOUT.
         """
         print("Setup: FIRST_TOKEN_TIMEOUT=500, STREAMING_READ_TIMEOUT=300...")
-        
-        with patch.dict(os.environ, {
-            "FIRST_TOKEN_TIMEOUT": "500",
-            "STREAMING_READ_TIMEOUT": "300"
-        }):
+
+        with patch.dict(
+            os.environ, {"FIRST_TOKEN_TIMEOUT": "500", "STREAMING_READ_TIMEOUT": "300"}
+        ):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             # Call the warning function
             config_module._warn_timeout_configuration()
-            
+
             captured = capsys.readouterr()
             print(f"Captured stderr: {captured.err}")
-            
+
             # Warning SHOULD be shown
-            assert "WARNING" in captured.err or "Suboptimal timeout configuration" in captured.err
+            assert (
+                "WARNING" in captured.err
+                or "Suboptimal timeout configuration" in captured.err
+            )
             # Verify that timeout values are mentioned in warning
             assert "500" in captured.err
             assert "300" in captured.err
-    
+
     def test_warning_contains_recommendation(self, capsys):
         """
         What it does: Verifies that warning contains a recommendation.
         Purpose: Ensure that user receives useful information.
         """
         print("Setup: FIRST_TOKEN_TIMEOUT=400, STREAMING_READ_TIMEOUT=300...")
-        
-        with patch.dict(os.environ, {
-            "FIRST_TOKEN_TIMEOUT": "400",
-            "STREAMING_READ_TIMEOUT": "300"
-        }):
+
+        with patch.dict(
+            os.environ, {"FIRST_TOKEN_TIMEOUT": "400", "STREAMING_READ_TIMEOUT": "300"}
+        ):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             # Call the warning function
             config_module._warn_timeout_configuration()
-            
+
             captured = capsys.readouterr()
             print(f"Captured stderr: {captured.err}")
-            
+
             # Warning should contain recommendation
             assert "Recommendation" in captured.err or "LESS than" in captured.err
 
 
 class TestAwsSsoOidcUrlConfig:
     """Tests for AWS SSO OIDC URL configuration."""
-    
+
     def test_aws_sso_oidc_url_template_exists(self):
         """
         What it does: Verifies that AWS_SSO_OIDC_URL_TEMPLATE constant exists.
@@ -293,16 +314,17 @@ class TestAwsSsoOidcUrlConfig:
         print("Setup: Importing config module...")
         import importlib
         import kiro.config as config_module
+
         importlib.reload(config_module)
-        
+
         print("Verification: AWS_SSO_OIDC_URL_TEMPLATE exists...")
-        assert hasattr(config_module, 'AWS_SSO_OIDC_URL_TEMPLATE')
-        
+        assert hasattr(config_module, "AWS_SSO_OIDC_URL_TEMPLATE")
+
         print(f"AWS_SSO_OIDC_URL_TEMPLATE: {config_module.AWS_SSO_OIDC_URL_TEMPLATE}")
         assert "oidc" in config_module.AWS_SSO_OIDC_URL_TEMPLATE
         assert "amazonaws.com" in config_module.AWS_SSO_OIDC_URL_TEMPLATE
         assert "{region}" in config_module.AWS_SSO_OIDC_URL_TEMPLATE
-    
+
     def test_get_aws_sso_oidc_url_returns_correct_url(self):
         """
         What it does: Verifies that get_aws_sso_oidc_url returns correct URL.
@@ -310,15 +332,15 @@ class TestAwsSsoOidcUrlConfig:
         """
         print("Setup: Importing get_aws_sso_oidc_url...")
         from kiro.config import get_aws_sso_oidc_url
-        
+
         print("Action: Calling get_aws_sso_oidc_url('us-east-1')...")
         url = get_aws_sso_oidc_url("us-east-1")
-        
-        print(f"Verification: URL is correct...")
+
+        print("Verification: URL is correct...")
         expected = "https://oidc.us-east-1.amazonaws.com/token"
         print(f"Comparing: Expected '{expected}', Got '{url}'")
         assert url == expected
-    
+
     def test_get_aws_sso_oidc_url_with_different_regions(self):
         """
         What it does: Verifies URL generation for different regions.
@@ -326,14 +348,14 @@ class TestAwsSsoOidcUrlConfig:
         """
         print("Setup: Importing get_aws_sso_oidc_url...")
         from kiro.config import get_aws_sso_oidc_url
-        
+
         test_cases = [
             ("us-east-1", "https://oidc.us-east-1.amazonaws.com/token"),
             ("eu-west-1", "https://oidc.eu-west-1.amazonaws.com/token"),
             ("ap-southeast-1", "https://oidc.ap-southeast-1.amazonaws.com/token"),
             ("us-west-2", "https://oidc.us-west-2.amazonaws.com/token"),
         ]
-        
+
         for region, expected in test_cases:
             print(f"Action: Calling get_aws_sso_oidc_url('{region}')...")
             url = get_aws_sso_oidc_url(region)
@@ -343,127 +365,134 @@ class TestAwsSsoOidcUrlConfig:
 
 class TestServerHostConfig:
     """Tests for SERVER_HOST configuration."""
-    
+
     def test_default_server_host_is_0_0_0_0(self):
         """
         What it does: Verifies that SERVER_HOST defaults to 0.0.0.0.
         Purpose: Ensure that 0.0.0.0 (all interfaces) is used when no environment variable is set.
         """
         print("Setup: Removing SERVER_HOST from environment...")
-        
+
         with patch.dict(os.environ, {}, clear=False):
             if "SERVER_HOST" in os.environ:
                 del os.environ["SERVER_HOST"]
-            
+
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_HOST: {config_module.SERVER_HOST}")
             print(f"DEFAULT_SERVER_HOST: {config_module.DEFAULT_SERVER_HOST}")
             print(f"Comparing: Expected '0.0.0.0', Got '{config_module.SERVER_HOST}'")
             assert config_module.SERVER_HOST == "0.0.0.0"
             assert config_module.DEFAULT_SERVER_HOST == "0.0.0.0"
-    
+
     def test_server_host_from_environment(self):
         """
         What it does: Verifies loading SERVER_HOST from environment variable.
         Purpose: Ensure that the value from environment is used.
         """
         print("Setup: Setting SERVER_HOST=127.0.0.1...")
-        
+
         with patch.dict(os.environ, {"SERVER_HOST": "127.0.0.1"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_HOST: {config_module.SERVER_HOST}")
             print(f"Comparing: Expected '127.0.0.1', Got '{config_module.SERVER_HOST}'")
             assert config_module.SERVER_HOST == "127.0.0.1"
-    
+
     def test_server_host_custom_value(self):
         """
         What it does: Verifies setting SERVER_HOST to a custom IP address.
         Purpose: Ensure that any valid IP address can be used.
         """
         print("Setup: Setting SERVER_HOST=192.168.1.100...")
-        
+
         with patch.dict(os.environ, {"SERVER_HOST": "192.168.1.100"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_HOST: {config_module.SERVER_HOST}")
             assert config_module.SERVER_HOST == "192.168.1.100"
 
 
 class TestServerPortConfig:
     """Tests for SERVER_PORT configuration."""
-    
+
     def test_default_server_port_is_8000(self):
         """
         What it does: Verifies that SERVER_PORT defaults to 8000.
         Purpose: Ensure that 8000 is used when no environment variable is set.
         """
         print("Setup: Removing SERVER_PORT from environment...")
-        
+
         with patch.dict(os.environ, {}, clear=False):
             if "SERVER_PORT" in os.environ:
                 del os.environ["SERVER_PORT"]
-            
+
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_PORT: {config_module.SERVER_PORT}")
             print(f"DEFAULT_SERVER_PORT: {config_module.DEFAULT_SERVER_PORT}")
             print(f"Comparing: Expected 8000, Got {config_module.SERVER_PORT}")
             assert config_module.SERVER_PORT == 8000
             assert config_module.DEFAULT_SERVER_PORT == 8000
-    
+
     def test_server_port_from_environment(self):
         """
         What it does: Verifies loading SERVER_PORT from environment variable.
         Purpose: Ensure that the value from environment is used.
         """
         print("Setup: Setting SERVER_PORT=9000...")
-        
+
         with patch.dict(os.environ, {"SERVER_PORT": "9000"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_PORT: {config_module.SERVER_PORT}")
             print(f"Comparing: Expected 9000, Got {config_module.SERVER_PORT}")
             assert config_module.SERVER_PORT == 9000
-    
+
     def test_server_port_custom_value(self):
         """
         What it does: Verifies setting SERVER_PORT to a custom port number.
         Purpose: Ensure that any valid port number can be used.
         """
         print("Setup: Setting SERVER_PORT=3000...")
-        
+
         with patch.dict(os.environ, {"SERVER_PORT": "3000"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_PORT: {config_module.SERVER_PORT}")
             assert config_module.SERVER_PORT == 3000
-    
+
     def test_server_port_is_integer(self):
         """
         What it does: Verifies that SERVER_PORT is converted to integer.
         Purpose: Ensure that string from environment is converted to int.
         """
         print("Setup: Setting SERVER_PORT=8080 (as string)...")
-        
+
         with patch.dict(os.environ, {"SERVER_PORT": "8080"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_PORT: {config_module.SERVER_PORT}")
             print(f"Type: {type(config_module.SERVER_PORT)}")
             assert isinstance(config_module.SERVER_PORT, int)
@@ -472,7 +501,7 @@ class TestServerPortConfig:
 
 class TestKiroCliDbFileConfig:
     """Tests for KIRO_CLI_DB_FILE configuration."""
-    
+
     def test_kiro_cli_db_file_config_exists(self):
         """
         What it does: Verifies that KIRO_CLI_DB_FILE constant exists.
@@ -481,27 +510,34 @@ class TestKiroCliDbFileConfig:
         print("Setup: Importing config module...")
         import importlib
         import kiro.config as config_module
+
         importlib.reload(config_module)
-        
+
         print("Verification: KIRO_CLI_DB_FILE exists...")
-        assert hasattr(config_module, 'KIRO_CLI_DB_FILE')
-        
+        assert hasattr(config_module, "KIRO_CLI_DB_FILE")
+
         print(f"KIRO_CLI_DB_FILE: '{config_module.KIRO_CLI_DB_FILE}'")
         # Default should be empty string
         assert isinstance(config_module.KIRO_CLI_DB_FILE, str)
-    
+
     def test_kiro_cli_db_file_from_environment(self):
         """
         What it does: Verifies loading KIRO_CLI_DB_FILE from environment variable.
         Purpose: Ensure the value from environment is used.
         """
         print("Setup: Setting KIRO_CLI_DB_FILE=~/.local/share/kiro-cli/data.sqlite3...")
-        
-        with patch.dict(os.environ, {"KIRO_CLI_DB_FILE": "~/.local/share/kiro-cli/data.sqlite3"}):
+
+        with patch.dict(
+            os.environ, {"KIRO_CLI_DB_FILE": "~/.local/share/kiro-cli/data.sqlite3"}
+        ):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"KIRO_CLI_DB_FILE: {config_module.KIRO_CLI_DB_FILE}")
             # Path should be normalized
-            assert "kiro-cli" in config_module.KIRO_CLI_DB_FILE or "kiro_cli" in config_module.KIRO_CLI_DB_FILE.lower()
+            assert (
+                "kiro-cli" in config_module.KIRO_CLI_DB_FILE
+                or "kiro_cli" in config_module.KIRO_CLI_DB_FILE.lower()
+            )

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -13,7 +13,7 @@ Tests for Anthropic Messages API to Kiro format conversion:
 """
 
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from kiro.converters_anthropic import (
     convert_anthropic_content_to_text,
@@ -24,7 +24,7 @@ from kiro.converters_anthropic import (
     convert_anthropic_tools,
     anthropic_to_kiro,
 )
-from kiro.converters_core import UnifiedMessage, UnifiedTool
+from kiro.converters_core import UnifiedTool
 from kiro.models_anthropic import (
     AnthropicMessagesRequest,
     AnthropicMessage,
@@ -40,9 +40,10 @@ from kiro.models_anthropic import (
 # Tests for convert_anthropic_content_to_text
 # ==================================================================================================
 
+
 class TestConvertAnthropicContentToText:
     """Tests for convert_anthropic_content_to_text function."""
-    
+
     def test_extracts_from_string(self):
         """
         What it does: Verifies text extraction from a string.
@@ -50,13 +51,13 @@ class TestConvertAnthropicContentToText:
         """
         print("Setup: Simple string content...")
         content = "Hello, World!"
-        
+
         print("Action: Extracting text...")
         result = convert_anthropic_content_to_text(content)
-        
+
         print(f"Comparing result: Expected 'Hello, World!', Got '{result}'")
         assert result == "Hello, World!"
-    
+
     def test_extracts_from_list_with_text_blocks(self):
         """
         What it does: Verifies extraction from list of text content blocks.
@@ -65,15 +66,15 @@ class TestConvertAnthropicContentToText:
         print("Setup: List with text content blocks...")
         content = [
             {"type": "text", "text": "Hello"},
-            {"type": "text", "text": " World"}
+            {"type": "text", "text": " World"},
         ]
-        
+
         print("Action: Extracting text...")
         result = convert_anthropic_content_to_text(content)
-        
+
         print(f"Comparing result: Expected 'Hello World', Got '{result}'")
         assert result == "Hello World"
-    
+
     def test_extracts_from_pydantic_text_blocks(self):
         """
         What it does: Verifies extraction from Pydantic TextContentBlock objects.
@@ -82,15 +83,15 @@ class TestConvertAnthropicContentToText:
         print("Setup: List with Pydantic TextContentBlock objects...")
         content = [
             TextContentBlock(type="text", text="Part 1"),
-            TextContentBlock(type="text", text=" Part 2")
+            TextContentBlock(type="text", text=" Part 2"),
         ]
-        
+
         print("Action: Extracting text...")
         result = convert_anthropic_content_to_text(content)
-        
+
         print(f"Comparing result: Expected 'Part 1 Part 2', Got '{result}'")
         assert result == "Part 1 Part 2"
-    
+
     def test_ignores_non_text_blocks(self):
         """
         What it does: Verifies that non-text blocks are ignored.
@@ -100,28 +101,28 @@ class TestConvertAnthropicContentToText:
         content = [
             {"type": "text", "text": "Hello"},
             {"type": "tool_use", "id": "call_123", "name": "test", "input": {}},
-            {"type": "text", "text": " World"}
+            {"type": "text", "text": " World"},
         ]
-        
+
         print("Action: Extracting text...")
         result = convert_anthropic_content_to_text(content)
-        
+
         print(f"Comparing result: Expected 'Hello World', Got '{result}'")
         assert result == "Hello World"
-    
+
     def test_handles_none(self):
         """
         What it does: Verifies None handling.
         Purpose: Ensure None returns empty string.
         """
         print("Setup: None content...")
-        
+
         print("Action: Extracting text...")
         result = convert_anthropic_content_to_text(None)
-        
+
         print(f"Comparing result: Expected '', Got '{result}'")
         assert result == ""
-    
+
     def test_handles_empty_list(self):
         """
         What it does: Verifies empty list handling.
@@ -129,13 +130,13 @@ class TestConvertAnthropicContentToText:
         """
         print("Setup: Empty list...")
         content = []
-        
+
         print("Action: Extracting text...")
         result = convert_anthropic_content_to_text(content)
-        
+
         print(f"Comparing result: Expected '', Got '{result}'")
         assert result == ""
-    
+
     def test_converts_other_types_to_string(self):
         """
         What it does: Verifies conversion of other types to string.
@@ -143,10 +144,10 @@ class TestConvertAnthropicContentToText:
         """
         print("Setup: Number content...")
         content = 42
-        
+
         print("Action: Extracting text...")
         result = convert_anthropic_content_to_text(content)
-        
+
         print(f"Comparing result: Expected '42', Got '{result}'")
         assert result == "42"
 
@@ -155,9 +156,10 @@ class TestConvertAnthropicContentToText:
 # Tests for extract_system_prompt
 # ==================================================================================================
 
+
 class TestExtractSystemPrompt:
     """Tests for extract_system_prompt function (Support System commit)."""
-    
+
     def test_extracts_from_string(self):
         """
         What it does: Verifies extraction from simple string.
@@ -165,13 +167,15 @@ class TestExtractSystemPrompt:
         """
         print("Setup: Simple string system prompt...")
         system = "You are a helpful assistant."
-        
+
         print("Action: Extracting system prompt...")
         result = extract_system_prompt(system)
-        
-        print(f"Comparing result: Expected 'You are a helpful assistant.', Got '{result}'")
+
+        print(
+            f"Comparing result: Expected 'You are a helpful assistant.', Got '{result}'"
+        )
         assert result == "You are a helpful assistant."
-    
+
     def test_extracts_from_list_with_text_blocks(self):
         """
         What it does: Verifies extraction from list of content blocks.
@@ -180,15 +184,17 @@ class TestExtractSystemPrompt:
         print("Setup: List with text content blocks (prompt caching format)...")
         system = [
             {"type": "text", "text": "You are helpful."},
-            {"type": "text", "text": "Be concise."}
+            {"type": "text", "text": "Be concise."},
         ]
-        
+
         print("Action: Extracting system prompt...")
         result = extract_system_prompt(system)
-        
-        print(f"Comparing result: Expected 'You are helpful.\\nBe concise.', Got '{result}'")
+
+        print(
+            f"Comparing result: Expected 'You are helpful.\\nBe concise.', Got '{result}'"
+        )
         assert result == "You are helpful.\nBe concise."
-    
+
     def test_extracts_from_list_with_cache_control(self):
         """
         What it does: Verifies extraction ignores cache_control field.
@@ -199,16 +205,18 @@ class TestExtractSystemPrompt:
             {
                 "type": "text",
                 "text": "You are a helpful assistant.",
-                "cache_control": {"type": "ephemeral"}
+                "cache_control": {"type": "ephemeral"},
             }
         ]
-        
+
         print("Action: Extracting system prompt...")
         result = extract_system_prompt(system)
-        
-        print(f"Comparing result: Expected 'You are a helpful assistant.', Got '{result}'")
+
+        print(
+            f"Comparing result: Expected 'You are a helpful assistant.', Got '{result}'"
+        )
         assert result == "You are a helpful assistant."
-    
+
     def test_extracts_from_pydantic_system_content_blocks(self):
         """
         What it does: Verifies extraction from Pydantic SystemContentBlock objects.
@@ -217,28 +225,28 @@ class TestExtractSystemPrompt:
         print("Setup: List with Pydantic SystemContentBlock objects...")
         system = [
             SystemContentBlock(type="text", text="Part 1"),
-            SystemContentBlock(type="text", text="Part 2")
+            SystemContentBlock(type="text", text="Part 2"),
         ]
-        
+
         print("Action: Extracting system prompt...")
         result = extract_system_prompt(system)
-        
+
         print(f"Comparing result: Expected 'Part 1\\nPart 2', Got '{result}'")
         assert result == "Part 1\nPart 2"
-    
+
     def test_handles_none(self):
         """
         What it does: Verifies None handling.
         Purpose: Ensure None returns empty string.
         """
         print("Setup: None system prompt...")
-        
+
         print("Action: Extracting system prompt...")
         result = extract_system_prompt(None)
-        
+
         print(f"Comparing result: Expected '', Got '{result}'")
         assert result == ""
-    
+
     def test_handles_empty_list(self):
         """
         What it does: Verifies empty list handling.
@@ -246,13 +254,13 @@ class TestExtractSystemPrompt:
         """
         print("Setup: Empty list...")
         system = []
-        
+
         print("Action: Extracting system prompt...")
         result = extract_system_prompt(system)
-        
+
         print(f"Comparing result: Expected '', Got '{result}'")
         assert result == ""
-    
+
     def test_handles_mixed_content_blocks(self):
         """
         What it does: Verifies handling of list with non-text blocks.
@@ -262,15 +270,15 @@ class TestExtractSystemPrompt:
         system = [
             {"type": "text", "text": "Hello"},
             {"type": "image", "source": {"type": "base64", "data": "..."}},
-            {"type": "text", "text": "World"}
+            {"type": "text", "text": "World"},
         ]
-        
+
         print("Action: Extracting system prompt...")
         result = extract_system_prompt(system)
-        
+
         print(f"Comparing result: Expected 'Hello\\nWorld', Got '{result}'")
         assert result == "Hello\nWorld"
-    
+
     def test_converts_other_types_to_string(self):
         """
         What it does: Verifies conversion of other types to string.
@@ -278,13 +286,13 @@ class TestExtractSystemPrompt:
         """
         print("Setup: Number as system prompt...")
         system = 42
-        
+
         print("Action: Extracting system prompt...")
         result = extract_system_prompt(system)
-        
+
         print(f"Comparing result: Expected '42', Got '{result}'")
         assert result == "42"
-    
+
     def test_handles_single_text_block(self):
         """
         What it does: Verifies extraction from single text block in list.
@@ -292,13 +300,13 @@ class TestExtractSystemPrompt:
         """
         print("Setup: Single text block in list...")
         system = [{"type": "text", "text": "Single block"}]
-        
+
         print("Action: Extracting system prompt...")
         result = extract_system_prompt(system)
-        
+
         print(f"Comparing result: Expected 'Single block', Got '{result}'")
         assert result == "Single block"
-    
+
     def test_handles_empty_text_in_block(self):
         """
         What it does: Verifies handling of empty text in content block.
@@ -306,13 +314,13 @@ class TestExtractSystemPrompt:
         """
         print("Setup: Content block with empty text...")
         system = [{"type": "text", "text": ""}]
-        
+
         print("Action: Extracting system prompt...")
         result = extract_system_prompt(system)
-        
+
         print(f"Comparing result: Expected '', Got '{result}'")
         assert result == ""
-    
+
     def test_handles_missing_text_key(self):
         """
         What it does: Verifies handling of content block without text key.
@@ -320,10 +328,10 @@ class TestExtractSystemPrompt:
         """
         print("Setup: Content block without text key...")
         system = [{"type": "text"}]
-        
+
         print("Action: Extracting system prompt...")
         result = extract_system_prompt(system)
-        
+
         print(f"Comparing result: Expected '', Got '{result}'")
         assert result == ""
 
@@ -332,9 +340,10 @@ class TestExtractSystemPrompt:
 # Tests for extract_tool_results_from_anthropic_content
 # ==================================================================================================
 
+
 class TestExtractToolResultsFromAnthropicContent:
     """Tests for extract_tool_results_from_anthropic_content function."""
-    
+
     def test_extracts_tool_result_from_dict(self):
         """
         What it does: Verifies extraction of tool result from dict content block.
@@ -344,16 +353,16 @@ class TestExtractToolResultsFromAnthropicContent:
         content = [
             {"type": "tool_result", "tool_use_id": "call_123", "content": "Result text"}
         ]
-        
+
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_anthropic_content(content)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["type"] == "tool_result"
         assert result[0]["tool_use_id"] == "call_123"
         assert result[0]["content"] == "Result text"
-    
+
     def test_extracts_tool_result_from_pydantic_model(self):
         """
         What it does: Verifies extraction from Pydantic ToolResultContentBlock.
@@ -362,20 +371,18 @@ class TestExtractToolResultsFromAnthropicContent:
         print("Setup: Content with Pydantic ToolResultContentBlock...")
         content = [
             ToolResultContentBlock(
-                type="tool_result",
-                tool_use_id="call_456",
-                content="Pydantic result"
+                type="tool_result", tool_use_id="call_456", content="Pydantic result"
             )
         ]
-        
+
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_anthropic_content(content)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["tool_use_id"] == "call_456"
         assert result[0]["content"] == "Pydantic result"
-    
+
     def test_extracts_multiple_tool_results(self):
         """
         What it does: Verifies extraction of multiple tool results.
@@ -385,17 +392,17 @@ class TestExtractToolResultsFromAnthropicContent:
         content = [
             {"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"},
             {"type": "text", "text": "Some text"},
-            {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"}
+            {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"},
         ]
-        
+
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_anthropic_content(content)
-        
+
         print(f"Result: {result}")
         assert len(result) == 2
         assert result[0]["tool_use_id"] == "call_1"
         assert result[1]["tool_use_id"] == "call_2"
-    
+
     def test_returns_empty_for_string_content(self):
         """
         What it does: Verifies empty list return for string content.
@@ -403,13 +410,13 @@ class TestExtractToolResultsFromAnthropicContent:
         """
         print("Setup: String content...")
         content = "Just a string"
-        
+
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_anthropic_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_returns_empty_for_list_without_tool_results(self):
         """
         What it does: Verifies empty list return without tool_result blocks.
@@ -417,45 +424,41 @@ class TestExtractToolResultsFromAnthropicContent:
         """
         print("Setup: List without tool_result...")
         content = [{"type": "text", "text": "Hello"}]
-        
+
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_anthropic_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_handles_empty_content_in_tool_result(self):
         """
         What it does: Verifies handling of empty content in tool_result.
         Purpose: Ensure empty content is replaced with "(empty result)".
         """
         print("Setup: Tool result with empty content...")
-        content = [
-            {"type": "tool_result", "tool_use_id": "call_123", "content": ""}
-        ]
-        
+        content = [{"type": "tool_result", "tool_use_id": "call_123", "content": ""}]
+
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_anthropic_content(content)
-        
+
         print(f"Result: {result}")
         assert result[0]["content"] == "(empty result)"
-    
+
     def test_handles_none_content_in_tool_result(self):
         """
         What it does: Verifies handling of None content in tool_result.
         Purpose: Ensure None content is replaced with "(empty result)".
         """
         print("Setup: Tool result with None content...")
-        content = [
-            {"type": "tool_result", "tool_use_id": "call_123", "content": None}
-        ]
-        
+        content = [{"type": "tool_result", "tool_use_id": "call_123", "content": None}]
+
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_anthropic_content(content)
-        
+
         print(f"Result: {result}")
         assert result[0]["content"] == "(empty result)"
-    
+
     def test_handles_list_content_in_tool_result(self):
         """
         What it does: Verifies handling of list content in tool_result.
@@ -466,29 +469,27 @@ class TestExtractToolResultsFromAnthropicContent:
             {
                 "type": "tool_result",
                 "tool_use_id": "call_123",
-                "content": [{"type": "text", "text": "List result"}]
+                "content": [{"type": "text", "text": "List result"}],
             }
         ]
-        
+
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_anthropic_content(content)
-        
+
         print(f"Result: {result}")
         assert result[0]["content"] == "List result"
-    
+
     def test_skips_tool_result_without_tool_use_id(self):
         """
         What it does: Verifies that tool_result without tool_use_id is skipped.
         Purpose: Ensure invalid tool_result blocks are ignored.
         """
         print("Setup: Tool result without tool_use_id...")
-        content = [
-            {"type": "tool_result", "content": "Result without ID"}
-        ]
-        
+        content = [{"type": "tool_result", "content": "Result without ID"}]
+
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_anthropic_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
 
@@ -497,9 +498,10 @@ class TestExtractToolResultsFromAnthropicContent:
 # Tests for extract_tool_uses_from_anthropic_content
 # ==================================================================================================
 
+
 class TestExtractToolUsesFromAnthropicContent:
     """Tests for extract_tool_uses_from_anthropic_content function."""
-    
+
     def test_extracts_tool_use_from_dict(self):
         """
         What it does: Verifies extraction of tool use from dict content block.
@@ -507,19 +509,24 @@ class TestExtractToolUsesFromAnthropicContent:
         """
         print("Setup: Content with tool_use block...")
         content = [
-            {"type": "tool_use", "id": "call_123", "name": "get_weather", "input": {"location": "Moscow"}}
+            {
+                "type": "tool_use",
+                "id": "call_123",
+                "name": "get_weather",
+                "input": {"location": "Moscow"},
+            }
         ]
-        
+
         print("Action: Extracting tool uses...")
         result = extract_tool_uses_from_anthropic_content(content)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["id"] == "call_123"
         assert result[0]["type"] == "function"
         assert result[0]["function"]["name"] == "get_weather"
         assert result[0]["function"]["arguments"] == {"location": "Moscow"}
-    
+
     def test_extracts_tool_use_from_pydantic_model(self):
         """
         What it does: Verifies extraction from Pydantic ToolUseContentBlock.
@@ -528,21 +535,18 @@ class TestExtractToolUsesFromAnthropicContent:
         print("Setup: Content with Pydantic ToolUseContentBlock...")
         content = [
             ToolUseContentBlock(
-                type="tool_use",
-                id="call_456",
-                name="search",
-                input={"query": "test"}
+                type="tool_use", id="call_456", name="search", input={"query": "test"}
             )
         ]
-        
+
         print("Action: Extracting tool uses...")
         result = extract_tool_uses_from_anthropic_content(content)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["id"] == "call_456"
         assert result[0]["function"]["name"] == "search"
-    
+
     def test_extracts_multiple_tool_uses(self):
         """
         What it does: Verifies extraction of multiple tool uses.
@@ -552,17 +556,17 @@ class TestExtractToolUsesFromAnthropicContent:
         content = [
             {"type": "tool_use", "id": "call_1", "name": "tool1", "input": {}},
             {"type": "text", "text": "Some text"},
-            {"type": "tool_use", "id": "call_2", "name": "tool2", "input": {}}
+            {"type": "tool_use", "id": "call_2", "name": "tool2", "input": {}},
         ]
-        
+
         print("Action: Extracting tool uses...")
         result = extract_tool_uses_from_anthropic_content(content)
-        
+
         print(f"Result: {result}")
         assert len(result) == 2
         assert result[0]["id"] == "call_1"
         assert result[1]["id"] == "call_2"
-    
+
     def test_returns_empty_for_string_content(self):
         """
         What it does: Verifies empty list return for string content.
@@ -570,13 +574,13 @@ class TestExtractToolUsesFromAnthropicContent:
         """
         print("Setup: String content...")
         content = "Just a string"
-        
+
         print("Action: Extracting tool uses...")
         result = extract_tool_uses_from_anthropic_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_returns_empty_for_list_without_tool_uses(self):
         """
         What it does: Verifies empty list return without tool_use blocks.
@@ -584,42 +588,38 @@ class TestExtractToolUsesFromAnthropicContent:
         """
         print("Setup: List without tool_use...")
         content = [{"type": "text", "text": "Hello"}]
-        
+
         print("Action: Extracting tool uses...")
         result = extract_tool_uses_from_anthropic_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_skips_tool_use_without_id(self):
         """
         What it does: Verifies that tool_use without id is skipped.
         Purpose: Ensure invalid tool_use blocks are ignored.
         """
         print("Setup: Tool use without id...")
-        content = [
-            {"type": "tool_use", "name": "test", "input": {}}
-        ]
-        
+        content = [{"type": "tool_use", "name": "test", "input": {}}]
+
         print("Action: Extracting tool uses...")
         result = extract_tool_uses_from_anthropic_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_skips_tool_use_without_name(self):
         """
         What it does: Verifies that tool_use without name is skipped.
         Purpose: Ensure invalid tool_use blocks are ignored.
         """
         print("Setup: Tool use without name...")
-        content = [
-            {"type": "tool_use", "id": "call_123", "input": {}}
-        ]
-        
+        content = [{"type": "tool_use", "id": "call_123", "input": {}}]
+
         print("Action: Extracting tool uses...")
         result = extract_tool_uses_from_anthropic_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
 
@@ -628,47 +628,44 @@ class TestExtractToolUsesFromAnthropicContent:
 # Tests for convert_anthropic_messages
 # ==================================================================================================
 
+
 class TestConvertAnthropicMessages:
     """Tests for convert_anthropic_messages function."""
-    
+
     def test_converts_simple_user_message(self):
         """
         What it does: Verifies conversion of simple user message.
         Purpose: Ensure basic user message is converted to UnifiedMessage.
         """
         print("Setup: Simple user message...")
-        messages = [
-            AnthropicMessage(role="user", content="Hello!")
-        ]
-        
+        messages = [AnthropicMessage(role="user", content="Hello!")]
+
         print("Action: Converting messages...")
         result = convert_anthropic_messages(messages)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0].role == "user"
         assert result[0].content == "Hello!"
         assert result[0].tool_calls is None
         assert result[0].tool_results is None
-    
+
     def test_converts_simple_assistant_message(self):
         """
         What it does: Verifies conversion of simple assistant message.
         Purpose: Ensure basic assistant message is converted to UnifiedMessage.
         """
         print("Setup: Simple assistant message...")
-        messages = [
-            AnthropicMessage(role="assistant", content="Hi there!")
-        ]
-        
+        messages = [AnthropicMessage(role="assistant", content="Hi there!")]
+
         print("Action: Converting messages...")
         result = convert_anthropic_messages(messages)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0].role == "assistant"
         assert result[0].content == "Hi there!"
-    
+
     def test_converts_user_message_with_content_blocks(self):
         """
         What it does: Verifies conversion of user message with content blocks.
@@ -680,18 +677,18 @@ class TestConvertAnthropicMessages:
                 role="user",
                 content=[
                     {"type": "text", "text": "Part 1"},
-                    {"type": "text", "text": " Part 2"}
-                ]
+                    {"type": "text", "text": " Part 2"},
+                ],
             )
         ]
-        
+
         print("Action: Converting messages...")
         result = convert_anthropic_messages(messages)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0].content == "Part 1 Part 2"
-    
+
     def test_converts_assistant_message_with_tool_use(self):
         """
         What it does: Verifies conversion of assistant message with tool_use.
@@ -703,14 +700,19 @@ class TestConvertAnthropicMessages:
                 role="assistant",
                 content=[
                     {"type": "text", "text": "I'll check the weather"},
-                    {"type": "tool_use", "id": "call_123", "name": "get_weather", "input": {"location": "Moscow"}}
-                ]
+                    {
+                        "type": "tool_use",
+                        "id": "call_123",
+                        "name": "get_weather",
+                        "input": {"location": "Moscow"},
+                    },
+                ],
             )
         ]
-        
+
         print("Action: Converting messages...")
         result = convert_anthropic_messages(messages)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0].role == "assistant"
@@ -718,7 +720,7 @@ class TestConvertAnthropicMessages:
         assert result[0].tool_calls is not None
         assert len(result[0].tool_calls) == 1
         assert result[0].tool_calls[0]["function"]["name"] == "get_weather"
-    
+
     def test_converts_user_message_with_tool_result(self):
         """
         What it does: Verifies conversion of user message with tool_result.
@@ -729,21 +731,25 @@ class TestConvertAnthropicMessages:
             AnthropicMessage(
                 role="user",
                 content=[
-                    {"type": "tool_result", "tool_use_id": "call_123", "content": "Weather: Sunny, 25°C"}
-                ]
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": "Weather: Sunny, 25°C",
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Converting messages...")
         result = convert_anthropic_messages(messages)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0].role == "user"
         assert result[0].tool_results is not None
         assert len(result[0].tool_results) == 1
         assert result[0].tool_results[0]["tool_use_id"] == "call_123"
-    
+
     def test_converts_full_conversation(self):
         """
         What it does: Verifies conversion of full conversation.
@@ -753,18 +759,18 @@ class TestConvertAnthropicMessages:
         messages = [
             AnthropicMessage(role="user", content="Hello"),
             AnthropicMessage(role="assistant", content="Hi! How can I help?"),
-            AnthropicMessage(role="user", content="What's the weather?")
+            AnthropicMessage(role="user", content="What's the weather?"),
         ]
-        
+
         print("Action: Converting messages...")
         result = convert_anthropic_messages(messages)
-        
+
         print(f"Result: {result}")
         assert len(result) == 3
         assert result[0].role == "user"
         assert result[1].role == "assistant"
         assert result[2].role == "user"
-    
+
     def test_handles_empty_messages_list(self):
         """
         What it does: Verifies handling of empty messages list.
@@ -772,28 +778,28 @@ class TestConvertAnthropicMessages:
         """
         print("Setup: Empty messages list...")
         messages = []
-        
+
         print("Action: Converting messages...")
         result = convert_anthropic_messages(messages)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     # ==================================================================================
     # Image extraction tests (Issue #30 fix)
     # ==================================================================================
-    
+
     def test_extracts_images_from_user_message(self):
         """
         What it does: Verifies that images are extracted from user messages.
         Purpose: Ensure Anthropic image content blocks are converted to unified format.
-        
+
         This test verifies the fix for Issue #30 - 422 Validation Error for image content.
         """
         print("Setup: User message with image content block...")
         # Base64 1x1 pixel JPEG
         test_image_base64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q=="
-        
+
         messages = [
             AnthropicMessage(
                 role="user",
@@ -804,34 +810,40 @@ class TestConvertAnthropicMessages:
                         "source": {
                             "type": "base64",
                             "media_type": "image/jpeg",
-                            "data": test_image_base64
-                        }
-                    }
-                ]
+                            "data": test_image_base64,
+                        },
+                    },
+                ],
             )
         ]
-        
+
         print("Action: Converting messages...")
         result = convert_anthropic_messages(messages)
-        
+
         print(f"Result: {result}")
         print(f"Images: {result[0].images}")
-        
+
         assert len(result) == 1
         assert result[0].role == "user"
         assert result[0].content == "What's in this image?"
-        
+
         print("Checking images field...")
         assert result[0].images is not None, "images field should not be None"
-        assert len(result[0].images) == 1, f"Expected 1 image, got {len(result[0].images)}"
-        
+        assert len(result[0].images) == 1, (
+            f"Expected 1 image, got {len(result[0].images)}"
+        )
+
         image = result[0].images[0]
-        print(f"Comparing image: Expected media_type='image/jpeg', Got '{image.get('media_type')}'")
+        print(
+            f"Comparing image: Expected media_type='image/jpeg', Got '{image.get('media_type')}'"
+        )
         assert image["media_type"] == "image/jpeg"
-        
-        print(f"Comparing image data: Expected {test_image_base64[:20]}..., Got {image.get('data', '')[:20]}...")
+
+        print(
+            f"Comparing image data: Expected {test_image_base64[:20]}..., Got {image.get('data', '')[:20]}..."
+        )
         assert image["data"] == test_image_base64
-    
+
     def test_images_only_extracted_from_user_role(self):
         """
         What it does: Verifies that images are only extracted from user messages.
@@ -839,7 +851,7 @@ class TestConvertAnthropicMessages:
         """
         print("Setup: Conversation with image in user message only...")
         test_image_base64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q=="
-        
+
         messages = [
             AnthropicMessage(
                 role="user",
@@ -850,29 +862,28 @@ class TestConvertAnthropicMessages:
                         "source": {
                             "type": "base64",
                             "media_type": "image/png",
-                            "data": test_image_base64
-                        }
-                    }
-                ]
+                            "data": test_image_base64,
+                        },
+                    },
+                ],
             ),
-            AnthropicMessage(
-                role="assistant",
-                content="I can see a small image."
-            )
+            AnthropicMessage(role="assistant", content="I can see a small image."),
         ]
-        
+
         print("Action: Converting messages...")
         result = convert_anthropic_messages(messages)
-        
+
         print(f"Result: {result}")
-        
+
         print("Checking user message has images...")
         assert result[0].images is not None
         assert len(result[0].images) == 1
-        
+
         print("Checking assistant message has no images...")
-        assert result[1].images is None, "Assistant messages should not have images extracted"
-    
+        assert result[1].images is None, (
+            "Assistant messages should not have images extracted"
+        )
+
     def test_extracts_multiple_images_from_user_message(self):
         """
         What it does: Verifies extraction of multiple images from a single user message.
@@ -880,7 +891,7 @@ class TestConvertAnthropicMessages:
         """
         print("Setup: User message with multiple images...")
         test_image_base64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q=="
-        
+
         messages = [
             AnthropicMessage(
                 role="user",
@@ -888,45 +899,61 @@ class TestConvertAnthropicMessages:
                     {"type": "text", "text": "Compare these images"},
                     {
                         "type": "image",
-                        "source": {"type": "base64", "media_type": "image/jpeg", "data": test_image_base64}
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/jpeg",
+                            "data": test_image_base64,
+                        },
                     },
                     {
                         "type": "image",
-                        "source": {"type": "base64", "media_type": "image/png", "data": test_image_base64}
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": test_image_base64,
+                        },
                     },
                     {
                         "type": "image",
-                        "source": {"type": "base64", "media_type": "image/webp", "data": test_image_base64}
-                    }
-                ]
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/webp",
+                            "data": test_image_base64,
+                        },
+                    },
+                ],
             )
         ]
-        
+
         print("Action: Converting messages...")
         result = convert_anthropic_messages(messages)
-        
-        print(f"Result images count: {len(result[0].images) if result[0].images else 0}")
-        
+
+        print(
+            f"Result images count: {len(result[0].images) if result[0].images else 0}"
+        )
+
         assert result[0].images is not None
-        assert len(result[0].images) == 3, f"Expected 3 images, got {len(result[0].images)}"
-        
+        assert len(result[0].images) == 3, (
+            f"Expected 3 images, got {len(result[0].images)}"
+        )
+
         print("Checking image media types...")
         media_types = [img["media_type"] for img in result[0].images]
         print(f"Media types: {media_types}")
         assert "image/jpeg" in media_types
         assert "image/png" in media_types
         assert "image/webp" in media_types
-    
+
     def test_counts_images_in_debug_log(self, caplog):
         """
         What it does: Verifies that image count is logged in debug message.
         Purpose: Ensure logging includes image statistics for debugging.
         """
         import logging
-        
+
         print("Setup: User message with images for logging test...")
         test_image_base64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q=="
-        
+
         messages = [
             AnthropicMessage(
                 role="user",
@@ -934,26 +961,34 @@ class TestConvertAnthropicMessages:
                     {"type": "text", "text": "Analyze this"},
                     {
                         "type": "image",
-                        "source": {"type": "base64", "media_type": "image/jpeg", "data": test_image_base64}
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/jpeg",
+                            "data": test_image_base64,
+                        },
                     },
                     {
                         "type": "image",
-                        "source": {"type": "base64", "media_type": "image/png", "data": test_image_base64}
-                    }
-                ]
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": test_image_base64,
+                        },
+                    },
+                ],
             )
         ]
-        
+
         print("Action: Converting messages with logging enabled...")
         with caplog.at_level(logging.DEBUG):
             result = convert_anthropic_messages(messages)
-        
+
         print(f"Log records: {[r.message for r in caplog.records]}")
-        
+
         # Check that images were extracted
         assert result[0].images is not None
         assert len(result[0].images) == 2
-        
+
         # Note: loguru doesn't integrate with caplog by default
         # The function logs "Converted X Anthropic messages: Y tool_calls, Z tool_results, W images"
         # We verify the images are extracted correctly, which proves the counting works
@@ -964,35 +999,36 @@ class TestConvertAnthropicMessages:
 # Tests for convert_anthropic_tools
 # ==================================================================================================
 
+
 class TestConvertAnthropicTools:
     """Tests for convert_anthropic_tools function."""
-    
+
     def test_returns_none_for_none(self):
         """
         What it does: Verifies handling of None.
         Purpose: Ensure None returns None.
         """
         print("Setup: None tools...")
-        
+
         print("Action: Converting tools...")
         result = convert_anthropic_tools(None)
-        
+
         print(f"Comparing result: Expected None, Got {result}")
         assert result is None
-    
+
     def test_returns_none_for_empty_list(self):
         """
         What it does: Verifies handling of empty list.
         Purpose: Ensure empty list returns None.
         """
         print("Setup: Empty tools list...")
-        
+
         print("Action: Converting tools...")
         result = convert_anthropic_tools([])
-        
+
         print(f"Comparing result: Expected None, Got {result}")
         assert result is None
-    
+
     def test_converts_tool_from_pydantic_model(self):
         """
         What it does: Verifies conversion of Pydantic AnthropicTool.
@@ -1003,21 +1039,27 @@ class TestConvertAnthropicTools:
             AnthropicTool(
                 name="get_weather",
                 description="Get weather for a location",
-                input_schema={"type": "object", "properties": {"location": {"type": "string"}}}
+                input_schema={
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                },
             )
         ]
-        
+
         print("Action: Converting tools...")
         result = convert_anthropic_tools(tools)
-        
+
         print(f"Result: {result}")
         assert result is not None
         assert len(result) == 1
         assert isinstance(result[0], UnifiedTool)
         assert result[0].name == "get_weather"
         assert result[0].description == "Get weather for a location"
-        assert result[0].input_schema == {"type": "object", "properties": {"location": {"type": "string"}}}
-    
+        assert result[0].input_schema == {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+        }
+
     def test_converts_tool_from_dict(self):
         """
         What it does: Verifies conversion of dict tool.
@@ -1028,19 +1070,22 @@ class TestConvertAnthropicTools:
             {
                 "name": "search",
                 "description": "Search the web",
-                "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}}
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                },
             }
         ]
-        
+
         print("Action: Converting tools...")
         result = convert_anthropic_tools(tools)
-        
+
         print(f"Result: {result}")
         assert result is not None
         assert len(result) == 1
         assert result[0].name == "search"
         assert result[0].description == "Search the web"
-    
+
     def test_converts_multiple_tools(self):
         """
         What it does: Verifies conversion of multiple tools.
@@ -1049,31 +1094,29 @@ class TestConvertAnthropicTools:
         print("Setup: Multiple tools...")
         tools = [
             AnthropicTool(name="tool1", description="Tool 1", input_schema={}),
-            AnthropicTool(name="tool2", description="Tool 2", input_schema={})
+            AnthropicTool(name="tool2", description="Tool 2", input_schema={}),
         ]
-        
+
         print("Action: Converting tools...")
         result = convert_anthropic_tools(tools)
-        
+
         print(f"Result: {result}")
         assert result is not None
         assert len(result) == 2
         assert result[0].name == "tool1"
         assert result[1].name == "tool2"
-    
+
     def test_handles_tool_without_description(self):
         """
         What it does: Verifies handling of tool without description.
         Purpose: Ensure None description is preserved.
         """
         print("Setup: Tool without description...")
-        tools = [
-            AnthropicTool(name="test_tool", input_schema={})
-        ]
-        
+        tools = [AnthropicTool(name="test_tool", input_schema={})]
+
         print("Action: Converting tools...")
         result = convert_anthropic_tools(tools)
-        
+
         print(f"Result: {result}")
         assert result is not None
         assert result[0].description is None
@@ -1083,9 +1126,10 @@ class TestConvertAnthropicTools:
 # Tests for anthropic_to_kiro
 # ==================================================================================================
 
+
 class TestAnthropicToKiro:
     """Tests for anthropic_to_kiro function - main entry point."""
-    
+
     def test_builds_simple_payload(self):
         """
         What it does: Verifies building of simple Kiro payload.
@@ -1095,21 +1139,24 @@ class TestAnthropicToKiro:
         request = AnthropicMessagesRequest(
             model="claude-sonnet-4-5",
             messages=[AnthropicMessage(role="user", content="Hello!")],
-            max_tokens=1024
+            max_tokens=1024,
         )
-        
+
         print("Action: Converting to Kiro payload...")
-        with patch('kiro.converters_anthropic.get_model_id_for_kiro', return_value='claude-sonnet-4.5'):
-            with patch('kiro.converters_core.FAKE_REASONING_ENABLED', False):
+        with patch(
+            "kiro.converters_anthropic.get_model_id_for_kiro",
+            return_value="claude-sonnet-4.5",
+        ):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
                 result = anthropic_to_kiro(request, "conv-123", "arn:aws:test")
-        
+
         print(f"Result: {result}")
         assert "conversationState" in result
         assert result["conversationState"]["conversationId"] == "conv-123"
         assert "currentMessage" in result["conversationState"]
         assert "userInputMessage" in result["conversationState"]["currentMessage"]
         assert result["profileArn"] == "arn:aws:test"
-    
+
     def test_includes_system_prompt(self):
         """
         What it does: Verifies that system prompt is included.
@@ -1120,19 +1167,24 @@ class TestAnthropicToKiro:
             model="claude-sonnet-4-5",
             messages=[AnthropicMessage(role="user", content="Hello!")],
             max_tokens=1024,
-            system="You are a helpful assistant."
+            system="You are a helpful assistant.",
         )
-        
+
         print("Action: Converting to Kiro payload...")
-        with patch('kiro.converters_anthropic.get_model_id_for_kiro', return_value='claude-sonnet-4.5'):
-            with patch('kiro.converters_core.FAKE_REASONING_ENABLED', False):
+        with patch(
+            "kiro.converters_anthropic.get_model_id_for_kiro",
+            return_value="claude-sonnet-4.5",
+        ):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
                 result = anthropic_to_kiro(request, "conv-123", "arn:aws:test")
-        
+
         print(f"Result: {result}")
-        current_content = result["conversationState"]["currentMessage"]["userInputMessage"]["content"]
+        current_content = result["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]["content"]
         print(f"Current content: {current_content}")
         assert "You are a helpful assistant." in current_content
-    
+
     def test_includes_tools(self):
         """
         What it does: Verifies that tools are included in payload.
@@ -1147,23 +1199,31 @@ class TestAnthropicToKiro:
                 AnthropicTool(
                     name="get_weather",
                     description="Get weather for a location",
-                    input_schema={"type": "object", "properties": {"location": {"type": "string"}}}
+                    input_schema={
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                    },
                 )
-            ]
+            ],
         )
-        
+
         print("Action: Converting to Kiro payload...")
-        with patch('kiro.converters_anthropic.get_model_id_for_kiro', return_value='claude-sonnet-4.5'):
-            with patch('kiro.converters_core.FAKE_REASONING_ENABLED', False):
+        with patch(
+            "kiro.converters_anthropic.get_model_id_for_kiro",
+            return_value="claude-sonnet-4.5",
+        ):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
                 result = anthropic_to_kiro(request, "conv-123", "arn:aws:test")
-        
+
         print(f"Result: {result}")
-        context = result["conversationState"]["currentMessage"]["userInputMessage"].get("userInputMessageContext", {})
+        context = result["conversationState"]["currentMessage"]["userInputMessage"].get(
+            "userInputMessageContext", {}
+        )
         tools = context.get("tools", [])
         print(f"Tools in payload: {tools}")
         assert len(tools) == 1
         assert tools[0]["toolSpecification"]["name"] == "get_weather"
-    
+
     def test_builds_history_for_multi_turn(self):
         """
         What it does: Verifies building of history for multi-turn conversation.
@@ -1175,23 +1235,26 @@ class TestAnthropicToKiro:
             messages=[
                 AnthropicMessage(role="user", content="Hello"),
                 AnthropicMessage(role="assistant", content="Hi! How can I help?"),
-                AnthropicMessage(role="user", content="What's the weather?")
+                AnthropicMessage(role="user", content="What's the weather?"),
             ],
-            max_tokens=1024
+            max_tokens=1024,
         )
-        
+
         print("Action: Converting to Kiro payload...")
-        with patch('kiro.converters_anthropic.get_model_id_for_kiro', return_value='claude-sonnet-4.5'):
-            with patch('kiro.converters_core.FAKE_REASONING_ENABLED', False):
+        with patch(
+            "kiro.converters_anthropic.get_model_id_for_kiro",
+            return_value="claude-sonnet-4.5",
+        ):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
                 result = anthropic_to_kiro(request, "conv-123", "arn:aws:test")
-        
+
         print(f"Result: {result}")
         history = result["conversationState"].get("history", [])
         print(f"History length: {len(history)}")
         assert len(history) == 2  # First user + assistant
         assert "userInputMessage" in history[0]
         assert "assistantResponseMessage" in history[1]
-    
+
     def test_handles_tool_use_and_result_flow(self):
         """
         What it does: Verifies handling of tool use and result flow.
@@ -1206,15 +1269,24 @@ class TestAnthropicToKiro:
                     role="assistant",
                     content=[
                         {"type": "text", "text": "I'll check the weather"},
-                        {"type": "tool_use", "id": "call_123", "name": "get_weather", "input": {"location": "Moscow"}}
-                    ]
+                        {
+                            "type": "tool_use",
+                            "id": "call_123",
+                            "name": "get_weather",
+                            "input": {"location": "Moscow"},
+                        },
+                    ],
                 ),
                 AnthropicMessage(
                     role="user",
                     content=[
-                        {"type": "tool_result", "tool_use_id": "call_123", "content": "Weather: Sunny, 25°C"}
-                    ]
-                )
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_123",
+                            "content": "Weather: Sunny, 25°C",
+                        }
+                    ],
+                ),
             ],
             max_tokens=1024,
             # Tools must be defined for tool_results to be preserved
@@ -1222,51 +1294,57 @@ class TestAnthropicToKiro:
                 AnthropicTool(
                     name="get_weather",
                     description="Get weather for a location",
-                    input_schema={"type": "object", "properties": {"location": {"type": "string"}}}
+                    input_schema={
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                    },
                 )
-            ]
+            ],
         )
-        
+
         print("Action: Converting to Kiro payload...")
-        with patch('kiro.converters_anthropic.get_model_id_for_kiro', return_value='claude-sonnet-4.5'):
-            with patch('kiro.converters_core.FAKE_REASONING_ENABLED', False):
+        with patch(
+            "kiro.converters_anthropic.get_model_id_for_kiro",
+            return_value="claude-sonnet-4.5",
+        ):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
                 result = anthropic_to_kiro(request, "conv-123", "arn:aws:test")
-        
+
         print(f"Result: {result}")
-        
+
         # Check history contains tool use
         history = result["conversationState"].get("history", [])
         print(f"History: {history}")
-        
+
         # Check current message contains tool result
         current_msg = result["conversationState"]["currentMessage"]["userInputMessage"]
         context = current_msg.get("userInputMessageContext", {})
         tool_results = context.get("toolResults", [])
         print(f"Tool results: {tool_results}")
         assert len(tool_results) == 1
-    
+
     def test_raises_for_empty_messages(self):
         """
         What it does: Verifies that empty messages raise Pydantic ValidationError.
         Purpose: Ensure Pydantic validation works correctly (min_length=1).
-        
+
         Note: AnthropicMessagesRequest has min_length=1 validation on messages field,
         so empty messages are rejected at the Pydantic level, not at anthropic_to_kiro.
         """
         from pydantic import ValidationError
-        
+
         print("Setup: Attempting to create request with empty messages...")
-        
-        print("Action: Creating AnthropicMessagesRequest (should raise ValidationError)...")
+
+        print(
+            "Action: Creating AnthropicMessagesRequest (should raise ValidationError)..."
+        )
         with pytest.raises(ValidationError):
             AnthropicMessagesRequest(
-                model="claude-sonnet-4-5",
-                messages=[],
-                max_tokens=1024
+                model="claude-sonnet-4-5", messages=[], max_tokens=1024
             )
-        
+
         print("ValidationError raised as expected - Pydantic rejects empty messages")
-    
+
     def test_injects_thinking_tags_when_enabled(self):
         """
         What it does: Verifies that thinking tags are injected when enabled.
@@ -1276,23 +1354,28 @@ class TestAnthropicToKiro:
         request = AnthropicMessagesRequest(
             model="claude-sonnet-4-5",
             messages=[AnthropicMessage(role="user", content="What is 2+2?")],
-            max_tokens=1024
+            max_tokens=1024,
         )
-        
+
         print("Action: Converting to Kiro payload with fake reasoning...")
-        with patch('kiro.converters_anthropic.get_model_id_for_kiro', return_value='claude-sonnet-4.5'):
-            with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-                with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 4000):
+        with patch(
+            "kiro.converters_anthropic.get_model_id_for_kiro",
+            return_value="claude-sonnet-4.5",
+        ):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+                with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 4000):
                     result = anthropic_to_kiro(request, "conv-123", "arn:aws:test")
-        
+
         print(f"Result: {result}")
-        current_content = result["conversationState"]["currentMessage"]["userInputMessage"]["content"]
+        current_content = result["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]["content"]
         print(f"Current content (first 200 chars): {current_content[:200]}...")
-        
+
         print("Checking that thinking tags are present...")
         assert "<thinking_mode>enabled</thinking_mode>" in current_content
         assert "What is 2+2?" in current_content
-    
+
     def test_injects_thinking_tags_even_when_tool_results_present(self):
         """
         What it does: Verifies that thinking tags ARE injected even when tool results are present.
@@ -1305,8 +1388,12 @@ class TestAnthropicToKiro:
                 AnthropicMessage(
                     role="user",
                     content=[
-                        {"type": "tool_result", "tool_use_id": "call_123", "content": "Result"}
-                    ]
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_123",
+                            "content": "Result",
+                        }
+                    ],
                 )
             ],
             max_tokens=1024,
@@ -1315,25 +1402,32 @@ class TestAnthropicToKiro:
                 AnthropicTool(
                     name="test_tool",
                     description="A test tool",
-                    input_schema={"type": "object", "properties": {}}
+                    input_schema={"type": "object", "properties": {}},
                 )
-            ]
+            ],
         )
-        
+
         print("Action: Converting to Kiro payload...")
-        with patch('kiro.converters_anthropic.get_model_id_for_kiro', return_value='claude-sonnet-4.5'):
-            with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-                with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 4000):
+        with patch(
+            "kiro.converters_anthropic.get_model_id_for_kiro",
+            return_value="claude-sonnet-4.5",
+        ):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+                with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 4000):
                     result = anthropic_to_kiro(request, "conv-123", "arn:aws:test")
-        
+
         print(f"Result: {result}")
-        current_content = result["conversationState"]["currentMessage"]["userInputMessage"]["content"]
+        current_content = result["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]["content"]
         print(f"Current content (first 100 chars): {current_content[:100]}...")
-        
+
         print("Checking that thinking tags ARE present...")
-        assert "<thinking_mode>enabled</thinking_mode>" in current_content, \
+        assert "<thinking_mode>enabled</thinking_mode>" in current_content, (
             "thinking tags SHOULD be injected even with tool results"
-        
+        )
+
         print("Checking that <max_thinking_length> tag IS present...")
-        assert "<max_thinking_length>4000</max_thinking_length>" in current_content, \
+        assert "<max_thinking_length>4000</max_thinking_length>" in current_content, (
             "max_thinking_length tag SHOULD be present even with tool results"
+        )

--- a/tests/unit/test_converters_core.py
+++ b/tests/unit/test_converters_core.py
@@ -11,7 +11,6 @@ Tests for shared conversion logic used by both OpenAI and Anthropic adapters:
 - Thinking tag injection
 """
 
-import pytest
 from unittest.mock import patch
 
 from kiro.converters_core import (
@@ -44,9 +43,10 @@ TEST_IMAGE_BASE64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAs
 # Tests for extract_text_content
 # ==================================================================================================
 
+
 class TestExtractTextContent:
     """Tests for extract_text_content function."""
-    
+
     def test_extracts_from_string(self):
         """
         What it does: Verifies text extraction from a string.
@@ -54,26 +54,26 @@ class TestExtractTextContent:
         """
         print("Setup: Simple string...")
         content = "Hello, World!"
-        
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Comparing result: Expected 'Hello, World!', Got '{result}'")
         assert result == "Hello, World!"
-    
+
     def test_extracts_from_none(self):
         """
         What it does: Verifies None handling.
         Purpose: Ensure None returns empty string.
         """
         print("Setup: None...")
-        
+
         print("Action: Extracting text...")
         result = extract_text_content(None)
-        
+
         print(f"Comparing result: Expected '', Got '{result}'")
         assert result == ""
-    
+
     def test_extracts_from_list_with_text_type(self):
         """
         What it does: Verifies extraction from list with type=text.
@@ -82,15 +82,15 @@ class TestExtractTextContent:
         print("Setup: List with type=text...")
         content = [
             {"type": "text", "text": "Hello"},
-            {"type": "text", "text": " World"}
+            {"type": "text", "text": " World"},
         ]
-        
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Comparing result: Expected 'Hello World', Got '{result}'")
         assert result == "Hello World"
-    
+
     def test_extracts_from_list_with_text_key(self):
         """
         What it does: Verifies extraction from list with text key.
@@ -98,13 +98,13 @@ class TestExtractTextContent:
         """
         print("Setup: List with text key...")
         content = [{"text": "Hello"}, {"text": " World"}]
-        
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Comparing result: Expected 'Hello World', Got '{result}'")
         assert result == "Hello World"
-    
+
     def test_extracts_from_list_with_strings(self):
         """
         What it does: Verifies extraction from list of strings.
@@ -112,31 +112,27 @@ class TestExtractTextContent:
         """
         print("Setup: List of strings...")
         content = ["Hello", " ", "World"]
-        
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Comparing result: Expected 'Hello World', Got '{result}'")
         assert result == "Hello World"
-    
+
     def test_extracts_from_mixed_list(self):
         """
         What it does: Verifies extraction from mixed list.
         Purpose: Ensure different formats in one list are handled.
         """
         print("Setup: Mixed list...")
-        content = [
-            {"type": "text", "text": "Part1"},
-            "Part2",
-            {"text": "Part3"}
-        ]
-        
+        content = [{"type": "text", "text": "Part1"}, "Part2", {"text": "Part3"}]
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Comparing result: Expected 'Part1Part2Part3', Got '{result}'")
         assert result == "Part1Part2Part3"
-    
+
     def test_converts_other_types_to_string(self):
         """
         What it does: Verifies conversion of other types to string.
@@ -144,13 +140,13 @@ class TestExtractTextContent:
         """
         print("Setup: Number...")
         content = 42
-        
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Comparing result: Expected '42', Got '{result}'")
         assert result == "42"
-    
+
     def test_handles_empty_list(self):
         """
         What it does: Verifies empty list handling.
@@ -158,10 +154,10 @@ class TestExtractTextContent:
         """
         print("Setup: Empty list...")
         content = []
-        
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Comparing result: Expected '', Got '{result}'")
         assert result == ""
 
@@ -170,21 +166,22 @@ class TestExtractTextContent:
 # Tests for extract_images_from_content (Issue #30 fix)
 # ==================================================================================================
 
+
 class TestExtractImagesFromContent:
     """
     Tests for extract_images_from_content function.
-    
+
     This function extracts images from message content in unified format.
     Supports both OpenAI (image_url with data URL) and Anthropic (image with source) formats.
-    
+
     This is a critical function for Issue #30 fix - 422 Validation Error for image content blocks.
     """
-    
+
     def test_extracts_from_openai_format_data_url(self):
         """
         What it does: Verifies extraction from OpenAI image_url format with data URL.
         Purpose: Ensure OpenAI Vision API format is handled correctly.
-        
+
         OpenAI format: {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}
         """
         print("Setup: OpenAI format image content...")
@@ -192,28 +189,28 @@ class TestExtractImagesFromContent:
             {"type": "text", "text": "What's in this image?"},
             {
                 "type": "image_url",
-                "image_url": {"url": f"data:image/jpeg;base64,{TEST_IMAGE_BASE64}"}
-            }
+                "image_url": {"url": f"data:image/jpeg;base64,{TEST_IMAGE_BASE64}"},
+            },
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 1, Got {len(result)}")
         assert len(result) == 1
-        
+
         print("Checking media_type...")
         assert result[0]["media_type"] == "image/jpeg"
-        
+
         print("Checking data...")
         assert result[0]["data"] == TEST_IMAGE_BASE64
-    
+
     def test_extracts_from_anthropic_format_base64(self):
         """
         What it does: Verifies extraction from Anthropic image format with base64 source.
         Purpose: Ensure Anthropic Messages API format is handled correctly.
-        
+
         Anthropic format: {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": "..."}}
         """
         print("Setup: Anthropic format image content...")
@@ -224,24 +221,24 @@ class TestExtractImagesFromContent:
                 "source": {
                     "type": "base64",
                     "media_type": "image/png",
-                    "data": TEST_IMAGE_BASE64
-                }
-            }
+                    "data": TEST_IMAGE_BASE64,
+                },
+            },
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 1, Got {len(result)}")
         assert len(result) == 1
-        
+
         print("Checking media_type...")
         assert result[0]["media_type"] == "image/png"
-        
+
         print("Checking data...")
         assert result[0]["data"] == TEST_IMAGE_BASE64
-    
+
     def test_extracts_from_mixed_content(self):
         """
         What it does: Verifies extraction from mixed content (text + multiple images).
@@ -252,30 +249,38 @@ class TestExtractImagesFromContent:
             {"type": "text", "text": "Compare these images:"},
             {
                 "type": "image",
-                "source": {"type": "base64", "media_type": "image/jpeg", "data": "image1_data"}
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/jpeg",
+                    "data": "image1_data",
+                },
             },
             {"type": "text", "text": "and"},
             {
                 "type": "image",
-                "source": {"type": "base64", "media_type": "image/png", "data": "image2_data"}
-            }
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": "image2_data",
+                },
+            },
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 2, Got {len(result)}")
         assert len(result) == 2
-        
+
         print("Checking first image...")
         assert result[0]["media_type"] == "image/jpeg"
         assert result[0]["data"] == "image1_data"
-        
+
         print("Checking second image...")
         assert result[1]["media_type"] == "image/png"
         assert result[1]["data"] == "image2_data"
-    
+
     def test_returns_empty_for_string_content(self):
         """
         What it does: Verifies empty list return for string content.
@@ -283,13 +288,13 @@ class TestExtractImagesFromContent:
         """
         print("Setup: String content...")
         content = "Just a text message"
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_returns_empty_for_empty_content(self):
         """
         What it does: Verifies empty list return for empty content.
@@ -297,13 +302,13 @@ class TestExtractImagesFromContent:
         """
         print("Setup: Empty list...")
         content = []
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_returns_empty_for_none_content(self):
         """
         What it does: Verifies empty list return for None content.
@@ -311,51 +316,45 @@ class TestExtractImagesFromContent:
         """
         print("Setup: None content...")
         content = None
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_returns_empty_for_text_only_content(self):
         """
         What it does: Verifies empty list return for text-only content.
         Purpose: Ensure text blocks don't produce images.
         """
         print("Setup: Text-only content...")
-        content = [
-            {"type": "text", "text": "Hello"},
-            {"type": "text", "text": "World"}
-        ]
-        
+        content = [{"type": "text", "text": "Hello"}, {"type": "text", "text": "World"}]
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_handles_url_images_with_warning(self):
         """
         What it does: Verifies URL-based images are skipped with warning.
         Purpose: Ensure URL images don't crash but are logged as unsupported.
-        
+
         URL-based images require fetching and are not supported by Kiro API directly.
         """
         print("Setup: URL-based image content...")
         content = [
-            {
-                "type": "image_url",
-                "image_url": {"url": "https://example.com/image.jpg"}
-            }
+            {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
         ]
-        
+
         print("Action: Extracting images (should skip URL images)...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []  # URL images are skipped
-    
+
     def test_handles_anthropic_url_source_with_warning(self):
         """
         What it does: Verifies Anthropic URL source images are skipped with warning.
@@ -365,19 +364,16 @@ class TestExtractImagesFromContent:
         content = [
             {
                 "type": "image",
-                "source": {
-                    "type": "url",
-                    "url": "https://example.com/image.png"
-                }
+                "source": {"type": "url", "url": "https://example.com/image.png"},
             }
         ]
-        
+
         print("Action: Extracting images (should skip URL images)...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []  # URL images are skipped
-    
+
     def test_handles_invalid_data_url(self):
         """
         What it does: Verifies handling of invalid data URL format.
@@ -387,16 +383,16 @@ class TestExtractImagesFromContent:
         content = [
             {
                 "type": "image_url",
-                "image_url": {"url": "data:invalid_format_without_comma"}
+                "image_url": {"url": "data:invalid_format_without_comma"},
             }
         ]
-        
+
         print("Action: Extracting images (should handle gracefully)...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []  # Invalid data URL is skipped
-    
+
     def test_handles_empty_data_in_image(self):
         """
         What it does: Verifies handling of image with empty data.
@@ -406,75 +402,70 @@ class TestExtractImagesFromContent:
         content = [
             {
                 "type": "image",
-                "source": {"type": "base64", "media_type": "image/jpeg", "data": ""}
+                "source": {"type": "base64", "media_type": "image/jpeg", "data": ""},
             }
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []  # Empty data is skipped
-    
+
     def test_extracts_from_pydantic_image_content_block(self):
         """
         What it does: Verifies extraction from Pydantic ImageContentBlock objects.
         Purpose: Ensure Pydantic models are handled correctly (Issue #30 fix).
-        
+
         This is the critical test for Issue #30 - the original bug was that
         Pydantic ImageContentBlock objects weren't being handled.
         """
         from kiro.models_anthropic import ImageContentBlock, Base64ImageSource
-        
+
         print("Setup: Pydantic ImageContentBlock...")
         content = [
             ImageContentBlock(
                 type="image",
                 source=Base64ImageSource(
-                    type="base64",
-                    media_type="image/webp",
-                    data=TEST_IMAGE_BASE64
-                )
+                    type="base64", media_type="image/webp", data=TEST_IMAGE_BASE64
+                ),
             )
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 1, Got {len(result)}")
         assert len(result) == 1
-        
+
         print("Checking media_type...")
         assert result[0]["media_type"] == "image/webp"
-        
+
         print("Checking data...")
         assert result[0]["data"] == TEST_IMAGE_BASE64
-    
+
     def test_extracts_from_pydantic_url_image_source(self):
         """
         What it does: Verifies handling of Pydantic URLImageSource objects.
         Purpose: Ensure Pydantic URL sources are skipped with warning.
         """
         from kiro.models_anthropic import ImageContentBlock, URLImageSource
-        
+
         print("Setup: Pydantic ImageContentBlock with URL source...")
         content = [
             ImageContentBlock(
                 type="image",
-                source=URLImageSource(
-                    type="url",
-                    url="https://example.com/image.gif"
-                )
+                source=URLImageSource(type="url", url="https://example.com/image.gif"),
             )
         ]
-        
+
         print("Action: Extracting images (should skip URL images)...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []  # URL images are skipped
-    
+
     def test_extracts_multiple_formats_mixed(self):
         """
         What it does: Verifies extraction from mixed OpenAI and Anthropic formats.
@@ -485,30 +476,34 @@ class TestExtractImagesFromContent:
             # OpenAI format
             {
                 "type": "image_url",
-                "image_url": {"url": f"data:image/jpeg;base64,openai_image_data"}
+                "image_url": {"url": "data:image/jpeg;base64,openai_image_data"},
             },
             # Anthropic format
             {
                 "type": "image",
-                "source": {"type": "base64", "media_type": "image/png", "data": "anthropic_image_data"}
-            }
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": "anthropic_image_data",
+                },
+            },
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 2, Got {len(result)}")
         assert len(result) == 2
-        
+
         print("Checking OpenAI image...")
         assert result[0]["media_type"] == "image/jpeg"
         assert result[0]["data"] == "openai_image_data"
-        
+
         print("Checking Anthropic image...")
         assert result[1]["media_type"] == "image/png"
         assert result[1]["data"] == "anthropic_image_data"
-    
+
     def test_handles_missing_source_in_anthropic_format(self):
         """
         What it does: Verifies handling of Anthropic image without source.
@@ -518,13 +513,13 @@ class TestExtractImagesFromContent:
         content = [
             {"type": "image"}  # Missing source
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_handles_missing_image_url_in_openai_format(self):
         """
         What it does: Verifies handling of OpenAI image_url without image_url field.
@@ -534,13 +529,13 @@ class TestExtractImagesFromContent:
         content = [
             {"type": "image_url"}  # Missing image_url
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_extracts_gif_format(self):
         """
         What it does: Verifies extraction of GIF images.
@@ -550,17 +545,21 @@ class TestExtractImagesFromContent:
         content = [
             {
                 "type": "image",
-                "source": {"type": "base64", "media_type": "image/gif", "data": "gif_data"}
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/gif",
+                    "data": "gif_data",
+                },
             }
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["media_type"] == "image/gif"
-    
+
     def test_extracts_webp_format(self):
         """
         What it does: Verifies extraction of WebP images.
@@ -570,17 +569,21 @@ class TestExtractImagesFromContent:
         content = [
             {
                 "type": "image",
-                "source": {"type": "base64", "media_type": "image/webp", "data": "webp_data"}
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/webp",
+                    "data": "webp_data",
+                },
             }
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["media_type"] == "image/webp"
-    
+
     def test_uses_default_media_type_when_missing(self):
         """
         What it does: Verifies default media_type is used when not specified.
@@ -590,13 +593,13 @@ class TestExtractImagesFromContent:
         content = [
             {
                 "type": "image",
-                "source": {"type": "base64", "data": "some_data"}  # No media_type
+                "source": {"type": "base64", "data": "some_data"},  # No media_type
             }
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["media_type"] == "image/jpeg"  # Default
@@ -606,16 +609,17 @@ class TestExtractImagesFromContent:
 # Tests for convert_images_to_kiro_format
 # ==================================================================================================
 
+
 class TestConvertImagesToKiroFormat:
     """
     Tests for convert_images_to_kiro_format function.
-    
+
     This function converts unified images to Kiro API format.
-    
+
     Unified format: [{"media_type": "image/jpeg", "data": "base64..."}]
     Kiro format: [{"format": "jpeg", "source": {"bytes": "base64..."}}]
     """
-    
+
     def test_converts_single_image(self):
         """
         What it does: Verifies conversion of a single image.
@@ -623,20 +627,20 @@ class TestConvertImagesToKiroFormat:
         """
         print("Setup: Single image in unified format...")
         images = [{"media_type": "image/jpeg", "data": TEST_IMAGE_BASE64}]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 1, Got {len(result)}")
         assert len(result) == 1
-        
+
         print("Checking format...")
         assert result[0]["format"] == "jpeg"
-        
+
         print("Checking source.bytes...")
         assert result[0]["source"]["bytes"] == TEST_IMAGE_BASE64
-    
+
     def test_converts_multiple_images(self):
         """
         What it does: Verifies conversion of multiple images.
@@ -646,47 +650,47 @@ class TestConvertImagesToKiroFormat:
         images = [
             {"media_type": "image/jpeg", "data": "jpeg_data"},
             {"media_type": "image/png", "data": "png_data"},
-            {"media_type": "image/gif", "data": "gif_data"}
+            {"media_type": "image/gif", "data": "gif_data"},
         ]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 3, Got {len(result)}")
         assert len(result) == 3
-        
+
         print("Checking formats...")
         assert result[0]["format"] == "jpeg"
         assert result[1]["format"] == "png"
         assert result[2]["format"] == "gif"
-    
+
     def test_returns_empty_for_none(self):
         """
         What it does: Verifies handling of None.
         Purpose: Ensure None returns empty list.
         """
         print("Setup: None images...")
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(None)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_returns_empty_for_empty_list(self):
         """
         What it does: Verifies handling of empty list.
         Purpose: Ensure empty list returns empty list.
         """
         print("Setup: Empty images list...")
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format([])
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_skips_images_with_empty_data(self):
         """
         What it does: Verifies skipping of images with empty data.
@@ -695,17 +699,17 @@ class TestConvertImagesToKiroFormat:
         print("Setup: Image with empty data...")
         images = [
             {"media_type": "image/jpeg", "data": ""},
-            {"media_type": "image/png", "data": "valid_data"}
+            {"media_type": "image/png", "data": "valid_data"},
         ]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 1, Got {len(result)}")
         assert len(result) == 1
         assert result[0]["format"] == "png"
-    
+
     def test_extracts_format_from_media_type(self):
         """
         What it does: Verifies extraction of format from media_type.
@@ -716,18 +720,18 @@ class TestConvertImagesToKiroFormat:
             {"media_type": "image/jpeg", "data": "data1"},
             {"media_type": "image/png", "data": "data2"},
             {"media_type": "image/gif", "data": "data3"},
-            {"media_type": "image/webp", "data": "data4"}
+            {"media_type": "image/webp", "data": "data4"},
         ]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result formats: {[r['format'] for r in result]}")
         assert result[0]["format"] == "jpeg"
         assert result[1]["format"] == "png"
         assert result[2]["format"] == "gif"
         assert result[3]["format"] == "webp"
-    
+
     def test_handles_media_type_without_slash(self):
         """
         What it does: Verifies handling of media_type without slash.
@@ -735,14 +739,14 @@ class TestConvertImagesToKiroFormat:
         """
         print("Setup: Media type without slash...")
         images = [{"media_type": "jpeg", "data": "data"}]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["format"] == "jpeg"
-    
+
     def test_uses_default_media_type_when_missing(self):
         """
         What it does: Verifies default media_type is used when not specified.
@@ -750,14 +754,14 @@ class TestConvertImagesToKiroFormat:
         """
         print("Setup: Image without media_type...")
         images = [{"data": "some_data"}]  # No media_type
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["format"] == "jpeg"  # Default from "image/jpeg"
-    
+
     def test_preserves_large_image_data(self):
         """
         What it does: Verifies large image data is preserved.
@@ -766,37 +770,44 @@ class TestConvertImagesToKiroFormat:
         print("Setup: Large image data...")
         large_data = "A" * 100000  # 100KB of data
         images = [{"media_type": "image/png", "data": large_data}]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result data length: {len(result[0]['source']['bytes'])}")
         assert len(result[0]["source"]["bytes"]) == 100000
-    
+
     # ==================================================================================
     # Data URL Prefix Stripping Tests (Issue #32 fix)
     # ==================================================================================
-    
+
     def test_strips_data_url_prefix_jpeg(self):
         """
         What it does: Verifies that data URL prefix is stripped from JPEG image data.
         Purpose: Ensure Kiro API receives pure base64 without the data URL prefix (Issue #32 fix).
-        
+
         Some clients send the full data URL in the data field instead of pure base64.
         Kiro API expects pure base64 without the "data:image/jpeg;base64," prefix.
         """
         print("Setup: Image with data URL prefix (JPEG)...")
         pure_base64 = "/9j/4AAQSkZJRg=="  # Sample JPEG base64
-        images = [{"media_type": "image/jpeg", "data": f"data:image/jpeg;base64,{pure_base64}"}]
-        
+        images = [
+            {
+                "media_type": "image/jpeg",
+                "data": f"data:image/jpeg;base64,{pure_base64}",
+            }
+        ]
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
-        print(f"Comparing bytes: Expected '{pure_base64}', Got '{result[0]['source']['bytes']}'")
+        print(
+            f"Comparing bytes: Expected '{pure_base64}', Got '{result[0]['source']['bytes']}'"
+        )
         assert result[0]["source"]["bytes"] == pure_base64
         assert result[0]["format"] == "jpeg"
-    
+
     def test_strips_data_url_prefix_png(self):
         """
         What it does: Verifies that data URL prefix is stripped from PNG image data.
@@ -804,79 +815,85 @@ class TestConvertImagesToKiroFormat:
         """
         print("Setup: Image with data URL prefix (PNG)...")
         pure_base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-        images = [{"media_type": "image/png", "data": f"data:image/png;base64,{pure_base64}"}]
-        
+        images = [
+            {"media_type": "image/png", "data": f"data:image/png;base64,{pure_base64}"}
+        ]
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
-        print(f"Comparing bytes: Expected pure base64, Got '{result[0]['source']['bytes'][:50]}...'")
+        print(
+            f"Comparing bytes: Expected pure base64, Got '{result[0]['source']['bytes'][:50]}...'"
+        )
         assert result[0]["source"]["bytes"] == pure_base64
         assert result[0]["format"] == "png"
-    
+
     def test_extracts_media_type_from_data_url(self):
         """
         What it does: Verifies that media_type is extracted from data URL header.
         Purpose: Ensure media_type from data URL overrides the original media_type (Issue #32 fix).
-        
+
         When data URL contains media type info, it should be used instead of the
         original media_type field (which might be incorrect or generic).
         """
         print("Setup: Image with mismatched media_type and data URL...")
         pure_base64 = "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"  # GIF
         # Original media_type says jpeg, but data URL says gif
-        images = [{"media_type": "image/jpeg", "data": f"data:image/gif;base64,{pure_base64}"}]
-        
+        images = [
+            {"media_type": "image/jpeg", "data": f"data:image/gif;base64,{pure_base64}"}
+        ]
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         print("Checking that media_type from data URL is used...")
         assert result[0]["format"] == "gif"  # Should use gif from data URL, not jpeg
         assert result[0]["source"]["bytes"] == pure_base64
-    
+
     def test_handles_malformed_data_url_no_comma(self):
         """
         What it does: Verifies graceful handling of malformed data URL without comma.
         Purpose: Ensure function doesn't crash on malformed data URLs (Issue #32 fix).
-        
+
         If data URL is malformed (no comma separator), the function should
         log a warning and use the original data as-is.
         """
         print("Setup: Malformed data URL without comma...")
         malformed_data = "data:image/jpeg;base64_without_comma"
         images = [{"media_type": "image/jpeg", "data": malformed_data}]
-        
+
         print("Action: Converting to Kiro format (should handle gracefully)...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         # The function should still produce output, using the malformed data as-is
         # (since split(",", 1) will fail and the except block will catch it)
         assert len(result) == 1
         # After the fix, malformed data URL should be preserved as-is
         assert result[0]["source"]["bytes"] == malformed_data
-    
+
     def test_preserves_pure_base64_data(self):
         """
         What it does: Verifies that pure base64 data (without prefix) is preserved.
         Purpose: Ensure normal base64 data is not modified (Issue #32 fix).
-        
+
         When data is already pure base64 (doesn't start with "data:"),
         it should be passed through unchanged.
         """
         print("Setup: Pure base64 data without prefix...")
         pure_base64 = TEST_IMAGE_BASE64
         images = [{"media_type": "image/jpeg", "data": pure_base64}]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         print("Checking that pure base64 is preserved unchanged...")
         assert result[0]["source"]["bytes"] == pure_base64
         assert result[0]["format"] == "jpeg"
-    
+
     def test_strips_data_url_prefix_webp(self):
         """
         What it does: Verifies that data URL prefix is stripped from WebP image data.
@@ -884,30 +901,35 @@ class TestConvertImagesToKiroFormat:
         """
         print("Setup: Image with data URL prefix (WebP)...")
         pure_base64 = "UklGRh4AAABXRUJQVlA4TBEAAAAvAAAAAAfQ//73v/+BiOh/AAA="
-        images = [{"media_type": "image/webp", "data": f"data:image/webp;base64,{pure_base64}"}]
-        
+        images = [
+            {
+                "media_type": "image/webp",
+                "data": f"data:image/webp;base64,{pure_base64}",
+            }
+        ]
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         assert result[0]["source"]["bytes"] == pure_base64
         assert result[0]["format"] == "webp"
-    
+
     def test_handles_data_url_with_empty_base64(self):
         """
         What it does: Verifies handling of data URL with empty base64 part.
         Purpose: Ensure empty data after prefix is handled correctly (Issue #32 fix).
-        
+
         Note: The function strips the prefix but doesn't re-check for empty data after stripping.
         This means an image with "data:image/jpeg;base64," will result in empty bytes.
         This is acceptable behavior as Kiro API will handle the validation.
         """
         print("Setup: Data URL with empty base64 part...")
         images = [{"media_type": "image/jpeg", "data": "data:image/jpeg;base64,"}]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         print("Checking that image is converted (with empty bytes)...")
         # The function strips the prefix but doesn't re-check for empty data
@@ -921,9 +943,10 @@ class TestConvertImagesToKiroFormat:
 # Tests for merge_adjacent_messages
 # ==================================================================================================
 
+
 class TestMergeAdjacentMessages:
     """Tests for merge_adjacent_messages function using UnifiedMessage."""
-    
+
     def test_merges_adjacent_user_messages(self):
         """
         What it does: Verifies merging of adjacent user messages.
@@ -932,17 +955,17 @@ class TestMergeAdjacentMessages:
         print("Setup: Two consecutive user messages...")
         messages = [
             UnifiedMessage(role="user", content="Hello"),
-            UnifiedMessage(role="user", content="World")
+            UnifiedMessage(role="user", content="World"),
         ]
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Comparing length: Expected 1, Got {len(result)}")
         assert len(result) == 1
         assert "Hello" in result[0].content
         assert "World" in result[0].content
-    
+
     def test_preserves_alternating_messages(self):
         """
         What it does: Verifies preservation of alternating messages.
@@ -952,28 +975,28 @@ class TestMergeAdjacentMessages:
         messages = [
             UnifiedMessage(role="user", content="Hello"),
             UnifiedMessage(role="assistant", content="Hi"),
-            UnifiedMessage(role="user", content="How are you?")
+            UnifiedMessage(role="user", content="How are you?"),
         ]
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Comparing length: Expected 3, Got {len(result)}")
         assert len(result) == 3
-    
+
     def test_handles_empty_list(self):
         """
         What it does: Verifies empty list handling.
         Purpose: Ensure empty list doesn't cause errors.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages([])
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_handles_single_message(self):
         """
         What it does: Verifies single message handling.
@@ -981,14 +1004,14 @@ class TestMergeAdjacentMessages:
         """
         print("Setup: Single message...")
         messages = [UnifiedMessage(role="user", content="Hello")]
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Comparing length: Expected 1, Got {len(result)}")
         assert len(result) == 1
         assert result[0].content == "Hello"
-    
+
     def test_merges_multiple_adjacent_groups(self):
         """
         What it does: Verifies merging of multiple groups.
@@ -1000,18 +1023,18 @@ class TestMergeAdjacentMessages:
             UnifiedMessage(role="user", content="B"),
             UnifiedMessage(role="assistant", content="C"),
             UnifiedMessage(role="assistant", content="D"),
-            UnifiedMessage(role="user", content="E")
+            UnifiedMessage(role="user", content="E"),
         ]
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Comparing length: Expected 3, Got {len(result)}")
         assert len(result) == 3
         assert result[0].role == "user"
         assert result[1].role == "assistant"
         assert result[2].role == "user"
-    
+
     def test_merges_list_contents_correctly(self):
         """
         What it does: Verifies merging of list contents.
@@ -1020,22 +1043,22 @@ class TestMergeAdjacentMessages:
         print("Setup: Two user messages with list content...")
         messages = [
             UnifiedMessage(role="user", content=[{"type": "text", "text": "Part 1"}]),
-            UnifiedMessage(role="user", content=[{"type": "text", "text": "Part 2"}])
+            UnifiedMessage(role="user", content=[{"type": "text", "text": "Part 2"}]),
         ]
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert isinstance(result[0].content, list)
         assert len(result[0].content) == 2
-    
+
     def test_merges_adjacent_assistant_tool_calls(self):
         """
         What it does: Verifies merging of tool_calls when merging adjacent assistant messages.
         Purpose: Ensure tool_calls from all assistant messages are preserved when merging.
-        
+
         This is a critical test for a bug where multiple assistant messages with tool_calls
         were sent in a row, and the second tool_call was lost.
         """
@@ -1044,41 +1067,53 @@ class TestMergeAdjacentMessages:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "tooluse_first",
-                    "type": "function",
-                    "function": {"name": "shell", "arguments": '{"command": ["ls"]}'}
-                }]
+                tool_calls=[
+                    {
+                        "id": "tooluse_first",
+                        "type": "function",
+                        "function": {
+                            "name": "shell",
+                            "arguments": '{"command": ["ls"]}',
+                        },
+                    }
+                ],
             ),
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "tooluse_second",
-                    "type": "function",
-                    "function": {"name": "shell", "arguments": '{"command": ["pwd"]}'}
-                }]
-            )
+                tool_calls=[
+                    {
+                        "id": "tooluse_second",
+                        "type": "function",
+                        "function": {
+                            "name": "shell",
+                            "arguments": '{"command": ["pwd"]}',
+                        },
+                    }
+                ],
+            ),
         ]
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Result: {result}")
         print(f"Comparing length: Expected 1, Got {len(result)}")
         assert len(result) == 1
         assert result[0].role == "assistant"
-        
+
         print("Checking that both tool_calls are preserved...")
         assert result[0].tool_calls is not None
-        print(f"Comparing tool_calls count: Expected 2, Got {len(result[0].tool_calls)}")
+        print(
+            f"Comparing tool_calls count: Expected 2, Got {len(result[0].tool_calls)}"
+        )
         assert len(result[0].tool_calls) == 2
-        
+
         tool_ids = [tc["id"] for tc in result[0].tool_calls]
         print(f"Tool IDs: {tool_ids}")
         assert "tooluse_first" in tool_ids
         assert "tooluse_second" in tool_ids
-    
+
     def test_merges_three_adjacent_assistant_tool_calls(self):
         """
         What it does: Verifies merging of tool_calls from three assistant messages.
@@ -1086,28 +1121,54 @@ class TestMergeAdjacentMessages:
         """
         print("Setup: Three assistant messages with tool_calls...")
         messages = [
-            UnifiedMessage(role="assistant", content="", tool_calls=[
-                {"id": "call_1", "type": "function", "function": {"name": "tool1", "arguments": "{}"}}
-            ]),
-            UnifiedMessage(role="assistant", content="", tool_calls=[
-                {"id": "call_2", "type": "function", "function": {"name": "tool2", "arguments": "{}"}}
-            ]),
-            UnifiedMessage(role="assistant", content="", tool_calls=[
-                {"id": "call_3", "type": "function", "function": {"name": "tool3", "arguments": "{}"}}
-            ])
+            UnifiedMessage(
+                role="assistant",
+                content="",
+                tool_calls=[
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "tool1", "arguments": "{}"},
+                    }
+                ],
+            ),
+            UnifiedMessage(
+                role="assistant",
+                content="",
+                tool_calls=[
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "tool2", "arguments": "{}"},
+                    }
+                ],
+            ),
+            UnifiedMessage(
+                role="assistant",
+                content="",
+                tool_calls=[
+                    {
+                        "id": "call_3",
+                        "type": "function",
+                        "function": {"name": "tool3", "arguments": "{}"},
+                    }
+                ],
+            ),
         ]
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert len(result[0].tool_calls) == 3
-        
+
         tool_ids = [tc["id"] for tc in result[0].tool_calls]
-        print(f"Comparing tool IDs: Expected ['call_1', 'call_2', 'call_3'], Got {tool_ids}")
+        print(
+            f"Comparing tool IDs: Expected ['call_1', 'call_2', 'call_3'], Got {tool_ids}"
+        )
         assert tool_ids == ["call_1", "call_2", "call_3"]
-    
+
     def test_merges_assistant_with_and_without_tool_calls(self):
         """
         What it does: Verifies merging of assistant with and without tool_calls.
@@ -1116,21 +1177,31 @@ class TestMergeAdjacentMessages:
         print("Setup: Assistant without tool_calls + assistant with tool_calls...")
         messages = [
             UnifiedMessage(role="assistant", content="Thinking...", tool_calls=None),
-            UnifiedMessage(role="assistant", content="", tool_calls=[
-                {"id": "call_1", "type": "function", "function": {"name": "tool1", "arguments": "{}"}}
-            ])
+            UnifiedMessage(
+                role="assistant",
+                content="",
+                tool_calls=[
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "tool1", "arguments": "{}"},
+                    }
+                ],
+            ),
         ]
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0].tool_calls is not None
-        print(f"Comparing tool_calls count: Expected 1, Got {len(result[0].tool_calls)}")
+        print(
+            f"Comparing tool_calls count: Expected 1, Got {len(result[0].tool_calls)}"
+        )
         assert len(result[0].tool_calls) == 1
         assert result[0].tool_calls[0]["id"] == "call_1"
-    
+
     def test_merges_user_messages_with_tool_results(self):
         """
         What it does: Verifies merging of user messages with tool_results.
@@ -1138,17 +1209,33 @@ class TestMergeAdjacentMessages:
         """
         print("Setup: Two user messages with tool_results...")
         messages = [
-            UnifiedMessage(role="user", content="", tool_results=[
-                {"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"}
-            ]),
-            UnifiedMessage(role="user", content="", tool_results=[
-                {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"}
-            ])
+            UnifiedMessage(
+                role="user",
+                content="",
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_1",
+                        "content": "Result 1",
+                    }
+                ],
+            ),
+            UnifiedMessage(
+                role="user",
+                content="",
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_2",
+                        "content": "Result 2",
+                    }
+                ],
+            ),
         ]
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0].tool_results is not None
@@ -1159,30 +1246,31 @@ class TestMergeAdjacentMessages:
 # Tests for ensure_assistant_before_tool_results
 # ==================================================================================================
 
+
 class TestEnsureAssistantBeforeToolResults:
     """
     Tests for ensure_assistant_before_tool_results function.
-    
+
     This function handles the case when clients (like Cline/Roo) send truncated
     conversations with tool_results but without the preceding assistant message
     that contains the tool_calls. Since we don't know the original tool name,
     we strip the orphaned tool_results to avoid Kiro API rejection.
     """
-    
+
     def test_returns_empty_list_for_empty_input(self):
         """
         What it does: Verifies empty list handling.
         Purpose: Ensure empty input returns empty output.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Processing messages...")
         result, stripped = ensure_assistant_before_tool_results([])
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
         assert stripped is False
-    
+
     def test_preserves_messages_without_tool_results(self):
         """
         What it does: Verifies messages without tool_results are unchanged.
@@ -1192,65 +1280,74 @@ class TestEnsureAssistantBeforeToolResults:
         messages = [
             UnifiedMessage(role="user", content="Hello"),
             UnifiedMessage(role="assistant", content="Hi there"),
-            UnifiedMessage(role="user", content="How are you?")
+            UnifiedMessage(role="user", content="How are you?"),
         ]
-        
+
         print("Action: Processing messages...")
         result, stripped = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Comparing length: Expected 3, Got {len(result)}")
         assert len(result) == 3
         assert result[0].content == "Hello"
         assert result[1].content == "Hi there"
         assert result[2].content == "How are you?"
         assert stripped is False
-    
+
     def test_preserves_tool_results_with_preceding_assistant(self):
         """
         What it does: Verifies tool_results are preserved when assistant with tool_calls precedes.
         Purpose: Ensure valid tool_results are not stripped.
         """
-        print("Setup: Valid conversation with assistant tool_calls followed by user tool_results...")
+        print(
+            "Setup: Valid conversation with assistant tool_calls followed by user tool_results..."
+        )
         messages = [
             UnifiedMessage(role="user", content="Call a tool"),
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "get_weather", "arguments": '{"location": "Moscow"}'}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"location": "Moscow"}',
+                        },
+                    }
+                ],
             ),
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Weather is sunny"
-                }]
-            )
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": "Weather is sunny",
+                    }
+                ],
+            ),
         ]
-        
+
         print("Action: Processing messages...")
         result, stripped = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print(f"Comparing length: Expected 3, Got {len(result)}")
         assert len(result) == 3
-        
+
         print("Checking that tool_results are preserved...")
         assert result[2].tool_results is not None
         assert len(result[2].tool_results) == 1
         assert result[2].tool_results[0]["tool_use_id"] == "call_123"
         assert stripped is False
-    
+
     def test_strips_orphaned_tool_results_at_start(self):
         """
         What it does: Verifies orphaned tool_results at the start are stripped.
         Purpose: Ensure tool_results without preceding assistant are removed.
-        
+
         This is the critical bug fix test - when a client sends a truncated
         conversation starting with tool_results, they should be stripped.
         """
@@ -1259,56 +1356,64 @@ class TestEnsureAssistantBeforeToolResults:
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_orphan",
-                    "content": "Orphaned result"
-                }]
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_orphan",
+                        "content": "Orphaned result",
+                    }
+                ],
             ),
-            UnifiedMessage(role="user", content="Continue the conversation")
+            UnifiedMessage(role="user", content="Continue the conversation"),
         ]
-        
+
         print("Action: Processing messages...")
         result, stripped = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print(f"Comparing length: Expected 2, Got {len(result)}")
         assert len(result) == 2
-        
+
         print("Checking that orphaned tool_results are stripped...")
         assert result[0].tool_results is None
         assert result[0].content == ""  # Content preserved
         assert result[1].content == "Continue the conversation"
         assert stripped is True
-    
+
     def test_strips_tool_results_after_assistant_without_tool_calls(self):
         """
         What it does: Verifies tool_results are stripped when preceding assistant has no tool_calls.
         Purpose: Ensure tool_results require assistant with tool_calls, not just any assistant.
         """
-        print("Setup: Assistant without tool_calls followed by user with tool_results...")
+        print(
+            "Setup: Assistant without tool_calls followed by user with tool_results..."
+        )
         messages = [
             UnifiedMessage(role="user", content="Hello"),
-            UnifiedMessage(role="assistant", content="Let me think...", tool_calls=None),
+            UnifiedMessage(
+                role="assistant", content="Let me think...", tool_calls=None
+            ),
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Result"
-                }]
-            )
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": "Result",
+                    }
+                ],
+            ),
         ]
-        
+
         print("Action: Processing messages...")
         result, stripped = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that tool_results are stripped...")
         assert result[2].tool_results is None
         assert stripped is True
-    
+
     def test_strips_tool_results_after_user_message(self):
         """
         What it does: Verifies tool_results are stripped when preceded by user message.
@@ -1320,22 +1425,24 @@ class TestEnsureAssistantBeforeToolResults:
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Result"
-                }]
-            )
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": "Result",
+                    }
+                ],
+            ),
         ]
-        
+
         print("Action: Processing messages...")
         result, stripped = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that tool_results are stripped...")
         assert result[1].tool_results is None
         assert stripped is True
-    
+
     def test_preserves_content_when_stripping_tool_results(self):
         """
         What it does: Verifies message content is preserved when tool_results are stripped.
@@ -1346,23 +1453,25 @@ class TestEnsureAssistantBeforeToolResults:
             UnifiedMessage(
                 role="user",
                 content="Here is some context",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Result"
-                }]
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": "Result",
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Processing messages...")
         result, stripped = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that content is preserved...")
         assert result[0].content == "Here is some context"
         assert result[0].tool_results is None
         assert stripped is True
-    
+
     def test_preserves_tool_calls_when_stripping_tool_results(self):
         """
         What it does: Verifies tool_calls are preserved when tool_results are stripped.
@@ -1373,29 +1482,33 @@ class TestEnsureAssistantBeforeToolResults:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "call_new",
-                    "type": "function",
-                    "function": {"name": "new_tool", "arguments": "{}"}
-                }],
-                tool_results=[{  # This shouldn't happen but let's test it
-                    "type": "tool_result",
-                    "tool_use_id": "call_old",
-                    "content": "Old result"
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_new",
+                        "type": "function",
+                        "function": {"name": "new_tool", "arguments": "{}"},
+                    }
+                ],
+                tool_results=[
+                    {  # This shouldn't happen but let's test it
+                        "type": "tool_result",
+                        "tool_use_id": "call_old",
+                        "content": "Old result",
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Processing messages...")
         result, stripped = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that tool_calls are preserved...")
         assert result[0].tool_calls is not None
         assert len(result[0].tool_calls) == 1
         assert result[0].tool_results is None
         assert stripped is True
-    
+
     def test_handles_multiple_orphaned_tool_results(self):
         """
         What it does: Verifies multiple orphaned tool_results are all stripped.
@@ -1407,21 +1520,33 @@ class TestEnsureAssistantBeforeToolResults:
                 role="user",
                 content="",
                 tool_results=[
-                    {"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"},
-                    {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"},
-                    {"type": "tool_result", "tool_use_id": "call_3", "content": "Result 3"}
-                ]
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_1",
+                        "content": "Result 1",
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_2",
+                        "content": "Result 2",
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_3",
+                        "content": "Result 3",
+                    },
+                ],
             )
         ]
-        
+
         print("Action: Processing messages...")
         result, stripped = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that all tool_results are stripped...")
         assert result[0].tool_results is None
         assert stripped is True
-    
+
     def test_mixed_valid_and_orphaned_tool_results(self):
         """
         What it does: Verifies correct handling of mixed valid and orphaned tool_results.
@@ -1433,46 +1558,52 @@ class TestEnsureAssistantBeforeToolResults:
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_orphan",
-                    "content": "Orphaned"
-                }]
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_orphan",
+                        "content": "Orphaned",
+                    }
+                ],
             ),
             # Valid assistant with tool_calls
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "call_valid",
-                    "type": "function",
-                    "function": {"name": "valid_tool", "arguments": "{}"}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_valid",
+                        "type": "function",
+                        "function": {"name": "valid_tool", "arguments": "{}"},
+                    }
+                ],
             ),
             # Valid tool_results
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_valid",
-                    "content": "Valid result"
-                }]
-            )
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_valid",
+                        "content": "Valid result",
+                    }
+                ],
+            ),
         ]
-        
+
         print("Action: Processing messages...")
         result, stripped = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print("Checking orphaned tool_results are stripped...")
         assert result[0].tool_results is None
-        
+
         print("Checking valid tool_results are preserved...")
         assert result[2].tool_results is not None
         assert result[2].tool_results[0]["tool_use_id"] == "call_valid"
         assert stripped is True  # Because orphaned ones were stripped
-    
+
     def test_single_message_with_tool_results(self):
         """
         What it does: Verifies handling of single message with tool_results.
@@ -1483,17 +1614,19 @@ class TestEnsureAssistantBeforeToolResults:
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Result"
-                }]
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": "Result",
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Processing messages...")
         result, stripped = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that tool_results are stripped...")
         assert len(result) == 1
@@ -1505,65 +1638,62 @@ class TestEnsureAssistantBeforeToolResults:
 # Tests for sanitize_json_schema
 # ==================================================================================================
 
+
 class TestSanitizeJsonSchema:
     """
     Tests for sanitize_json_schema function.
-    
+
     This function cleans JSON Schema from fields that Kiro API doesn't accept:
     - Empty required arrays []
     - additionalProperties
     """
-    
+
     def test_returns_empty_dict_for_none(self):
         """
         What it does: Verifies handling of None.
         Purpose: Ensure None returns empty dict.
         """
         print("Setup: None schema...")
-        
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(None)
-        
+
         print(f"Comparing result: Expected {{}}, Got {result}")
         assert result == {}
-    
+
     def test_returns_empty_dict_for_empty_dict(self):
         """
         What it does: Verifies handling of empty dict.
         Purpose: Ensure empty dict is returned as-is.
         """
         print("Setup: Empty dict...")
-        
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema({})
-        
+
         print(f"Comparing result: Expected {{}}, Got {result}")
         assert result == {}
-    
+
     def test_removes_empty_required_array(self):
         """
         What it does: Verifies removal of empty required array.
         Purpose: Ensure required: [] is removed from schema.
-        
+
         This is a critical test for a bug where tools with required: []
         caused a 400 "Improperly formed request" error from Kiro API.
         """
         print("Setup: Schema with empty required...")
-        schema = {
-            "type": "object",
-            "properties": {},
-            "required": []
-        }
-        
+        schema = {"type": "object", "properties": {}, "required": []}
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(schema)
-        
+
         print(f"Result: {result}")
         print("Checking that required is removed...")
         assert "required" not in result
         assert result["type"] == "object"
         assert result["properties"] == {}
-    
+
     def test_preserves_non_empty_required_array(self):
         """
         What it does: Verifies preservation of non-empty required array.
@@ -1573,39 +1703,35 @@ class TestSanitizeJsonSchema:
         schema = {
             "type": "object",
             "properties": {"location": {"type": "string"}},
-            "required": ["location"]
+            "required": ["location"],
         }
-        
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(schema)
-        
+
         print(f"Result: {result}")
         print("Checking that required is preserved...")
         assert "required" in result
         assert result["required"] == ["location"]
-    
+
     def test_removes_additional_properties(self):
         """
         What it does: Verifies removal of additionalProperties.
         Purpose: Ensure additionalProperties is removed from schema.
-        
+
         Kiro API doesn't support additionalProperties in JSON Schema.
         """
         print("Setup: Schema with additionalProperties...")
-        schema = {
-            "type": "object",
-            "properties": {},
-            "additionalProperties": False
-        }
-        
+        schema = {"type": "object", "properties": {}, "additionalProperties": False}
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(schema)
-        
+
         print(f"Result: {result}")
         print("Checking that additionalProperties is removed...")
         assert "additionalProperties" not in result
         assert result["type"] == "object"
-    
+
     def test_removes_both_empty_required_and_additional_properties(self):
         """
         What it does: Verifies removal of both problematic fields.
@@ -1616,18 +1742,18 @@ class TestSanitizeJsonSchema:
             "type": "object",
             "properties": {},
             "required": [],
-            "additionalProperties": False
+            "additionalProperties": False,
         }
-        
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(schema)
-        
+
         print(f"Result: {result}")
         print("Checking that both fields are removed...")
         assert "required" not in result
         assert "additionalProperties" not in result
         assert result == {"type": "object", "properties": {}}
-    
+
     def test_recursively_sanitizes_nested_properties(self):
         """
         What it does: Verifies recursive sanitization of nested properties.
@@ -1641,20 +1767,20 @@ class TestSanitizeJsonSchema:
                     "type": "object",
                     "properties": {},
                     "required": [],
-                    "additionalProperties": False
+                    "additionalProperties": False,
                 }
-            }
+            },
         }
-        
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(schema)
-        
+
         print(f"Result: {result}")
         print("Checking nested object...")
         nested = result["properties"]["nested"]
         assert "required" not in nested
         assert "additionalProperties" not in nested
-    
+
     def test_sanitizes_items_in_lists(self):
         """
         What it does: Verifies sanitization of items in lists (anyOf, oneOf).
@@ -1664,36 +1790,33 @@ class TestSanitizeJsonSchema:
         schema = {
             "anyOf": [
                 {"type": "string", "additionalProperties": False},
-                {"type": "number", "required": []}
+                {"type": "number", "required": []},
             ]
         }
-        
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(schema)
-        
+
         print(f"Result: {result}")
         print("Checking anyOf elements...")
         assert "additionalProperties" not in result["anyOf"][0]
         assert "required" not in result["anyOf"][1]
-    
+
     def test_preserves_non_dict_list_items(self):
         """
         What it does: Verifies preservation of non-dict list items.
         Purpose: Ensure strings and other types in lists are preserved.
         """
         print("Setup: Schema with enum...")
-        schema = {
-            "type": "string",
-            "enum": ["value1", "value2", "value3"]
-        }
-        
+        schema = {"type": "string", "enum": ["value1", "value2", "value3"]}
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(schema)
-        
+
         print(f"Result: {result}")
         print("Checking enum is preserved...")
         assert result["enum"] == ["value1", "value2", "value3"]
-    
+
     def test_complex_real_world_schema(self):
         """
         What it does: Verifies sanitization of real complex schema.
@@ -1704,19 +1827,22 @@ class TestSanitizeJsonSchema:
             "type": "object",
             "properties": {
                 "question": {"type": "string", "description": "The question to ask"},
-                "options": {"type": "string", "description": "Array of options"}
+                "options": {"type": "string", "description": "Array of options"},
             },
             "required": ["question", "options"],
-            "additionalProperties": False
+            "additionalProperties": False,
         }
-        
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(schema)
-        
+
         print(f"Result: {result}")
         print("Checking result...")
         assert "additionalProperties" not in result
-        assert result["required"] == ["question", "options"]  # Non-empty required is preserved
+        assert result["required"] == [
+            "question",
+            "options",
+        ]  # Non-empty required is preserved
         assert result["properties"]["question"]["type"] == "string"
 
 
@@ -1724,9 +1850,10 @@ class TestSanitizeJsonSchema:
 # Tests for extract_tool_results_from_content
 # ==================================================================================================
 
+
 class TestExtractToolResults:
     """Tests for extract_tool_results_from_content function."""
-    
+
     def test_extracts_tool_results_from_list(self):
         """
         What it does: Verifies extraction of tool results from list.
@@ -1736,15 +1863,15 @@ class TestExtractToolResults:
         content = [
             {"type": "tool_result", "tool_use_id": "call_123", "content": "Result text"}
         ]
-        
+
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_content(content)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["toolUseId"] == "call_123"
         assert result[0]["status"] == "success"
-    
+
     def test_returns_empty_for_string_content(self):
         """
         What it does: Verifies empty list return for string.
@@ -1752,13 +1879,13 @@ class TestExtractToolResults:
         """
         print("Setup: String...")
         content = "Just a string"
-        
+
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_returns_empty_for_list_without_tool_results(self):
         """
         What it does: Verifies empty list return without tool_result.
@@ -1766,13 +1893,13 @@ class TestExtractToolResults:
         """
         print("Setup: List without tool_result...")
         content = [{"type": "text", "text": "Hello"}]
-        
+
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_extracts_multiple_tool_results(self):
         """
         What it does: Verifies extraction of multiple tool results.
@@ -1782,12 +1909,12 @@ class TestExtractToolResults:
         content = [
             {"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"},
             {"type": "text", "text": "Some text"},
-            {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"}
+            {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"},
         ]
-        
+
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_content(content)
-        
+
         print(f"Result: {result}")
         assert len(result) == 2
         assert result[0]["toolUseId"] == "call_1"
@@ -1798,19 +1925,20 @@ class TestExtractToolResults:
 # Tests for convert_tool_results_to_kiro_format
 # ==================================================================================================
 
+
 class TestConvertToolResultsToKiroFormat:
     """
     Tests for convert_tool_results_to_kiro_format function.
-    
+
     This function converts unified tool results format (snake_case) to Kiro API format (camelCase).
-    
+
     Unified format: {"type": "tool_result", "tool_use_id": "...", "content": "..."}
     Kiro format: {"content": [{"text": "..."}], "status": "success", "toolUseId": "..."}
-    
+
     This is a critical function for fixing the 400 "Improperly formed request" bug
     where tool_results were sent in unified format instead of Kiro format.
     """
-    
+
     def test_converts_single_tool_result(self):
         """
         What it does: Verifies conversion of a single tool result.
@@ -1820,26 +1948,26 @@ class TestConvertToolResultsToKiroFormat:
         tool_results = [
             {"type": "tool_result", "tool_use_id": "call_123", "content": "Result text"}
         ]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result: {result}")
         print("Checking structure...")
         assert len(result) == 1
-        
+
         print("Checking toolUseId (camelCase)...")
         assert result[0]["toolUseId"] == "call_123"
-        
+
         print("Checking status...")
         assert result[0]["status"] == "success"
-        
+
         print("Checking content structure...")
         assert "content" in result[0]
         assert isinstance(result[0]["content"], list)
         assert len(result[0]["content"]) == 1
         assert result[0]["content"][0]["text"] == "Result text"
-    
+
     def test_converts_multiple_tool_results(self):
         """
         What it does: Verifies conversion of multiple tool results.
@@ -1849,39 +1977,39 @@ class TestConvertToolResultsToKiroFormat:
         tool_results = [
             {"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"},
             {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"},
-            {"type": "tool_result", "tool_use_id": "call_3", "content": "Result 3"}
+            {"type": "tool_result", "tool_use_id": "call_3", "content": "Result 3"},
         ]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 3, Got {len(result)}")
         assert len(result) == 3
-        
+
         print("Checking all toolUseIds...")
         assert result[0]["toolUseId"] == "call_1"
         assert result[1]["toolUseId"] == "call_2"
         assert result[2]["toolUseId"] == "call_3"
-        
+
         print("Checking all contents...")
         assert result[0]["content"][0]["text"] == "Result 1"
         assert result[1]["content"][0]["text"] == "Result 2"
         assert result[2]["content"][0]["text"] == "Result 3"
-    
+
     def test_returns_empty_list_for_empty_input(self):
         """
         What it does: Verifies empty list handling.
         Purpose: Ensure empty input returns empty output.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format([])
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_replaces_empty_content_with_placeholder(self):
         """
         What it does: Verifies empty content is replaced with placeholder.
@@ -1891,14 +2019,14 @@ class TestConvertToolResultsToKiroFormat:
         tool_results = [
             {"type": "tool_result", "tool_use_id": "call_123", "content": ""}
         ]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result: {result}")
         print("Checking that empty content is replaced with placeholder...")
         assert result[0]["content"][0]["text"] == "(empty result)"
-    
+
     def test_replaces_none_content_with_placeholder(self):
         """
         What it does: Verifies None content is replaced with placeholder.
@@ -1908,49 +2036,45 @@ class TestConvertToolResultsToKiroFormat:
         tool_results = [
             {"type": "tool_result", "tool_use_id": "call_123", "content": None}
         ]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result: {result}")
         print("Checking that None content is replaced with placeholder...")
         assert result[0]["content"][0]["text"] == "(empty result)"
-    
+
     def test_handles_missing_content_key(self):
         """
         What it does: Verifies handling of missing content key.
         Purpose: Ensure function doesn't crash when content key is missing.
         """
         print("Setup: Tool result without content key...")
-        tool_results = [
-            {"type": "tool_result", "tool_use_id": "call_123"}
-        ]
-        
+        tool_results = [{"type": "tool_result", "tool_use_id": "call_123"}]
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result: {result}")
         print("Checking that missing content is replaced with placeholder...")
         assert result[0]["content"][0]["text"] == "(empty result)"
-    
+
     def test_handles_missing_tool_use_id(self):
         """
         What it does: Verifies handling of missing tool_use_id.
         Purpose: Ensure function returns empty string for missing tool_use_id.
         """
         print("Setup: Tool result without tool_use_id...")
-        tool_results = [
-            {"type": "tool_result", "content": "Result text"}
-        ]
-        
+        tool_results = [{"type": "tool_result", "content": "Result text"}]
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result: {result}")
         print("Checking that missing tool_use_id becomes empty string...")
         assert result[0]["toolUseId"] == ""
         assert result[0]["content"][0]["text"] == "Result text"
-    
+
     def test_extracts_text_from_list_content(self):
         """
         What it does: Verifies extraction of text from list content.
@@ -1963,18 +2087,18 @@ class TestConvertToolResultsToKiroFormat:
                 "tool_use_id": "call_123",
                 "content": [
                     {"type": "text", "text": "Part 1"},
-                    {"type": "text", "text": " Part 2"}
-                ]
+                    {"type": "text", "text": " Part 2"},
+                ],
             }
         ]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result: {result}")
         print("Checking that list content is extracted correctly...")
         assert result[0]["content"][0]["text"] == "Part 1 Part 2"
-    
+
     def test_preserves_long_content(self):
         """
         What it does: Verifies long content is preserved.
@@ -1985,15 +2109,15 @@ class TestConvertToolResultsToKiroFormat:
         tool_results = [
             {"type": "tool_result", "tool_use_id": "call_123", "content": long_content}
         ]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result content length: {len(result[0]['content'][0]['text'])}")
         print("Checking that long content is preserved...")
         assert result[0]["content"][0]["text"] == long_content
         assert len(result[0]["content"][0]["text"]) == 10000
-    
+
     def test_all_results_have_success_status(self):
         """
         What it does: Verifies all results have status="success".
@@ -2002,17 +2126,17 @@ class TestConvertToolResultsToKiroFormat:
         print("Setup: Multiple tool results...")
         tool_results = [
             {"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"},
-            {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"}
+            {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"},
         ]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print("Checking all statuses...")
         for i, r in enumerate(result):
             print(f"Result {i}: status = {r['status']}")
             assert r["status"] == "success"
-    
+
     def test_handles_unicode_content(self):
         """
         What it does: Verifies Unicode content is preserved.
@@ -2020,12 +2144,16 @@ class TestConvertToolResultsToKiroFormat:
         """
         print("Setup: Tool result with Unicode content...")
         tool_results = [
-            {"type": "tool_result", "tool_use_id": "call_123", "content": "Привет мир! 你好世界! 🎉"}
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_123",
+                "content": "Привет мир! 你好世界! 🎉",
+            }
         ]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result: {result}")
         print("Checking that Unicode content is preserved...")
         assert result[0]["content"][0]["text"] == "Привет мир! 你好世界! 🎉"
@@ -2035,85 +2163,84 @@ class TestConvertToolResultsToKiroFormat:
 # Tests for extract_tool_uses_from_message
 # ==================================================================================================
 
+
 class TestExtractToolUses:
     """Tests for extract_tool_uses_from_message function."""
-    
+
     def test_extracts_from_tool_calls_field(self):
         """
         What it does: Verifies extraction from tool_calls field.
         Purpose: Ensure OpenAI tool_calls format is handled.
         """
         print("Setup: tool_calls list...")
-        tool_calls = [{
-            "id": "call_123",
-            "function": {
-                "name": "get_weather",
-                "arguments": '{"location": "Moscow"}'
+        tool_calls = [
+            {
+                "id": "call_123",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '{"location": "Moscow"}',
+                },
             }
-        }]
-        
+        ]
+
         print("Action: Extracting tool uses...")
         result = extract_tool_uses_from_message(content="", tool_calls=tool_calls)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["name"] == "get_weather"
         assert result[0]["toolUseId"] == "call_123"
-    
+
     def test_extracts_from_content_list(self):
         """
         What it does: Verifies extraction from content list.
         Purpose: Ensure tool_use in content is handled (Anthropic format).
         """
         print("Setup: Content with tool_use...")
-        content = [{
-            "type": "tool_use",
-            "id": "call_456",
-            "name": "search",
-            "input": {"query": "test"}
-        }]
-        
+        content = [
+            {
+                "type": "tool_use",
+                "id": "call_456",
+                "name": "search",
+                "input": {"query": "test"},
+            }
+        ]
+
         print("Action: Extracting tool uses...")
         result = extract_tool_uses_from_message(content=content, tool_calls=None)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["name"] == "search"
         assert result[0]["toolUseId"] == "call_456"
-    
+
     def test_returns_empty_for_no_tool_uses(self):
         """
         What it does: Verifies empty list return without tool uses.
         Purpose: Ensure regular message doesn't contain tool uses.
         """
         print("Setup: Regular content...")
-        
+
         print("Action: Extracting tool uses...")
         result = extract_tool_uses_from_message(content="Hello", tool_calls=None)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_extracts_from_both_sources(self):
         """
         What it does: Verifies extraction from both tool_calls and content.
         Purpose: Ensure both sources are combined.
         """
         print("Setup: Both tool_calls and content with tool_use...")
-        tool_calls = [{
-            "id": "call_1",
-            "function": {"name": "tool1", "arguments": "{}"}
-        }]
-        content = [{
-            "type": "tool_use",
-            "id": "call_2",
-            "name": "tool2",
-            "input": {}
-        }]
-        
+        tool_calls = [
+            {"id": "call_1", "function": {"name": "tool1", "arguments": "{}"}}
+        ]
+        content = [{"type": "tool_use", "id": "call_2", "name": "tool2", "input": {}}]
+
         print("Action: Extracting tool uses...")
         result = extract_tool_uses_from_message(content=content, tool_calls=tool_calls)
-        
+
         print(f"Result: {result}")
         assert len(result) == 2
 
@@ -2122,58 +2249,63 @@ class TestExtractToolUses:
 # Tests for process_tools_with_long_descriptions
 # ==================================================================================================
 
+
 class TestProcessToolsWithLongDescriptions:
     """Tests for process_tools_with_long_descriptions function using UnifiedTool."""
-    
+
     def test_returns_none_and_empty_string_for_none_tools(self):
         """
         What it does: Verifies handling of None instead of tools list.
         Purpose: Ensure None returns (None, "").
         """
         print("Setup: None instead of tools...")
-        
+
         print("Action: Processing tools...")
         processed, doc = process_tools_with_long_descriptions(None)
-        
+
         print(f"Comparing result: Expected (None, ''), Got ({processed}, '{doc}')")
         assert processed is None
         assert doc == ""
-    
+
     def test_returns_none_and_empty_string_for_empty_list(self):
         """
         What it does: Verifies handling of empty tools list.
         Purpose: Ensure empty list returns (None, "").
         """
         print("Setup: Empty tools list...")
-        
+
         print("Action: Processing tools...")
         processed, doc = process_tools_with_long_descriptions([])
-        
+
         print(f"Comparing result: Expected (None, ''), Got ({processed}, '{doc}')")
         assert processed is None
         assert doc == ""
-    
+
     def test_short_description_unchanged(self):
         """
         What it does: Verifies short descriptions are unchanged.
         Purpose: Ensure tools with short descriptions remain as-is.
         """
         print("Setup: Tool with short description...")
-        tools = [UnifiedTool(
-            name="get_weather",
-            description="Get weather for a location",
-            input_schema={"type": "object", "properties": {}}
-        )]
-        
+        tools = [
+            UnifiedTool(
+                name="get_weather",
+                description="Get weather for a location",
+                input_schema={"type": "object", "properties": {}},
+            )
+        ]
+
         print("Action: Processing tools...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 10000):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 10000):
             processed, doc = process_tools_with_long_descriptions(tools)
-        
-        print(f"Comparing description: Expected 'Get weather for a location', Got '{processed[0].description}'")
+
+        print(
+            f"Comparing description: Expected 'Get weather for a location', Got '{processed[0].description}'"
+        )
         assert len(processed) == 1
         assert processed[0].description == "Get weather for a location"
         assert doc == ""
-    
+
     def test_long_description_moved_to_system_prompt(self):
         """
         What it does: Verifies moving long description to system prompt.
@@ -2181,25 +2313,33 @@ class TestProcessToolsWithLongDescriptions:
         """
         print("Setup: Tool with very long description...")
         long_description = "A" * 15000  # 15000 chars - exceeds limit
-        tools = [UnifiedTool(
-            name="bash",
-            description=long_description,
-            input_schema={"type": "object", "properties": {"command": {"type": "string"}}}
-        )]
-        
+        tools = [
+            UnifiedTool(
+                name="bash",
+                description=long_description,
+                input_schema={
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                },
+            )
+        ]
+
         print("Action: Processing tools with limit 10000...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 10000):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 10000):
             processed, doc = process_tools_with_long_descriptions(tools)
-        
+
         print("Checking reference in description...")
         assert len(processed) == 1
-        assert "[Full documentation in system prompt under '## Tool: bash']" in processed[0].description
-        
+        assert (
+            "[Full documentation in system prompt under '## Tool: bash']"
+            in processed[0].description
+        )
+
         print("Checking documentation in system prompt...")
         assert "## Tool: bash" in doc
         assert long_description in doc
         assert "# Tool Documentation" in doc
-    
+
     def test_mixed_short_and_long_descriptions(self):
         """
         What it does: Verifies handling of mixed tools list.
@@ -2210,24 +2350,24 @@ class TestProcessToolsWithLongDescriptions:
         long_desc = "B" * 15000
         tools = [
             UnifiedTool(name="short_tool", description=short_desc, input_schema={}),
-            UnifiedTool(name="long_tool", description=long_desc, input_schema={})
+            UnifiedTool(name="long_tool", description=long_desc, input_schema={}),
         ]
-        
+
         print("Action: Processing tools...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 10000):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 10000):
             processed, doc = process_tools_with_long_descriptions(tools)
-        
+
         print(f"Checking tools count: Expected 2, Got {len(processed)}")
         assert len(processed) == 2
-        
+
         print("Checking short tool...")
         assert processed[0].description == short_desc
-        
+
         print("Checking long tool...")
         assert "[Full documentation in system prompt" in processed[1].description
         assert "## Tool: long_tool" in doc
         assert long_desc in doc
-    
+
     def test_disabled_when_limit_is_zero(self):
         """
         What it does: Verifies function is disabled when limit is 0.
@@ -2236,15 +2376,15 @@ class TestProcessToolsWithLongDescriptions:
         print("Setup: Tool with long description and limit 0...")
         long_desc = "D" * 15000
         tools = [UnifiedTool(name="test_tool", description=long_desc, input_schema={})]
-        
+
         print("Action: Processing tools with limit 0...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 0):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 0):
             processed, doc = process_tools_with_long_descriptions(tools)
-        
+
         print("Checking that description is unchanged...")
         assert processed[0].description == long_desc
         assert doc == ""
-    
+
     def test_multiple_long_descriptions_all_moved(self):
         """
         What it does: Verifies moving of multiple long descriptions.
@@ -2254,23 +2394,23 @@ class TestProcessToolsWithLongDescriptions:
         tools = [
             UnifiedTool(name="tool1", description="F" * 15000, input_schema={}),
             UnifiedTool(name="tool2", description="G" * 15000, input_schema={}),
-            UnifiedTool(name="tool3", description="H" * 15000, input_schema={})
+            UnifiedTool(name="tool3", description="H" * 15000, input_schema={}),
         ]
-        
+
         print("Action: Processing tools...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 10000):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 10000):
             processed, doc = process_tools_with_long_descriptions(tools)
-        
+
         print("Checking all three tools...")
         assert len(processed) == 3
         for tool in processed:
             assert "[Full documentation in system prompt" in tool.description
-        
+
         print("Checking documentation contains all three sections...")
         assert "## Tool: tool1" in doc
         assert "## Tool: tool2" in doc
         assert "## Tool: tool3" in doc
-    
+
     def test_empty_description_unchanged(self):
         """
         What it does: Verifies handling of empty description.
@@ -2278,15 +2418,15 @@ class TestProcessToolsWithLongDescriptions:
         """
         print("Setup: Tool with empty description...")
         tools = [UnifiedTool(name="empty_desc_tool", description="", input_schema={})]
-        
+
         print("Action: Processing tools...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 10000):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 10000):
             processed, doc = process_tools_with_long_descriptions(tools)
-        
+
         print("Checking that empty description remains empty...")
         assert processed[0].description == ""
         assert doc == ""
-    
+
     def test_none_description_unchanged(self):
         """
         What it does: Verifies handling of None description.
@@ -2294,16 +2434,16 @@ class TestProcessToolsWithLongDescriptions:
         """
         print("Setup: Tool with None description...")
         tools = [UnifiedTool(name="none_desc_tool", description=None, input_schema={})]
-        
+
         print("Action: Processing tools...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 10000):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 10000):
             processed, doc = process_tools_with_long_descriptions(tools)
-        
+
         print("Checking that None description is handled correctly...")
         # None should remain None or become empty string
         assert processed[0].description is None or processed[0].description == ""
         assert doc == ""
-    
+
     def test_preserves_tool_input_schema(self):
         """
         What it does: Verifies input_schema preservation when moving description.
@@ -2314,20 +2454,20 @@ class TestProcessToolsWithLongDescriptions:
             "type": "object",
             "properties": {
                 "location": {"type": "string", "description": "City name"},
-                "units": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+                "units": {"type": "string", "enum": ["celsius", "fahrenheit"]},
             },
-            "required": ["location"]
+            "required": ["location"],
         }
-        tools = [UnifiedTool(
-            name="weather",
-            description="C" * 15000,
-            input_schema=input_schema
-        )]
-        
+        tools = [
+            UnifiedTool(
+                name="weather", description="C" * 15000, input_schema=input_schema
+            )
+        ]
+
         print("Action: Processing tools...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 10000):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 10000):
             processed, doc = process_tools_with_long_descriptions(tools)
-        
+
         print("Checking input_schema preservation...")
         assert processed[0].input_schema == input_schema
 
@@ -2336,50 +2476,56 @@ class TestProcessToolsWithLongDescriptions:
 # Tests for convert_tools_to_kiro_format
 # ==================================================================================================
 
+
 class TestConvertToolsToKiroFormat:
     """Tests for convert_tools_to_kiro_format function."""
-    
+
     def test_returns_empty_list_for_none(self):
         """
         What it does: Verifies handling of None.
         Purpose: Ensure None returns empty list.
         """
         print("Setup: None tools...")
-        
+
         print("Action: Converting tools...")
         result = convert_tools_to_kiro_format(None)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_returns_empty_list_for_empty_list(self):
         """
         What it does: Verifies handling of empty list.
         Purpose: Ensure empty list returns empty list.
         """
         print("Setup: Empty tools list...")
-        
+
         print("Action: Converting tools...")
         result = convert_tools_to_kiro_format([])
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_converts_tool_to_kiro_format(self):
         """
         What it does: Verifies conversion of tool to Kiro format.
         Purpose: Ensure toolSpecification structure is correct.
         """
         print("Setup: Tool...")
-        tools = [UnifiedTool(
-            name="get_weather",
-            description="Get weather for a location",
-            input_schema={"type": "object", "properties": {"location": {"type": "string"}}}
-        )]
-        
+        tools = [
+            UnifiedTool(
+                name="get_weather",
+                description="Get weather for a location",
+                input_schema={
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                },
+            )
+        ]
+
         print("Action: Converting tools...")
         result = convert_tools_to_kiro_format(tools)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert "toolSpecification" in result[0]
@@ -2388,7 +2534,7 @@ class TestConvertToolsToKiroFormat:
         assert spec["description"] == "Get weather for a location"
         assert "inputSchema" in spec
         assert "json" in spec["inputSchema"]
-    
+
     def test_replaces_empty_description_with_placeholder(self):
         """
         What it does: Verifies replacement of empty description.
@@ -2396,14 +2542,14 @@ class TestConvertToolsToKiroFormat:
         """
         print("Setup: Tool with empty description...")
         tools = [UnifiedTool(name="focus_chain", description="", input_schema={})]
-        
+
         print("Action: Converting tools...")
         result = convert_tools_to_kiro_format(tools)
-        
+
         print(f"Result: {result}")
         spec = result[0]["toolSpecification"]
         assert spec["description"] == "Tool: focus_chain"
-    
+
     def test_replaces_none_description_with_placeholder(self):
         """
         What it does: Verifies replacement of None description.
@@ -2411,34 +2557,36 @@ class TestConvertToolsToKiroFormat:
         """
         print("Setup: Tool with None description...")
         tools = [UnifiedTool(name="test_tool", description=None, input_schema={})]
-        
+
         print("Action: Converting tools...")
         result = convert_tools_to_kiro_format(tools)
-        
+
         print(f"Result: {result}")
         spec = result[0]["toolSpecification"]
         assert spec["description"] == "Tool: test_tool"
-    
+
     def test_sanitizes_input_schema(self):
         """
         What it does: Verifies sanitization of input schema.
         Purpose: Ensure problematic fields are removed from schema.
         """
         print("Setup: Tool with problematic schema...")
-        tools = [UnifiedTool(
-            name="test_tool",
-            description="Test",
-            input_schema={
-                "type": "object",
-                "properties": {},
-                "required": [],
-                "additionalProperties": False
-            }
-        )]
-        
+        tools = [
+            UnifiedTool(
+                name="test_tool",
+                description="Test",
+                input_schema={
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                    "additionalProperties": False,
+                },
+            )
+        ]
+
         print("Action: Converting tools...")
         result = convert_tools_to_kiro_format(tools)
-        
+
         print(f"Result: {result}")
         schema = result[0]["toolSpecification"]["inputSchema"]["json"]
         assert "required" not in schema
@@ -2449,13 +2597,14 @@ class TestConvertToolsToKiroFormat:
 # Tests for inject_thinking_tags
 # ==================================================================================================
 
+
 class TestInjectThinkingTags:
     """
     Tests for inject_thinking_tags function.
-    
+
     This function injects thinking mode tags into content when FAKE_REASONING_ENABLED is True.
     """
-    
+
     def test_returns_original_content_when_disabled(self):
         """
         What it does: Verifies that content is returned unchanged when fake reasoning is disabled.
@@ -2463,14 +2612,14 @@ class TestInjectThinkingTags:
         """
         print("Setup: Content with fake reasoning disabled...")
         content = "Hello, world!"
-        
+
         print("Action: Inject thinking tags with FAKE_REASONING_ENABLED=False...")
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', False):
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
             result = inject_thinking_tags(content)
-        
+
         print(f"Comparing result: Expected 'Hello, world!', Got '{result}'")
         assert result == "Hello, world!"
-    
+
     def test_injects_tags_when_enabled(self):
         """
         What it does: Verifies that thinking tags are injected when enabled.
@@ -2478,22 +2627,22 @@ class TestInjectThinkingTags:
         """
         print("Setup: Content with fake reasoning enabled...")
         content = "What is 2+2?"
-        
+
         print("Action: Inject thinking tags with FAKE_REASONING_ENABLED=True...")
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-            with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 4000):
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 4000):
                 result = inject_thinking_tags(content)
-        
+
         print(f"Result: {result[:200]}...")
         print("Checking that thinking_mode tag is present...")
         assert "<thinking_mode>enabled</thinking_mode>" in result
-        
+
         print("Checking that max_thinking_length tag is present...")
         assert "<max_thinking_length>4000</max_thinking_length>" in result
-        
+
         print("Checking that original content is preserved at the end...")
         assert result.endswith("What is 2+2?")
-    
+
     def test_injects_thinking_instruction_tag(self):
         """
         What it does: Verifies that thinking_instruction tag is injected.
@@ -2501,17 +2650,17 @@ class TestInjectThinkingTags:
         """
         print("Setup: Content with fake reasoning enabled...")
         content = "Analyze this code"
-        
+
         print("Action: Inject thinking tags...")
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-            with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 8000):
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 8000):
                 result = inject_thinking_tags(content)
-        
+
         print(f"Result length: {len(result)} chars")
         print("Checking that thinking_instruction tag is present...")
         assert "<thinking_instruction>" in result
         assert "</thinking_instruction>" in result
-    
+
     def test_thinking_instruction_contains_english_directive(self):
         """
         What it does: Verifies that thinking instruction includes English language directive.
@@ -2519,15 +2668,15 @@ class TestInjectThinkingTags:
         """
         print("Setup: Content with fake reasoning enabled...")
         content = "Test"
-        
+
         print("Action: Inject thinking tags...")
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-            with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 4000):
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 4000):
                 result = inject_thinking_tags(content)
-        
+
         print("Checking for English directive...")
         assert "Think in English" in result
-    
+
     def test_uses_configured_max_tokens(self):
         """
         What it does: Verifies that FAKE_REASONING_MAX_TOKENS config value is used.
@@ -2535,16 +2684,16 @@ class TestInjectThinkingTags:
         """
         print("Setup: Content with custom max tokens...")
         content = "Test"
-        
+
         print("Action: Inject thinking tags with FAKE_REASONING_MAX_TOKENS=16000...")
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-            with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 16000):
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 16000):
                 result = inject_thinking_tags(content)
-        
+
         print(f"Result: {result[:300]}...")
         print("Checking that max_thinking_length uses configured value...")
         assert "<max_thinking_length>16000</max_thinking_length>" in result
-    
+
     def test_preserves_empty_content(self):
         """
         What it does: Verifies that empty content is handled correctly.
@@ -2552,17 +2701,17 @@ class TestInjectThinkingTags:
         """
         print("Setup: Empty content with fake reasoning enabled...")
         content = ""
-        
+
         print("Action: Inject thinking tags...")
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-            with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 4000):
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 4000):
                 result = inject_thinking_tags(content)
-        
+
         print(f"Result length: {len(result)} chars")
         print("Checking that tags are present even with empty content...")
         assert "<thinking_mode>enabled</thinking_mode>" in result
         assert "<thinking_instruction>" in result
-    
+
     def test_preserves_multiline_content(self):
         """
         What it does: Verifies that multiline content is preserved correctly.
@@ -2570,15 +2719,15 @@ class TestInjectThinkingTags:
         """
         print("Setup: Multiline content...")
         content = "Line 1\nLine 2\nLine 3"
-        
+
         print("Action: Inject thinking tags...")
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-            with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 4000):
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 4000):
                 result = inject_thinking_tags(content)
-        
+
         print("Checking that multiline content is preserved...")
         assert "Line 1\nLine 2\nLine 3" in result
-    
+
     def test_preserves_special_characters(self):
         """
         What it does: Verifies that special characters in content are preserved.
@@ -2586,16 +2735,16 @@ class TestInjectThinkingTags:
         """
         print("Setup: Content with special characters...")
         content = "Check this <code>example</code> and {json: 'value'}"
-        
+
         print("Action: Inject thinking tags...")
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-            with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 4000):
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 4000):
                 result = inject_thinking_tags(content)
-        
+
         print("Checking that special characters are preserved...")
         assert "<code>example</code>" in result
         assert "{json: 'value'}" in result
-    
+
     def test_thinking_instruction_contains_systematic_approach(self):
         """
         What it does: Verifies that thinking instruction includes systematic approach guidance.
@@ -2603,15 +2752,15 @@ class TestInjectThinkingTags:
         """
         print("Setup: Content with fake reasoning enabled...")
         content = "Test"
-        
+
         print("Action: Inject thinking tags...")
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-            with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 4000):
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 4000):
                 result = inject_thinking_tags(content)
-        
+
         print("Checking for systematic approach keywords...")
         assert "thorough" in result.lower() or "systematic" in result.lower()
-    
+
     def test_thinking_instruction_contains_understanding_step(self):
         """
         What it does: Verifies that thinking instruction includes understanding step.
@@ -2619,15 +2768,15 @@ class TestInjectThinkingTags:
         """
         print("Setup: Content with fake reasoning enabled...")
         content = "Test"
-        
+
         print("Action: Inject thinking tags...")
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-            with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 4000):
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 4000):
                 result = inject_thinking_tags(content)
-        
+
         print("Checking for understanding step...")
         assert "understand" in result.lower()
-    
+
     def test_thinking_instruction_contains_verification_step(self):
         """
         What it does: Verifies that thinking instruction includes verification step.
@@ -2635,15 +2784,15 @@ class TestInjectThinkingTags:
         """
         print("Setup: Content with fake reasoning enabled...")
         content = "Test"
-        
+
         print("Action: Inject thinking tags...")
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-            with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 4000):
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 4000):
                 result = inject_thinking_tags(content)
-        
+
         print("Checking for verification step...")
         assert "verify" in result.lower()
-    
+
     def test_thinking_instruction_contains_quality_emphasis(self):
         """
         What it does: Verifies that thinking instruction emphasizes quality over speed.
@@ -2651,15 +2800,15 @@ class TestInjectThinkingTags:
         """
         print("Setup: Content with fake reasoning enabled...")
         content = "Test"
-        
+
         print("Action: Inject thinking tags...")
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-            with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 4000):
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 4000):
                 result = inject_thinking_tags(content)
-        
+
         print("Checking for quality emphasis...")
         assert "quality" in result.lower()
-    
+
     def test_tag_order_is_correct(self):
         """
         What it does: Verifies that tags are in the correct order.
@@ -2667,32 +2816,41 @@ class TestInjectThinkingTags:
         """
         print("Setup: Content...")
         content = "USER_CONTENT_HERE"
-        
+
         print("Action: Inject thinking tags...")
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-            with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 4000):
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 4000):
                 result = inject_thinking_tags(content)
-        
+
         print("Checking tag order...")
         thinking_mode_pos = result.find("<thinking_mode>")
         max_length_pos = result.find("<max_thinking_length>")
         instruction_pos = result.find("<thinking_instruction>")
         content_pos = result.find("USER_CONTENT_HERE")
-        
-        print(f"Positions: thinking_mode={thinking_mode_pos}, max_length={max_length_pos}, instruction={instruction_pos}, content={content_pos}")
-        
-        assert thinking_mode_pos < max_length_pos, "thinking_mode should come before max_thinking_length"
-        assert max_length_pos < instruction_pos, "max_thinking_length should come before thinking_instruction"
-        assert instruction_pos < content_pos, "thinking_instruction should come before user content"
+
+        print(
+            f"Positions: thinking_mode={thinking_mode_pos}, max_length={max_length_pos}, instruction={instruction_pos}, content={content_pos}"
+        )
+
+        assert thinking_mode_pos < max_length_pos, (
+            "thinking_mode should come before max_thinking_length"
+        )
+        assert max_length_pos < instruction_pos, (
+            "max_thinking_length should come before thinking_instruction"
+        )
+        assert instruction_pos < content_pos, (
+            "thinking_instruction should come before user content"
+        )
 
 
 # ==================================================================================================
 # Tests for build_kiro_history
 # ==================================================================================================
 
+
 class TestBuildKiroHistory:
     """Tests for build_kiro_history function using UnifiedMessage."""
-    
+
     def test_builds_user_message(self):
         """
         What it does: Verifies building of user message.
@@ -2700,16 +2858,16 @@ class TestBuildKiroHistory:
         """
         print("Setup: User message...")
         messages = [UnifiedMessage(role="user", content="Hello")]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert "userInputMessage" in result[0]
         assert result[0]["userInputMessage"]["content"] == "Hello"
         assert result[0]["userInputMessage"]["modelId"] == "claude-sonnet-4"
-    
+
     def test_builds_assistant_message(self):
         """
         What it does: Verifies building of assistant message.
@@ -2717,15 +2875,15 @@ class TestBuildKiroHistory:
         """
         print("Setup: Assistant message...")
         messages = [UnifiedMessage(role="assistant", content="Hi there")]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert "assistantResponseMessage" in result[0]
         assert result[0]["assistantResponseMessage"]["content"] == "Hi there"
-    
+
     def test_ignores_system_messages(self):
         """
         What it does: Verifies ignoring of system messages.
@@ -2733,13 +2891,13 @@ class TestBuildKiroHistory:
         """
         print("Setup: System message...")
         messages = [UnifiedMessage(role="system", content="You are helpful")]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Comparing length: Expected 0, Got {len(result)}")
         assert len(result) == 0
-    
+
     def test_builds_conversation_history(self):
         """
         What it does: Verifies building of full conversation history.
@@ -2749,31 +2907,31 @@ class TestBuildKiroHistory:
         messages = [
             UnifiedMessage(role="user", content="Hello"),
             UnifiedMessage(role="assistant", content="Hi"),
-            UnifiedMessage(role="user", content="How are you?")
+            UnifiedMessage(role="user", content="How are you?"),
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         assert len(result) == 3
         assert "userInputMessage" in result[0]
         assert "assistantResponseMessage" in result[1]
         assert "userInputMessage" in result[2]
-    
+
     def test_handles_empty_list(self):
         """
         What it does: Verifies empty list handling.
         Purpose: Ensure empty list returns empty history.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Building history...")
         result = build_kiro_history([], "claude-sonnet-4")
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_builds_user_message_with_tool_results(self):
         """
         What it does: Verifies building of user message with tool_results.
@@ -2785,21 +2943,25 @@ class TestBuildKiroHistory:
                 role="user",
                 content="Here are the results",
                 tool_results=[
-                    {"type": "tool_result", "tool_use_id": "call_123", "content": "Result text"}
-                ]
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": "Result text",
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert "userInputMessage" in result[0]
         user_msg = result[0]["userInputMessage"]
         assert "userInputMessageContext" in user_msg
         assert "toolResults" in user_msg["userInputMessageContext"]
-    
+
     def test_builds_assistant_message_with_tool_calls(self):
         """
         What it does: Verifies building of assistant message with tool_calls.
@@ -2810,63 +2972,65 @@ class TestBuildKiroHistory:
             UnifiedMessage(
                 role="assistant",
                 content="I'll call a tool",
-                tool_calls=[{
-                    "id": "call_123",
-                    "function": {
-                        "name": "get_weather",
-                        "arguments": '{"location": "Moscow"}'
+                tool_calls=[
+                    {
+                        "id": "call_123",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"location": "Moscow"}',
+                        },
                     }
-                }]
+                ],
             )
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert "assistantResponseMessage" in result[0]
         assistant_msg = result[0]["assistantResponseMessage"]
         assert "toolUses" in assistant_msg
-    
+
     def test_adds_empty_placeholder_for_empty_user_content(self):
         """
         What it does: Verifies that "(empty)" placeholder is added for user messages with empty content.
         Purpose: Ensure Kiro API receives non-empty content in history.
-        
+
         This is a fallback test for issue #20 - ensures any edge case with empty content
         is handled even if strip_all_tool_content didn't add a placeholder.
         """
         print("Setup: User message with empty content...")
         messages = [UnifiedMessage(role="user", content="")]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         print(f"Content: '{result[0]['userInputMessage']['content']}'")
         print("Checking that '(empty)' placeholder is added...")
         assert result[0]["userInputMessage"]["content"] == "(empty)"
-    
+
     def test_adds_empty_placeholder_for_empty_assistant_content(self):
         """
         What it does: Verifies that "(empty)" placeholder is added for assistant messages with empty content.
         Purpose: Ensure Kiro API receives non-empty content in history.
-        
+
         This is a fallback test for issue #20 - ensures any edge case with empty content
         is handled even if strip_all_tool_content didn't add a placeholder.
         """
         print("Setup: Assistant message with empty content...")
         messages = [UnifiedMessage(role="assistant", content="")]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         print(f"Content: '{result[0]['assistantResponseMessage']['content']}'")
         print("Checking that '(empty)' placeholder is added...")
         assert result[0]["assistantResponseMessage"]["content"] == "(empty)"
-    
+
     def test_adds_empty_placeholder_for_none_user_content(self):
         """
         What it does: Verifies that "(empty)" placeholder is added for user messages with None content.
@@ -2874,15 +3038,15 @@ class TestBuildKiroHistory:
         """
         print("Setup: User message with None content...")
         messages = [UnifiedMessage(role="user", content=None)]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         print(f"Content: '{result[0]['userInputMessage']['content']}'")
         print("Checking that '(empty)' placeholder is added...")
         assert result[0]["userInputMessage"]["content"] == "(empty)"
-    
+
     def test_adds_empty_placeholder_for_none_assistant_content(self):
         """
         What it does: Verifies that "(empty)" placeholder is added for assistant messages with None content.
@@ -2890,15 +3054,15 @@ class TestBuildKiroHistory:
         """
         print("Setup: Assistant message with None content...")
         messages = [UnifiedMessage(role="assistant", content=None)]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         print(f"Content: '{result[0]['assistantResponseMessage']['content']}'")
         print("Checking that '(empty)' placeholder is added...")
         assert result[0]["assistantResponseMessage"]["content"] == "(empty)"
-    
+
     def test_preserves_non_empty_content_in_history(self):
         """
         What it does: Verifies that non-empty content is preserved (not replaced with placeholder).
@@ -2907,55 +3071,61 @@ class TestBuildKiroHistory:
         print("Setup: Messages with actual content...")
         messages = [
             UnifiedMessage(role="user", content="Hello"),
-            UnifiedMessage(role="assistant", content="Hi there")
+            UnifiedMessage(role="assistant", content="Hi there"),
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         print("Checking that original content is preserved...")
         assert result[0]["userInputMessage"]["content"] == "Hello"
         assert result[1]["assistantResponseMessage"]["content"] == "Hi there"
-    
+
     def test_mixed_empty_and_non_empty_content_in_history(self):
         """
         What it does: Verifies correct handling of mixed empty and non-empty content.
         Purpose: Ensure only empty messages get placeholders.
-        
+
         This simulates a conversation where some messages have content and some don't.
         """
         print("Setup: Mixed conversation with empty and non-empty content...")
         messages = [
             UnifiedMessage(role="user", content="Start"),
-            UnifiedMessage(role="assistant", content=""),  # Empty - should get placeholder
+            UnifiedMessage(
+                role="assistant", content=""
+            ),  # Empty - should get placeholder
             UnifiedMessage(role="user", content=""),  # Empty - should get placeholder
-            UnifiedMessage(role="assistant", content="Response")
+            UnifiedMessage(role="assistant", content="Response"),
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         print("Checking each message...")
-        
+
         print(f"Message 0 content: '{result[0]['userInputMessage']['content']}'")
         assert result[0]["userInputMessage"]["content"] == "Start"
-        
-        print(f"Message 1 content: '{result[1]['assistantResponseMessage']['content']}'")
+
+        print(
+            f"Message 1 content: '{result[1]['assistantResponseMessage']['content']}'"
+        )
         assert result[1]["assistantResponseMessage"]["content"] == "(empty)"
-        
+
         print(f"Message 2 content: '{result[2]['userInputMessage']['content']}'")
         assert result[2]["userInputMessage"]["content"] == "(empty)"
-        
-        print(f"Message 3 content: '{result[3]['assistantResponseMessage']['content']}'")
+
+        print(
+            f"Message 3 content: '{result[3]['assistantResponseMessage']['content']}'"
+        )
         assert result[3]["assistantResponseMessage"]["content"] == "Response"
-    
+
     def test_builds_user_message_with_images(self):
         """
         What it does: Verifies building of user message with images.
         Purpose: Ensure images are included directly in userInputMessage.images (Issue #32 fix).
-        
+
         This is a critical test for Issue #30/#32 fix - images should be in Kiro format
         and placed directly in userInputMessage, NOT in userInputMessageContext.
         """
@@ -2964,29 +3134,31 @@ class TestBuildKiroHistory:
             UnifiedMessage(
                 role="user",
                 content="What's in this image?",
-                images=[{"media_type": "image/jpeg", "data": TEST_IMAGE_BASE64}]
+                images=[{"media_type": "image/jpeg", "data": TEST_IMAGE_BASE64}],
             )
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert "userInputMessage" in result[0]
-        
+
         user_msg = result[0]["userInputMessage"]
         print(f"User message: {user_msg}")
-        
-        print("Checking that images are directly in userInputMessage (Issue #32 fix)...")
+
+        print(
+            "Checking that images are directly in userInputMessage (Issue #32 fix)..."
+        )
         assert "images" in user_msg
-        
+
         print("Checking image format (Kiro format)...")
         images = user_msg["images"]
         assert len(images) == 1
         assert images[0]["format"] == "jpeg"
         assert images[0]["source"]["bytes"] == TEST_IMAGE_BASE64
-    
+
     def test_builds_user_message_with_multiple_images(self):
         """
         What it does: Verifies building of user message with multiple images.
@@ -2999,29 +3171,29 @@ class TestBuildKiroHistory:
                 content="Compare these images",
                 images=[
                     {"media_type": "image/jpeg", "data": "image1_data"},
-                    {"media_type": "image/png", "data": "image2_data"}
-                ]
+                    {"media_type": "image/png", "data": "image2_data"},
+                ],
             )
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         user_msg = result[0]["userInputMessage"]
         images = user_msg["images"]
-        
+
         print(f"Comparing image count: Expected 2, Got {len(images)}")
         assert len(images) == 2
-        
+
         print("Checking first image...")
         assert images[0]["format"] == "jpeg"
         assert images[0]["source"]["bytes"] == "image1_data"
-        
+
         print("Checking second image...")
         assert images[1]["format"] == "png"
         assert images[1]["source"]["bytes"] == "image2_data"
-    
+
     def test_builds_user_message_with_images_and_tool_results(self):
         """
         What it does: Verifies building of user message with both images and tool_results.
@@ -3033,51 +3205,53 @@ class TestBuildKiroHistory:
                 role="user",
                 content="Here's the image and tool result",
                 images=[{"media_type": "image/png", "data": "image_data"}],
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Tool output"
-                }]
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": "Tool output",
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         user_msg = result[0]["userInputMessage"]
         context = user_msg.get("userInputMessageContext", {})
-        
-        print("Checking that images are directly in userInputMessage (Issue #32 fix)...")
+
+        print(
+            "Checking that images are directly in userInputMessage (Issue #32 fix)..."
+        )
         assert "images" in user_msg
-        
+
         print("Checking that toolResults are in userInputMessageContext...")
         assert "toolResults" in context
-        
+
         print("Checking images...")
         assert len(user_msg["images"]) == 1
         assert user_msg["images"][0]["format"] == "png"
-        
+
         print("Checking toolResults...")
         assert len(context["toolResults"]) == 1
         assert context["toolResults"][0]["toolUseId"] == "call_123"
-    
+
     def test_no_images_context_when_no_images(self):
         """
         What it does: Verifies that images key is not added when there are no images.
         Purpose: Ensure clean payload without empty images array.
         """
         print("Setup: User message without images...")
-        messages = [
-            UnifiedMessage(role="user", content="Hello, no images here")
-        ]
-        
+        messages = [UnifiedMessage(role="user", content="Hello, no images here")]
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         user_msg = result[0]["userInputMessage"]
-        
+
         print("Checking that images key is not present...")
         # Either no context at all, or context without images
         if "userInputMessageContext" in user_msg:
@@ -3085,7 +3259,7 @@ class TestBuildKiroHistory:
             assert "images" not in context or context.get("images") == []
         else:
             print("No userInputMessageContext - OK")
-    
+
     def test_builds_user_message_with_webp_image(self):
         """
         What it does: Verifies building of user message with WebP image.
@@ -3096,22 +3270,22 @@ class TestBuildKiroHistory:
             UnifiedMessage(
                 role="user",
                 content="Analyze this WebP image",
-                images=[{"media_type": "image/webp", "data": "webp_image_data"}]
+                images=[{"media_type": "image/webp", "data": "webp_image_data"}],
             )
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         user_msg = result[0]["userInputMessage"]
         images = user_msg["images"]
-        
+
         print("Checking WebP format...")
         assert len(images) == 1
         assert images[0]["format"] == "webp"
         assert images[0]["source"]["bytes"] == "webp_image_data"
-    
+
     def test_builds_user_message_with_gif_image(self):
         """
         What it does: Verifies building of user message with GIF image.
@@ -3122,17 +3296,17 @@ class TestBuildKiroHistory:
             UnifiedMessage(
                 role="user",
                 content="What's happening in this GIF?",
-                images=[{"media_type": "image/gif", "data": "gif_image_data"}]
+                images=[{"media_type": "image/gif", "data": "gif_image_data"}],
             )
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         user_msg = result[0]["userInputMessage"]
         images = user_msg["images"]
-        
+
         print("Checking GIF format...")
         assert len(images) == 1
         assert images[0]["format"] == "gif"
@@ -3143,32 +3317,33 @@ class TestBuildKiroHistory:
 # Tests for strip_all_tool_content
 # ==================================================================================================
 
+
 class TestStripAllToolContent:
     """
     Tests for strip_all_tool_content function.
-    
+
     This function strips ALL tool-related content (tool_calls and tool_results)
     from messages. It is used when no tools are defined in the request, because
     Kiro API rejects requests that have toolResults but no tools defined.
-    
+
     This is a critical function for handling clients like Cline/Roo that may
     send tool-related content even when tools are not available.
     """
-    
+
     def test_returns_empty_list_for_empty_input(self):
         """
         What it does: Verifies empty list handling.
         Purpose: Ensure empty input returns empty output.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content([])
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
         assert had_content is False
-    
+
     def test_preserves_messages_without_tool_content(self):
         """
         What it does: Verifies messages without tool content are unchanged.
@@ -3178,19 +3353,19 @@ class TestStripAllToolContent:
         messages = [
             UnifiedMessage(role="user", content="Hello"),
             UnifiedMessage(role="assistant", content="Hi there"),
-            UnifiedMessage(role="user", content="How are you?")
+            UnifiedMessage(role="user", content="How are you?"),
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Comparing length: Expected 3, Got {len(result)}")
         assert len(result) == 3
         assert result[0].content == "Hello"
         assert result[1].content == "Hi there"
         assert result[2].content == "How are you?"
         assert had_content is False
-    
+
     def test_strips_tool_calls_from_assistant(self):
         """
         What it does: Verifies tool_calls are stripped and converted to text.
@@ -3201,17 +3376,22 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="I'll call a tool",
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "get_weather", "arguments": '{"location": "Moscow"}'}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"location": "Moscow"}',
+                        },
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that tool_calls are stripped and converted to text...")
         assert len(result) == 1
@@ -3220,7 +3400,7 @@ class TestStripAllToolContent:
         assert "I'll call a tool" in result[0].content
         assert "[Tool: get_weather" in result[0].content
         assert had_content is True
-    
+
     def test_strips_tool_results_from_user(self):
         """
         What it does: Verifies tool_results are stripped and converted to text.
@@ -3231,17 +3411,19 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="user",
                 content="Here are the results",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Weather is sunny"
-                }]
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": "Weather is sunny",
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that tool_results are stripped and converted to text...")
         assert len(result) == 1
@@ -3251,7 +3433,7 @@ class TestStripAllToolContent:
         assert "[Tool Result" in result[0].content
         assert "Weather is sunny" in result[0].content
         assert had_content is True
-    
+
     def test_strips_both_tool_calls_and_tool_results(self):
         """
         What it does: Verifies both tool_calls and tool_results are stripped.
@@ -3263,26 +3445,30 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "get_weather", "arguments": "{}"}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": "{}"},
+                    }
+                ],
             ),
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Result"
-                }]
-            )
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": "Result",
+                    }
+                ],
+            ),
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that all tool content is stripped...")
         assert len(result) == 3
@@ -3293,7 +3479,7 @@ class TestStripAllToolContent:
         assert result[2].tool_calls is None
         assert result[2].tool_results is None
         assert had_content is True
-    
+
     def test_strips_multiple_tool_calls(self):
         """
         What it does: Verifies multiple tool_calls are all stripped.
@@ -3305,21 +3491,33 @@ class TestStripAllToolContent:
                 role="assistant",
                 content="",
                 tool_calls=[
-                    {"id": "call_1", "type": "function", "function": {"name": "tool1", "arguments": "{}"}},
-                    {"id": "call_2", "type": "function", "function": {"name": "tool2", "arguments": "{}"}},
-                    {"id": "call_3", "type": "function", "function": {"name": "tool3", "arguments": "{}"}}
-                ]
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "tool1", "arguments": "{}"},
+                    },
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "tool2", "arguments": "{}"},
+                    },
+                    {
+                        "id": "call_3",
+                        "type": "function",
+                        "function": {"name": "tool3", "arguments": "{}"},
+                    },
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that all tool_calls are stripped...")
         assert result[0].tool_calls is None
         assert had_content is True
-    
+
     def test_strips_multiple_tool_results(self):
         """
         What it does: Verifies multiple tool_results are all stripped.
@@ -3331,21 +3529,33 @@ class TestStripAllToolContent:
                 role="user",
                 content="",
                 tool_results=[
-                    {"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"},
-                    {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"},
-                    {"type": "tool_result", "tool_use_id": "call_3", "content": "Result 3"}
-                ]
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_1",
+                        "content": "Result 1",
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_2",
+                        "content": "Result 2",
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_3",
+                        "content": "Result 3",
+                    },
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that all tool_results are stripped...")
         assert result[0].tool_results is None
         assert had_content is True
-    
+
     def test_preserves_message_content_when_stripping(self):
         """
         What it does: Verifies message content is preserved and tool content is appended as text.
@@ -3356,34 +3566,40 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="Let me help you with that",
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "helper", "arguments": "{}"}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "helper", "arguments": "{}"},
+                    }
+                ],
             ),
             UnifiedMessage(
                 role="user",
                 content="Thanks for the result",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Done"
-                }]
-            )
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": "Done",
+                    }
+                ],
+            ),
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
-        print("Checking that original content is preserved and tool text is appended...")
+        print(
+            "Checking that original content is preserved and tool text is appended..."
+        )
         assert "Let me help you with that" in result[0].content
         assert "[Tool: helper" in result[0].content
         assert "Thanks for the result" in result[1].content
         assert "[Tool Result" in result[1].content
         assert had_content is True
-    
+
     def test_preserves_message_role_when_stripping(self):
         """
         What it does: Verifies message role is preserved when tool content is stripped.
@@ -3391,23 +3607,39 @@ class TestStripAllToolContent:
         """
         print("Setup: Messages with tool content...")
         messages = [
-            UnifiedMessage(role="assistant", content="", tool_calls=[
-                {"id": "call_1", "type": "function", "function": {"name": "tool", "arguments": "{}"}}
-            ]),
-            UnifiedMessage(role="user", content="", tool_results=[
-                {"type": "tool_result", "tool_use_id": "call_1", "content": "Result"}
-            ])
+            UnifiedMessage(
+                role="assistant",
+                content="",
+                tool_calls=[
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "tool", "arguments": "{}"},
+                    }
+                ],
+            ),
+            UnifiedMessage(
+                role="user",
+                content="",
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_1",
+                        "content": "Result",
+                    }
+                ],
+            ),
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that roles are preserved...")
         assert result[0].role == "assistant"
         assert result[1].role == "user"
         assert had_content is True
-    
+
     def test_mixed_messages_with_and_without_tool_content(self):
         """
         What it does: Verifies correct handling of mixed messages.
@@ -3419,14 +3651,20 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "tool", "arguments": "{}"}}]
+                tool_calls=[
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "tool", "arguments": "{}"},
+                    }
+                ],
             ),  # Has tool content
             UnifiedMessage(role="user", content="Continue"),  # No tool content
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print("Checking mixed handling...")
         assert result[0].content == "Hello"
@@ -3435,7 +3673,7 @@ class TestStripAllToolContent:
         assert result[2].content == "Continue"
         assert result[2].tool_calls is None
         assert had_content is True
-    
+
     def test_returns_false_when_no_tool_content_stripped(self):
         """
         What it does: Verifies had_content flag is False when no tool content exists.
@@ -3445,15 +3683,15 @@ class TestStripAllToolContent:
         messages = [
             UnifiedMessage(role="user", content="Hello"),
             UnifiedMessage(role="assistant", content="Hi"),
-            UnifiedMessage(role="user", content="Bye")
+            UnifiedMessage(role="user", content="Bye"),
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"had_content: {had_content}")
         assert had_content is False
-    
+
     def test_returns_true_when_tool_content_stripped(self):
         """
         What it does: Verifies had_content flag is True when tool content is stripped.
@@ -3464,57 +3702,59 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "tool", "arguments": "{}"}}]
+                tool_calls=[
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "tool", "arguments": "{}"},
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"had_content: {had_content}")
         assert had_content is True
-    
+
     def test_handles_empty_tool_calls_list(self):
         """
         What it does: Verifies handling of empty tool_calls list.
         Purpose: Ensure empty list is treated as no tool content.
         """
         print("Setup: Message with empty tool_calls list...")
-        messages = [
-            UnifiedMessage(role="assistant", content="Hello", tool_calls=[])
-        ]
-        
+        messages = [UnifiedMessage(role="assistant", content="Hello", tool_calls=[])]
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"had_content: {had_content}")
         # Empty list is falsy, so should not be considered as having tool content
         assert had_content is False
-    
+
     def test_handles_empty_tool_results_list(self):
         """
         What it does: Verifies handling of empty tool_results list.
         Purpose: Ensure empty list is treated as no tool content.
         """
         print("Setup: Message with empty tool_results list...")
-        messages = [
-            UnifiedMessage(role="user", content="Hello", tool_results=[])
-        ]
-        
+        messages = [UnifiedMessage(role="user", content="Hello", tool_results=[])]
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"had_content: {had_content}")
         # Empty list is falsy, so should not be considered as having tool content
         assert had_content is False
-    
+
     def test_adds_tool_text_for_empty_content_with_tool_calls(self):
         """
         What it does: Verifies that tool_calls are converted to text when content is empty.
         Purpose: Ensure Kiro API receives non-empty content for messages that only had tool_calls.
-        
+
         This is a critical test for issue #20 - OpenCode compaction returns 400 error
         because messages with only tool_calls become empty after stripping.
         Now we convert tool_calls to text representation instead of simple placeholder.
@@ -3524,17 +3764,22 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="",  # Empty content - only tool_calls
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "read_file", "arguments": '{"path": "test.py"}'}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path": "test.py"}',
+                        },
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"Content after stripping: '{result[0].content}'")
         print("Checking that tool_calls are converted to text representation...")
@@ -3543,12 +3788,12 @@ class TestStripAllToolContent:
         assert '{"path": "test.py"}' in result[0].content
         assert result[0].tool_calls is None
         assert had_content is True
-    
+
     def test_adds_tool_text_for_empty_content_with_tool_results(self):
         """
         What it does: Verifies that tool_results are converted to text when content is empty.
         Purpose: Ensure Kiro API receives non-empty content for messages that only had tool_results.
-        
+
         This is a critical test for issue #20 - OpenCode compaction returns 400 error
         because messages with only tool_results become empty after stripping.
         Now we convert tool_results to text representation instead of simple placeholder.
@@ -3558,17 +3803,19 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="user",
                 content="",  # Empty content - only tool_results
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "File contents here"
-                }]
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": "File contents here",
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"Content after stripping: '{result[0].content}'")
         print("Checking that tool_results are converted to text representation...")
@@ -3577,7 +3824,7 @@ class TestStripAllToolContent:
         assert "File contents here" in result[0].content
         assert result[0].tool_results is None
         assert had_content is True
-    
+
     def test_preserves_existing_content_when_stripping_tool_calls(self):
         """
         What it does: Verifies that existing content is preserved and tool text is appended.
@@ -3588,25 +3835,29 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="I'll read the file for you",
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "read_file", "arguments": "{}"}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"Content after stripping: '{result[0].content}'")
-        print("Checking that original content is preserved and tool text is appended...")
+        print(
+            "Checking that original content is preserved and tool text is appended..."
+        )
         assert "I'll read the file for you" in result[0].content
         assert "[Tool: read_file" in result[0].content
         assert result[0].tool_calls is None
         assert had_content is True
-    
+
     def test_preserves_existing_content_when_stripping_tool_results(self):
         """
         What it does: Verifies that existing content is preserved and tool result text is appended.
@@ -3617,31 +3868,35 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="user",
                 content="Here are the results you requested",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Result data"
-                }]
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": "Result data",
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"Content after stripping: '{result[0].content}'")
-        print("Checking that original content is preserved and tool result text is appended...")
+        print(
+            "Checking that original content is preserved and tool result text is appended..."
+        )
         assert "Here are the results you requested" in result[0].content
         assert "[Tool Result" in result[0].content
         assert "Result data" in result[0].content
         assert result[0].tool_results is None
         assert had_content is True
-    
+
     def test_both_tool_calls_and_results_converted_to_text(self):
         """
         What it does: Verifies that both tool_calls and tool_results are converted to text.
         Purpose: Ensure all tool content is preserved when message has both types.
-        
+
         Note: This is an edge case - normally assistant messages have tool_calls and user messages have tool_results.
         """
         print("Setup: Message with both tool_calls and tool_results (edge case)...")
@@ -3649,14 +3904,26 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "my_tool", "arguments": '{"x": 1}'}}],
-                tool_results=[{"type": "tool_result", "tool_use_id": "call_0", "content": "Previous result"}]
+                tool_calls=[
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "my_tool", "arguments": '{"x": 1}'},
+                    }
+                ],
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_0",
+                        "content": "Previous result",
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"Content after stripping: '{result[0].content}'")
         print("Checking that both tool_calls and tool_results are converted to text...")
@@ -3664,12 +3931,12 @@ class TestStripAllToolContent:
         assert "[Tool Result" in result[0].content
         assert "Previous result" in result[0].content
         assert had_content is True
-    
+
     def test_multiple_messages_with_empty_content_get_text_representation(self):
         """
         What it does: Verifies correct text representation for multiple messages in a conversation.
         Purpose: Ensure each message gets the appropriate text representation based on its tool content type.
-        
+
         This simulates the OpenCode compaction scenario from issue #20 where multiple
         tool-only messages are sent without text content.
         """
@@ -3679,57 +3946,95 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="",  # Only tool_calls
-                tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "read_file", "arguments": '{"path": "a.txt"}'}}]
+                tool_calls=[
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path": "a.txt"}',
+                        },
+                    }
+                ],
             ),
             UnifiedMessage(
                 role="user",
                 content="",  # Only tool_results
-                tool_results=[{"type": "tool_result", "tool_use_id": "call_1", "content": "File content ABC"}]
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_1",
+                        "content": "File content ABC",
+                    }
+                ],
             ),
             UnifiedMessage(
                 role="assistant",
                 content="",  # Only tool_calls
-                tool_calls=[{"id": "call_2", "type": "function", "function": {"name": "write_file", "arguments": '{"path": "b.txt"}'}}]
+                tool_calls=[
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {
+                            "name": "write_file",
+                            "arguments": '{"path": "b.txt"}',
+                        },
+                    }
+                ],
             ),
             UnifiedMessage(
                 role="user",
                 content="",  # Only tool_results
-                tool_results=[{"type": "tool_result", "tool_use_id": "call_2", "content": "Write completed"}]
-            )
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_2",
+                        "content": "Write completed",
+                    }
+                ],
+            ),
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print("Checking text representation for each message...")
-        
+
         print(f"Message 0 content: '{result[0].content}'")
         assert result[0].content == "Read these files"  # Original content preserved
-        
+
         print(f"Message 1 content: '{result[1].content}'")
-        assert "[Tool: read_file" in result[1].content  # Text representation for tool_calls
+        assert (
+            "[Tool: read_file" in result[1].content
+        )  # Text representation for tool_calls
         assert "call_1" in result[1].content
-        
+
         print(f"Message 2 content: '{result[2].content}'")
-        assert "[Tool Result" in result[2].content  # Text representation for tool_results
+        assert (
+            "[Tool Result" in result[2].content
+        )  # Text representation for tool_results
         assert "File content ABC" in result[2].content
-        
+
         print(f"Message 3 content: '{result[3].content}'")
-        assert "[Tool: write_file" in result[3].content  # Text representation for tool_calls
+        assert (
+            "[Tool: write_file" in result[3].content
+        )  # Text representation for tool_calls
         assert "call_2" in result[3].content
-        
+
         print(f"Message 4 content: '{result[4].content}'")
-        assert "[Tool Result" in result[4].content  # Text representation for tool_results
+        assert (
+            "[Tool Result" in result[4].content
+        )  # Text representation for tool_results
         assert "Write completed" in result[4].content
-        
+
         assert had_content is True
-    
+
     def test_converts_tool_calls_to_text_representation(self):
         """
         What it does: Verifies that tool_calls are converted to text representation.
         Purpose: Ensure tool context is preserved as readable text when stripping.
-        
+
         This is a critical test for issue #20 - instead of losing tool context,
         we convert it to human-readable text.
         """
@@ -3738,17 +4043,22 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "call_abc123",
-                    "type": "function",
-                    "function": {"name": "read_file", "arguments": '{"path": "test.py"}'}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_abc123",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path": "test.py"}',
+                        },
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result content: '{result[0].content}'")
         print("Checking that tool name is in text representation...")
         assert "[Tool: read_file" in result[0].content
@@ -3757,12 +4067,12 @@ class TestStripAllToolContent:
         print("Checking that arguments are in text representation...")
         assert '{"path": "test.py"}' in result[0].content
         assert had_content is True
-    
+
     def test_converts_tool_results_to_text_representation(self):
         """
         What it does: Verifies that tool_results are converted to text representation.
         Purpose: Ensure tool result context is preserved as readable text when stripping.
-        
+
         This is a critical test for issue #20 - instead of losing tool context,
         we convert it to human-readable text.
         """
@@ -3771,17 +4081,19 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_xyz789",
-                    "content": "File contents:\ndef hello():\n    print('world')"
-                }]
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_xyz789",
+                        "content": "File contents:\ndef hello():\n    print('world')",
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result content: '{result[0].content}'")
         print("Checking that [Tool Result] marker is present...")
         assert "[Tool Result" in result[0].content
@@ -3796,35 +4108,38 @@ class TestStripAllToolContent:
 # Tests for tool_calls_to_text
 # ==================================================================================================
 
+
 class TestToolCallsToText:
     """
     Tests for tool_calls_to_text function.
-    
+
     This function converts tool_calls to human-readable text representation.
     Used when stripping tool content from messages (when no tools are defined).
     """
-    
+
     def test_converts_single_tool_call_to_text(self):
         """
         What it does: Verifies conversion of a single tool call to text.
         Purpose: Ensure basic conversion works correctly.
         """
         print("Setup: Single tool call...")
-        tool_calls = [{
-            "id": "call_123",
-            "type": "function",
-            "function": {"name": "bash", "arguments": '{"command": "ls -la"}'}
-        }]
-        
+        tool_calls = [
+            {
+                "id": "call_123",
+                "type": "function",
+                "function": {"name": "bash", "arguments": '{"command": "ls -la"}'},
+            }
+        ]
+
         print("Action: Converting to text...")
         result = tool_calls_to_text(tool_calls)
-        
+
         print(f"Result: '{result}'")
         print("Checking that tool name is present...")
         assert "[Tool: bash" in result
         print("Checking that arguments are present...")
         assert '{"command": "ls -la"}' in result
-    
+
     def test_converts_multiple_tool_calls_to_text(self):
         """
         What it does: Verifies conversion of multiple tool calls to text.
@@ -3832,70 +4147,79 @@ class TestToolCallsToText:
         """
         print("Setup: Multiple tool calls...")
         tool_calls = [
-            {"id": "call_1", "type": "function", "function": {"name": "read_file", "arguments": '{"path": "a.txt"}'}},
-            {"id": "call_2", "type": "function", "function": {"name": "write_file", "arguments": '{"path": "b.txt"}'}}
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": '{"path": "a.txt"}'},
+            },
+            {
+                "id": "call_2",
+                "type": "function",
+                "function": {"name": "write_file", "arguments": '{"path": "b.txt"}'},
+            },
         ]
-        
+
         print("Action: Converting to text...")
         result = tool_calls_to_text(tool_calls)
-        
+
         print(f"Result: '{result}'")
         print("Checking that both tools are present...")
         assert "[Tool: read_file" in result
         assert "[Tool: write_file" in result
         assert '{"path": "a.txt"}' in result
         assert '{"path": "b.txt"}' in result
-    
+
     def test_includes_tool_id_in_output(self):
         """
         What it does: Verifies that tool_id is included in output.
         Purpose: Ensure traceability between tool calls and results.
         """
         print("Setup: Tool call with id...")
-        tool_calls = [{
-            "id": "tooluse_abc123xyz",
-            "type": "function",
-            "function": {"name": "search", "arguments": "{}"}
-        }]
-        
+        tool_calls = [
+            {
+                "id": "tooluse_abc123xyz",
+                "type": "function",
+                "function": {"name": "search", "arguments": "{}"},
+            }
+        ]
+
         print("Action: Converting to text...")
         result = tool_calls_to_text(tool_calls)
-        
+
         print(f"Result: '{result}'")
         print("Checking that tool_id is present...")
         assert "tooluse_abc123xyz" in result
-    
+
     def test_handles_missing_tool_id(self):
         """
         What it does: Verifies handling of tool call without id.
         Purpose: Ensure function doesn't crash when id is missing.
         """
         print("Setup: Tool call without id...")
-        tool_calls = [{
-            "type": "function",
-            "function": {"name": "test_tool", "arguments": "{}"}
-        }]
-        
+        tool_calls = [
+            {"type": "function", "function": {"name": "test_tool", "arguments": "{}"}}
+        ]
+
         print("Action: Converting to text...")
         result = tool_calls_to_text(tool_calls)
-        
+
         print(f"Result: '{result}'")
         print("Checking that tool name is still present...")
         assert "[Tool: test_tool]" in result
-    
+
     def test_returns_empty_string_for_empty_list(self):
         """
         What it does: Verifies empty list handling.
         Purpose: Ensure empty input returns empty output.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Converting to text...")
         result = tool_calls_to_text([])
-        
+
         print(f"Comparing result: Expected '', Got '{result}'")
         assert result == ""
-    
+
     def test_handles_missing_function_key(self):
         """
         What it does: Verifies handling of malformed tool call without function key.
@@ -3903,14 +4227,14 @@ class TestToolCallsToText:
         """
         print("Setup: Tool call without function key...")
         tool_calls = [{"id": "call_123", "type": "function"}]
-        
+
         print("Action: Converting to text...")
         result = tool_calls_to_text(tool_calls)
-        
+
         print(f"Result: '{result}'")
         print("Checking that 'unknown' is used as fallback...")
         assert "[Tool: unknown" in result
-    
+
     def test_handles_complex_json_arguments(self):
         """
         What it does: Verifies handling of complex JSON arguments.
@@ -3918,15 +4242,17 @@ class TestToolCallsToText:
         """
         print("Setup: Tool call with complex arguments...")
         complex_args = '{"files": ["a.py", "b.py"], "options": {"recursive": true}}'
-        tool_calls = [{
-            "id": "call_123",
-            "type": "function",
-            "function": {"name": "process", "arguments": complex_args}
-        }]
-        
+        tool_calls = [
+            {
+                "id": "call_123",
+                "type": "function",
+                "function": {"name": "process", "arguments": complex_args},
+            }
+        ]
+
         print("Action: Converting to text...")
         result = tool_calls_to_text(tool_calls)
-        
+
         print(f"Result: '{result}'")
         print("Checking that complex arguments are preserved...")
         assert complex_args in result
@@ -3936,35 +4262,38 @@ class TestToolCallsToText:
 # Tests for tool_results_to_text
 # ==================================================================================================
 
+
 class TestToolResultsToText:
     """
     Tests for tool_results_to_text function.
-    
+
     This function converts tool_results to human-readable text representation.
     Used when stripping tool content from messages (when no tools are defined).
     """
-    
+
     def test_converts_single_tool_result_to_text(self):
         """
         What it does: Verifies conversion of a single tool result to text.
         Purpose: Ensure basic conversion works correctly.
         """
         print("Setup: Single tool result...")
-        tool_results = [{
-            "type": "tool_result",
-            "tool_use_id": "call_123",
-            "content": "Operation completed successfully"
-        }]
-        
+        tool_results = [
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_123",
+                "content": "Operation completed successfully",
+            }
+        ]
+
         print("Action: Converting to text...")
         result = tool_results_to_text(tool_results)
-        
+
         print(f"Result: '{result}'")
         print("Checking that [Tool Result] marker is present...")
         assert "[Tool Result" in result
         print("Checking that content is present...")
         assert "Operation completed successfully" in result
-    
+
     def test_converts_multiple_tool_results_to_text(self):
         """
         What it does: Verifies conversion of multiple tool results to text.
@@ -3973,89 +4302,86 @@ class TestToolResultsToText:
         print("Setup: Multiple tool results...")
         tool_results = [
             {"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"},
-            {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"}
+            {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"},
         ]
-        
+
         print("Action: Converting to text...")
         result = tool_results_to_text(tool_results)
-        
+
         print(f"Result: '{result}'")
         print("Checking that both results are present...")
         assert "Result 1" in result
         assert "Result 2" in result
         assert "call_1" in result
         assert "call_2" in result
-    
+
     def test_includes_tool_use_id_in_output(self):
         """
         What it does: Verifies that tool_use_id is included in output.
         Purpose: Ensure traceability between tool calls and results.
         """
         print("Setup: Tool result with tool_use_id...")
-        tool_results = [{
-            "type": "tool_result",
-            "tool_use_id": "tooluse_xyz789abc",
-            "content": "Done"
-        }]
-        
+        tool_results = [
+            {
+                "type": "tool_result",
+                "tool_use_id": "tooluse_xyz789abc",
+                "content": "Done",
+            }
+        ]
+
         print("Action: Converting to text...")
         result = tool_results_to_text(tool_results)
-        
+
         print(f"Result: '{result}'")
         print("Checking that tool_use_id is present...")
         assert "tooluse_xyz789abc" in result
-    
+
     def test_handles_missing_tool_use_id(self):
         """
         What it does: Verifies handling of tool result without tool_use_id.
         Purpose: Ensure function doesn't crash when tool_use_id is missing.
         """
         print("Setup: Tool result without tool_use_id...")
-        tool_results = [{
-            "type": "tool_result",
-            "content": "Some result"
-        }]
-        
+        tool_results = [{"type": "tool_result", "content": "Some result"}]
+
         print("Action: Converting to text...")
         result = tool_results_to_text(tool_results)
-        
+
         print(f"Result: '{result}'")
         print("Checking that content is still present...")
         assert "Some result" in result
         assert "[Tool Result]" in result
-    
+
     def test_handles_empty_content(self):
         """
         What it does: Verifies handling of empty content.
         Purpose: Ensure empty content is replaced with placeholder.
         """
         print("Setup: Tool result with empty content...")
-        tool_results = [{
-            "type": "tool_result",
-            "tool_use_id": "call_123",
-            "content": ""
-        }]
-        
+        tool_results = [
+            {"type": "tool_result", "tool_use_id": "call_123", "content": ""}
+        ]
+
         print("Action: Converting to text...")
         result = tool_results_to_text(tool_results)
-        
+
         print(f"Result: '{result}'")
         print("Checking that placeholder is used...")
         assert "(empty result)" in result
-    
+
     def test_returns_empty_string_for_empty_list(self):
         """
         What it does: Verifies empty list handling.
         Purpose: Ensure empty input returns empty output.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Converting to text...")
         result = tool_results_to_text([])
-        
+
         print(f"Comparing result: Expected '', Got '{result}'")
         assert result == ""
-    
+
     def test_handles_multiline_content(self):
         """
         What it does: Verifies handling of multiline content.
@@ -4063,34 +4389,38 @@ class TestToolResultsToText:
         """
         print("Setup: Tool result with multiline content...")
         multiline_content = "Line 1\nLine 2\nLine 3"
-        tool_results = [{
-            "type": "tool_result",
-            "tool_use_id": "call_123",
-            "content": multiline_content
-        }]
-        
+        tool_results = [
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_123",
+                "content": multiline_content,
+            }
+        ]
+
         print("Action: Converting to text...")
         result = tool_results_to_text(tool_results)
-        
+
         print(f"Result: '{result}'")
         print("Checking that multiline content is preserved...")
         assert "Line 1\nLine 2\nLine 3" in result
-    
+
     def test_handles_list_content(self):
         """
         What it does: Verifies handling of list content (multimodal format).
         Purpose: Ensure list content is extracted correctly.
         """
         print("Setup: Tool result with list content...")
-        tool_results = [{
-            "type": "tool_result",
-            "tool_use_id": "call_123",
-            "content": [{"type": "text", "text": "Extracted text"}]
-        }]
-        
+        tool_results = [
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_123",
+                "content": [{"type": "text", "text": "Extracted text"}],
+            }
+        ]
+
         print("Action: Converting to text...")
         result = tool_results_to_text(tool_results)
-        
+
         print(f"Result: '{result}'")
         print("Checking that text is extracted from list...")
         assert "Extracted text" in result
@@ -4100,22 +4430,23 @@ class TestToolResultsToText:
 # Tests for build_kiro_payload with Issue #20 Scenario
 # ==================================================================================================
 
+
 class TestBuildKiroPayloadIssue20:
     """
     Tests for build_kiro_payload function specifically for Issue #20 scenario.
-    
+
     Issue #20: OpenCode compaction returns 400 "Improperly formed request"
     because it sends tool_calls/tool_results in history but WITHOUT tools definitions.
-    
+
     Kiro API requires tools definitions if toolUses/toolResults are present.
     The fix converts tool content to text representation when no tools are defined.
     """
-    
+
     def test_compaction_without_tools_converts_tool_content_to_text(self):
         """
         What it does: Simulates OpenCode compaction scenario - messages with tool content but no tools.
         Purpose: Ensure build_kiro_payload doesn't crash and converts tool content to text.
-        
+
         This is THE critical test for issue #20. If this test passes but the fix is removed,
         the actual API call would fail with 400 error.
         """
@@ -4125,25 +4456,34 @@ class TestBuildKiroPayloadIssue20:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "tooluse_abc123",
-                    "type": "function",
-                    "function": {"name": "read_file", "arguments": '{"path": "test.py"}'}
-                }]
+                tool_calls=[
+                    {
+                        "id": "tooluse_abc123",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path": "test.py"}',
+                        },
+                    }
+                ],
             ),
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "tooluse_abc123",
-                    "content": "def hello():\n    print('world')"
-                }]
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tooluse_abc123",
+                        "content": "def hello():\n    print('world')",
+                    }
+                ],
             ),
-            UnifiedMessage(role="assistant", content="I see the file contains a hello function."),
-            UnifiedMessage(role="user", content="Summarize what we did")
+            UnifiedMessage(
+                role="assistant", content="I see the file contains a hello function."
+            ),
+            UnifiedMessage(role="user", content="Summarize what we did"),
         ]
-        
+
         print("Action: Building Kiro payload WITHOUT tools (compaction scenario)...")
         result = build_kiro_payload(
             messages=messages,
@@ -4152,34 +4492,46 @@ class TestBuildKiroPayloadIssue20:
             tools=None,  # NO TOOLS - this is the compaction scenario
             conversation_id="test-conv-123",
             profile_arn="arn:aws:codewhisperer:us-east-1:123456789:profile/test",
-            inject_thinking=False
+            inject_thinking=False,
         )
-        
+
         print(f"Result payload keys: {result.payload.keys()}")
         print("Checking that payload was built successfully...")
         assert "conversationState" in result.payload
         assert "currentMessage" in result.payload["conversationState"]
-        
+
         print("Checking that history exists...")
         history = result.payload["conversationState"].get("history", [])
         print(f"History length: {len(history)}")
         assert len(history) > 0
-        
-        print("Checking that NO toolUses in history (they should be converted to text)...")
+
+        print(
+            "Checking that NO toolUses in history (they should be converted to text)..."
+        )
         for i, msg in enumerate(history):
             if "assistantResponseMessage" in msg:
                 assistant_msg = msg["assistantResponseMessage"]
-                print(f"History[{i}] assistant content: '{assistant_msg.get('content', '')[:100]}...'")
-                assert "toolUses" not in assistant_msg, f"toolUses should not be in history[{i}]"
-        
-        print("Checking that NO toolResults in history (they should be converted to text)...")
+                print(
+                    f"History[{i}] assistant content: '{assistant_msg.get('content', '')[:100]}...'"
+                )
+                assert "toolUses" not in assistant_msg, (
+                    f"toolUses should not be in history[{i}]"
+                )
+
+        print(
+            "Checking that NO toolResults in history (they should be converted to text)..."
+        )
         for i, msg in enumerate(history):
             if "userInputMessage" in msg:
                 user_msg = msg["userInputMessage"]
                 context = user_msg.get("userInputMessageContext", {})
-                print(f"History[{i}] user content: '{user_msg.get('content', '')[:100]}...'")
-                assert "toolResults" not in context, f"toolResults should not be in history[{i}]"
-        
+                print(
+                    f"History[{i}] user content: '{user_msg.get('content', '')[:100]}...'"
+                )
+                assert "toolResults" not in context, (
+                    f"toolResults should not be in history[{i}]"
+                )
+
         print("Checking that tool content was converted to text (preserved context)...")
         # Find the assistant message that had tool_calls
         found_tool_text = False
@@ -4191,7 +4543,7 @@ class TestBuildKiroPayloadIssue20:
                     print(f"Found tool text representation: '{content[:200]}...'")
                     break
         assert found_tool_text, "Tool calls should be converted to text representation"
-    
+
     def test_compaction_preserves_tool_result_content_as_text(self):
         """
         What it does: Verifies that tool result content is preserved as text.
@@ -4202,15 +4554,17 @@ class TestBuildKiroPayloadIssue20:
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "IMPORTANT_DATA_12345"
-                }]
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": "IMPORTANT_DATA_12345",
+                    }
+                ],
             ),
-            UnifiedMessage(role="user", content="What was in that result?")
+            UnifiedMessage(role="user", content="What was in that result?"),
         ]
-        
+
         print("Action: Building Kiro payload without tools...")
         result = build_kiro_payload(
             messages=messages,
@@ -4219,15 +4573,15 @@ class TestBuildKiroPayloadIssue20:
             tools=None,
             conversation_id="test-conv",
             profile_arn="arn:test",
-            inject_thinking=False
+            inject_thinking=False,
         )
-        
+
         print("Checking that important data is preserved...")
         # The data could be in history OR in current message (after merging adjacent user messages)
         payload = result.payload
-        
+
         found_data = False
-        
+
         # Check history
         history = payload["conversationState"].get("history", [])
         for msg in history:
@@ -4237,16 +4591,20 @@ class TestBuildKiroPayloadIssue20:
                     found_data = True
                     print(f"Found preserved data in history: '{content[:100]}...'")
                     break
-        
+
         # Check current message (adjacent user messages are merged)
         if not found_data:
-            current_content = payload["conversationState"]["currentMessage"]["userInputMessage"].get("content", "")
+            current_content = payload["conversationState"]["currentMessage"][
+                "userInputMessage"
+            ].get("content", "")
             if "IMPORTANT_DATA_12345" in current_content:
                 found_data = True
-                print(f"Found preserved data in current message: '{current_content[:100]}...'")
-        
+                print(
+                    f"Found preserved data in current message: '{current_content[:100]}...'"
+                )
+
         assert found_data, "Tool result content should be preserved as text"
-    
+
     def test_with_tools_defined_keeps_tool_structure(self):
         """
         What it does: Verifies that when tools ARE defined, tool structure is preserved.
@@ -4258,30 +4616,36 @@ class TestBuildKiroPayloadIssue20:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "test_tool", "arguments": "{}"}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "test_tool", "arguments": "{}"},
+                    }
+                ],
             ),
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Tool executed"
-                }]
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": "Tool executed",
+                    }
+                ],
             ),
-            UnifiedMessage(role="user", content="Continue")
+            UnifiedMessage(role="user", content="Continue"),
         ]
-        
-        tools = [UnifiedTool(
-            name="test_tool",
-            description="A test tool",
-            input_schema={"type": "object", "properties": {}}
-        )]
-        
+
+        tools = [
+            UnifiedTool(
+                name="test_tool",
+                description="A test tool",
+                input_schema={"type": "object", "properties": {}},
+            )
+        ]
+
         print("Action: Building Kiro payload WITH tools...")
         result = build_kiro_payload(
             messages=messages,
@@ -4290,14 +4654,16 @@ class TestBuildKiroPayloadIssue20:
             tools=tools,  # TOOLS DEFINED
             conversation_id="test-conv",
             profile_arn="arn:test",
-            inject_thinking=False
+            inject_thinking=False,
         )
-        
+
         print("Checking that tools are in payload...")
-        current_msg = result.payload["conversationState"]["currentMessage"]["userInputMessage"]
+        current_msg = result.payload["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]
         context = current_msg.get("userInputMessageContext", {})
         assert "tools" in context, "Tools should be in payload when defined"
-        
+
         print("Checking that toolUses are preserved in history...")
         history = result.payload["conversationState"].get("history", [])
         found_tool_uses = False
@@ -4307,7 +4673,7 @@ class TestBuildKiroPayloadIssue20:
                     found_tool_uses = True
                     break
         assert found_tool_uses, "toolUses should be preserved when tools are defined"
-    
+
     def test_empty_tools_list_triggers_stripping(self):
         """
         What it does: Verifies that empty tools list (tools=[]) triggers tool content stripping.
@@ -4318,15 +4684,17 @@ class TestBuildKiroPayloadIssue20:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "some_tool", "arguments": "{}"}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "some_tool", "arguments": "{}"},
+                    }
+                ],
             ),
-            UnifiedMessage(role="user", content="Continue")
+            UnifiedMessage(role="user", content="Continue"),
         ]
-        
+
         print("Action: Building Kiro payload with empty tools list...")
         result = build_kiro_payload(
             messages=messages,
@@ -4335,14 +4703,18 @@ class TestBuildKiroPayloadIssue20:
             tools=[],  # EMPTY TOOLS LIST
             conversation_id="test-conv",
             profile_arn="arn:test",
-            inject_thinking=False
+            inject_thinking=False,
         )
-        
+
         print("Checking that NO tools in payload...")
-        current_msg = result.payload["conversationState"]["currentMessage"]["userInputMessage"]
+        current_msg = result.payload["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]
         context = current_msg.get("userInputMessageContext", {})
-        assert "tools" not in context, "Empty tools list should result in no tools in payload"
-        
+        assert "tools" not in context, (
+            "Empty tools list should result in no tools in payload"
+        )
+
         print("Checking that tool content was converted to text...")
         history = result.payload["conversationState"].get("history", [])
         for msg in history:
@@ -4354,21 +4726,22 @@ class TestBuildKiroPayloadIssue20:
 # Tests for build_kiro_payload with Images (Issue #30)
 # ==================================================================================================
 
+
 class TestBuildKiroPayloadImages:
     """
     Tests for build_kiro_payload function with image content.
-    
+
     Issue #30: 422 Validation Error when sending image content blocks.
     The fix adds support for image content blocks in messages.
-    
+
     These tests verify that images are correctly included in the Kiro payload.
     """
-    
+
     def test_includes_images_in_current_message(self):
         """
         What it does: Verifies that images are included in the current message.
         Purpose: Ensure images from the last user message are directly in userInputMessage (Issue #32 fix).
-        
+
         This is a critical test for Issue #30/#32 fix - images should be in userInputMessage, NOT in userInputMessageContext.
         """
         print("Setup: User message with image as current message...")
@@ -4376,10 +4749,10 @@ class TestBuildKiroPayloadImages:
             UnifiedMessage(
                 role="user",
                 content="What's in this image?",
-                images=[{"media_type": "image/jpeg", "data": TEST_IMAGE_BASE64}]
+                images=[{"media_type": "image/jpeg", "data": TEST_IMAGE_BASE64}],
             )
         ]
-        
+
         print("Action: Building Kiro payload...")
         result = build_kiro_payload(
             messages=messages,
@@ -4388,27 +4761,31 @@ class TestBuildKiroPayloadImages:
             tools=None,
             conversation_id="test-conv-123",
             profile_arn="arn:aws:codewhisperer:us-east-1:123456789:profile/test",
-            inject_thinking=False
+            inject_thinking=False,
         )
-        
+
         print(f"Result payload keys: {result.payload.keys()}")
         print("Checking that payload was built successfully...")
         assert "conversationState" in result.payload
-        
-        current_msg = result.payload["conversationState"]["currentMessage"]["userInputMessage"]
+
+        current_msg = result.payload["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]
         print(f"Current message: {current_msg}")
-        
-        print("Checking that images are directly in userInputMessage (Issue #32 fix)...")
+
+        print(
+            "Checking that images are directly in userInputMessage (Issue #32 fix)..."
+        )
         assert "images" in current_msg
-        
+
         images = current_msg["images"]
         print(f"Images: {images}")
         assert len(images) == 1
-        
+
         print("Checking image format (Kiro format)...")
         assert images[0]["format"] == "jpeg"
         assert images[0]["source"]["bytes"] == TEST_IMAGE_BASE64
-    
+
     def test_includes_multiple_images_in_current_message(self):
         """
         What it does: Verifies that multiple images are included in the current message.
@@ -4422,11 +4799,11 @@ class TestBuildKiroPayloadImages:
                 images=[
                     {"media_type": "image/jpeg", "data": "image1_data"},
                     {"media_type": "image/png", "data": "image2_data"},
-                    {"media_type": "image/gif", "data": "image3_data"}
-                ]
+                    {"media_type": "image/gif", "data": "image3_data"},
+                ],
             )
         ]
-        
+
         print("Action: Building Kiro payload...")
         result = build_kiro_payload(
             messages=messages,
@@ -4435,20 +4812,22 @@ class TestBuildKiroPayloadImages:
             tools=None,
             conversation_id="test-conv",
             profile_arn="arn:test",
-            inject_thinking=False
+            inject_thinking=False,
         )
-        
-        current_msg = result.payload["conversationState"]["currentMessage"]["userInputMessage"]
+
+        current_msg = result.payload["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]
         images = current_msg["images"]
-        
+
         print(f"Comparing image count: Expected 3, Got {len(images)}")
         assert len(images) == 3
-        
+
         print("Checking image formats...")
         assert images[0]["format"] == "jpeg"
         assert images[1]["format"] == "png"
         assert images[2]["format"] == "gif"
-    
+
     def test_includes_images_in_history(self):
         """
         What it does: Verifies that images are included in history messages.
@@ -4459,12 +4838,12 @@ class TestBuildKiroPayloadImages:
             UnifiedMessage(
                 role="user",
                 content="What's in this image?",
-                images=[{"media_type": "image/jpeg", "data": "history_image_data"}]
+                images=[{"media_type": "image/jpeg", "data": "history_image_data"}],
             ),
             UnifiedMessage(role="assistant", content="I see a cat in the image."),
-            UnifiedMessage(role="user", content="What color is the cat?")
+            UnifiedMessage(role="user", content="What color is the cat?"),
         ]
-        
+
         print("Action: Building Kiro payload...")
         result = build_kiro_payload(
             messages=messages,
@@ -4473,24 +4852,26 @@ class TestBuildKiroPayloadImages:
             tools=None,
             conversation_id="test-conv",
             profile_arn="arn:test",
-            inject_thinking=False
+            inject_thinking=False,
         )
-        
+
         print("Checking history...")
         history = result.payload["conversationState"]["history"]
         print(f"History length: {len(history)}")
         assert len(history) >= 1
-        
-        print("Checking that first history message has images directly in userInputMessage (Issue #32 fix)...")
+
+        print(
+            "Checking that first history message has images directly in userInputMessage (Issue #32 fix)..."
+        )
         first_msg = history[0]["userInputMessage"]
         assert "images" in first_msg
-        
+
         images = first_msg["images"]
         print(f"History images: {images}")
         assert len(images) == 1
         assert images[0]["format"] == "jpeg"
         assert images[0]["source"]["bytes"] == "history_image_data"
-    
+
     def test_images_with_tools(self):
         """
         What it does: Verifies that images work correctly with tools.
@@ -4501,16 +4882,18 @@ class TestBuildKiroPayloadImages:
             UnifiedMessage(
                 role="user",
                 content="Analyze this image and use tools if needed",
-                images=[{"media_type": "image/png", "data": "image_with_tools_data"}]
+                images=[{"media_type": "image/png", "data": "image_with_tools_data"}],
             )
         ]
-        
-        tools = [UnifiedTool(
-            name="analyze_image",
-            description="Analyze an image",
-            input_schema={"type": "object", "properties": {}}
-        )]
-        
+
+        tools = [
+            UnifiedTool(
+                name="analyze_image",
+                description="Analyze an image",
+                input_schema={"type": "object", "properties": {}},
+            )
+        ]
+
         print("Action: Building Kiro payload with tools...")
         result = build_kiro_payload(
             messages=messages,
@@ -4519,26 +4902,30 @@ class TestBuildKiroPayloadImages:
             tools=tools,
             conversation_id="test-conv",
             profile_arn="arn:test",
-            inject_thinking=False
+            inject_thinking=False,
         )
-        
-        current_msg = result.payload["conversationState"]["currentMessage"]["userInputMessage"]
+
+        current_msg = result.payload["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]
         context = current_msg.get("userInputMessageContext", {})
-        
-        print("Checking that images are directly in userInputMessage (Issue #32 fix)...")
+
+        print(
+            "Checking that images are directly in userInputMessage (Issue #32 fix)..."
+        )
         assert "images" in current_msg
-        
+
         print("Checking that tools are in userInputMessageContext...")
         assert "tools" in context
-        
+
         print("Checking images...")
         assert len(current_msg["images"]) == 1
         assert current_msg["images"][0]["format"] == "png"
-        
+
         print("Checking tools...")
         assert len(context["tools"]) == 1
         assert context["tools"][0]["toolSpecification"]["name"] == "analyze_image"
-    
+
     def test_images_with_tool_results(self):
         """
         What it does: Verifies that images work correctly with tool results.
@@ -4550,30 +4937,36 @@ class TestBuildKiroPayloadImages:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "get_data", "arguments": "{}"}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "get_data", "arguments": "{}"},
+                    }
+                ],
             ),
             UnifiedMessage(
                 role="user",
                 content="Here's the result and an image",
                 images=[{"media_type": "image/jpeg", "data": "image_with_result_data"}],
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Tool output"
-                }]
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": "Tool output",
+                    }
+                ],
+            ),
+        ]
+
+        tools = [
+            UnifiedTool(
+                name="get_data",
+                description="Get data",
+                input_schema={"type": "object", "properties": {}},
             )
         ]
-        
-        tools = [UnifiedTool(
-            name="get_data",
-            description="Get data",
-            input_schema={"type": "object", "properties": {}}
-        )]
-        
+
         print("Action: Building Kiro payload...")
         result = build_kiro_payload(
             messages=messages,
@@ -4582,36 +4975,38 @@ class TestBuildKiroPayloadImages:
             tools=tools,
             conversation_id="test-conv",
             profile_arn="arn:test",
-            inject_thinking=False
+            inject_thinking=False,
         )
-        
+
         # The last user message becomes current message
-        current_msg = result.payload["conversationState"]["currentMessage"]["userInputMessage"]
+        current_msg = result.payload["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]
         context = current_msg.get("userInputMessageContext", {})
-        
-        print("Checking that images are directly in userInputMessage (Issue #32 fix)...")
+
+        print(
+            "Checking that images are directly in userInputMessage (Issue #32 fix)..."
+        )
         assert "images" in current_msg
-        
+
         print("Checking that toolResults are in userInputMessageContext...")
         assert "toolResults" in context
-        
+
         print("Checking images...")
         assert len(current_msg["images"]) == 1
         assert current_msg["images"][0]["format"] == "jpeg"
-        
+
         print("Checking toolResults...")
         assert len(context["toolResults"]) == 1
-    
+
     def test_no_images_when_none_provided(self):
         """
         What it does: Verifies that images key is not added when no images are provided.
         Purpose: Ensure clean payload without unnecessary empty arrays.
         """
         print("Setup: User message without images...")
-        messages = [
-            UnifiedMessage(role="user", content="Hello, no images here")
-        ]
-        
+        messages = [UnifiedMessage(role="user", content="Hello, no images here")]
+
         print("Action: Building Kiro payload...")
         result = build_kiro_payload(
             messages=messages,
@@ -4620,18 +5015,20 @@ class TestBuildKiroPayloadImages:
             tools=None,
             conversation_id="test-conv",
             profile_arn="arn:test",
-            inject_thinking=False
+            inject_thinking=False,
         )
-        
-        context = result.payload["conversationState"]["currentMessage"]["userInputMessage"].get("userInputMessageContext", {})
-        
+
+        context = result.payload["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ].get("userInputMessageContext", {})
+
         print("Checking that images key is not present or empty...")
         # Either no images key, or empty images array
         if "images" in context:
             assert context["images"] == [], "Images should be empty when none provided"
         else:
             print("No images key - OK")
-    
+
     def test_large_image_data_preserved(self):
         """
         What it does: Verifies that large image data is preserved without truncation.
@@ -4643,10 +5040,10 @@ class TestBuildKiroPayloadImages:
             UnifiedMessage(
                 role="user",
                 content="Analyze this large image",
-                images=[{"media_type": "image/png", "data": large_image_data}]
+                images=[{"media_type": "image/png", "data": large_image_data}],
             )
         ]
-        
+
         print("Action: Building Kiro payload...")
         result = build_kiro_payload(
             messages=messages,
@@ -4655,16 +5052,20 @@ class TestBuildKiroPayloadImages:
             tools=None,
             conversation_id="test-conv",
             profile_arn="arn:test",
-            inject_thinking=False
+            inject_thinking=False,
         )
-        
-        current_msg = result.payload["conversationState"]["currentMessage"]["userInputMessage"]
+
+        current_msg = result.payload["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]
         images = current_msg["images"]
-        
-        print(f"Checking image data length: Expected 500000, Got {len(images[0]['source']['bytes'])}")
+
+        print(
+            f"Checking image data length: Expected 500000, Got {len(images[0]['source']['bytes'])}"
+        )
         assert len(images[0]["source"]["bytes"]) == 500000
         assert images[0]["source"]["bytes"] == large_image_data
-    
+
     def test_images_with_thinking_injection(self):
         """
         What it does: Verifies that images work correctly with thinking injection.
@@ -4675,13 +5076,13 @@ class TestBuildKiroPayloadImages:
             UnifiedMessage(
                 role="user",
                 content="What's in this image?",
-                images=[{"media_type": "image/jpeg", "data": "thinking_test_image"}]
+                images=[{"media_type": "image/jpeg", "data": "thinking_test_image"}],
             )
         ]
-        
+
         print("Action: Building Kiro payload with thinking injection...")
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-            with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 4000):
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 4000):
                 result = build_kiro_payload(
                     messages=messages,
                     system_prompt="",
@@ -4689,16 +5090,20 @@ class TestBuildKiroPayloadImages:
                     tools=None,
                     conversation_id="test-conv",
                     profile_arn="arn:test",
-                    inject_thinking=True
+                    inject_thinking=True,
                 )
-        
-        current_msg = result.payload["conversationState"]["currentMessage"]["userInputMessage"]
-        
-        print("Checking that images are directly in userInputMessage (Issue #32 fix)...")
+
+        current_msg = result.payload["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]
+
+        print(
+            "Checking that images are directly in userInputMessage (Issue #32 fix)..."
+        )
         assert "images" in current_msg
         assert len(current_msg["images"]) == 1
         assert current_msg["images"][0]["source"]["bytes"] == "thinking_test_image"
-        
+
         print("Checking that thinking tags were injected in content...")
         content = current_msg["content"]
         assert "<thinking_mode>" in content

--- a/tests/unit/test_converters_openai.py
+++ b/tests/unit/test_converters_openai.py
@@ -24,9 +24,10 @@ from kiro.models_openai import ChatMessage, ChatCompletionRequest, Tool, ToolFun
 # Tests for convert_openai_messages_to_unified
 # ==================================================================================================
 
+
 class TestConvertOpenAIMessagesToUnified:
     """Tests for convert_openai_messages_to_unified function."""
-    
+
     def test_extracts_system_prompt(self):
         """
         What it does: Verifies extraction of system prompt from messages.
@@ -35,18 +36,18 @@ class TestConvertOpenAIMessagesToUnified:
         print("Setup: Messages with system prompt...")
         messages = [
             ChatMessage(role="system", content="You are helpful"),
-            ChatMessage(role="user", content="Hello")
+            ChatMessage(role="user", content="Hello"),
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"System prompt: '{system_prompt}'")
         print(f"Unified messages: {len(unified)}")
         assert system_prompt == "You are helpful"
         assert len(unified) == 1
         assert unified[0].role == "user"
-    
+
     def test_combines_multiple_system_messages(self):
         """
         What it does: Verifies combining of multiple system messages.
@@ -56,17 +57,17 @@ class TestConvertOpenAIMessagesToUnified:
         messages = [
             ChatMessage(role="system", content="You are helpful."),
             ChatMessage(role="system", content="Be concise."),
-            ChatMessage(role="user", content="Hello")
+            ChatMessage(role="user", content="Hello"),
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"System prompt: '{system_prompt}'")
         assert "You are helpful." in system_prompt
         assert "Be concise." in system_prompt
         assert len(unified) == 1
-    
+
     def test_converts_tool_message_to_user_with_tool_results(self):
         """
         What it does: Verifies conversion of tool message to user message with tool_results.
@@ -74,19 +75,21 @@ class TestConvertOpenAIMessagesToUnified:
         """
         print("Setup: Tool message...")
         messages = [
-            ChatMessage(role="tool", content="Tool result text", tool_call_id="call_123")
+            ChatMessage(
+                role="tool", content="Tool result text", tool_call_id="call_123"
+            )
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Unified messages: {unified}")
         assert len(unified) == 1
         assert unified[0].role == "user"
         assert unified[0].tool_results is not None
         assert len(unified[0].tool_results) == 1
         assert unified[0].tool_results[0]["tool_use_id"] == "call_123"
-    
+
     def test_converts_multiple_tool_messages(self):
         """
         What it does: Verifies conversion of multiple consecutive tool messages.
@@ -96,17 +99,17 @@ class TestConvertOpenAIMessagesToUnified:
         messages = [
             ChatMessage(role="tool", content="Result 1", tool_call_id="call_1"),
             ChatMessage(role="tool", content="Result 2", tool_call_id="call_2"),
-            ChatMessage(role="tool", content="Result 3", tool_call_id="call_3")
+            ChatMessage(role="tool", content="Result 3", tool_call_id="call_3"),
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Unified messages: {unified}")
         assert len(unified) == 1
         assert unified[0].role == "user"
         assert len(unified[0].tool_results) == 3
-    
+
     def test_extracts_tool_calls_from_assistant(self):
         """
         What it does: Verifies extraction of tool_calls from assistant message.
@@ -117,56 +120,57 @@ class TestConvertOpenAIMessagesToUnified:
             ChatMessage(
                 role="assistant",
                 content="I'll call a tool",
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "get_weather", "arguments": '{"location": "Moscow"}'}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"location": "Moscow"}',
+                        },
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Unified messages: {unified}")
         assert len(unified) == 1
         assert unified[0].role == "assistant"
         assert unified[0].tool_calls is not None
         assert len(unified[0].tool_calls) == 1
         assert unified[0].tool_calls[0]["id"] == "call_123"
-    
+
     def test_handles_empty_tool_call_id(self):
         """
         What it does: Verifies handling of None tool_call_id.
         Purpose: Ensure None is replaced with empty string.
         """
         print("Setup: Tool message with None tool_call_id...")
-        messages = [
-            ChatMessage(role="tool", content="Result", tool_call_id=None)
-        ]
-        
+        messages = [ChatMessage(role="tool", content="Result", tool_call_id=None)]
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Unified messages: {unified}")
         assert unified[0].tool_results[0]["tool_use_id"] == ""
-    
+
     def test_handles_empty_tool_content(self):
         """
         What it does: Verifies handling of empty tool content.
         Purpose: Ensure empty content is replaced with "(empty result)".
         """
         print("Setup: Tool message with empty content...")
-        messages = [
-            ChatMessage(role="tool", content="", tool_call_id="call_1")
-        ]
-        
+        messages = [ChatMessage(role="tool", content="", tool_call_id="call_1")]
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Unified messages: {unified}")
         assert unified[0].tool_results[0]["content"] == "(empty result)"
-    
+
     def test_tool_messages_followed_by_user_message(self):
         """
         What it does: Verifies tool messages followed by user message.
@@ -175,12 +179,12 @@ class TestConvertOpenAIMessagesToUnified:
         print("Setup: Tool messages + user message...")
         messages = [
             ChatMessage(role="tool", content="Result 1", tool_call_id="call_1"),
-            ChatMessage(role="user", content="Continue please")
+            ChatMessage(role="user", content="Continue please"),
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Unified messages: {unified}")
         # Tool results should be in first message, user content in second
         assert len(unified) == 2
@@ -188,22 +192,22 @@ class TestConvertOpenAIMessagesToUnified:
         assert unified[0].tool_results is not None
         assert unified[1].role == "user"
         assert unified[1].content == "Continue please"
-    
+
     # ==================================================================================
     # Image extraction tests (Issue #30 fix)
     # ==================================================================================
-    
+
     def test_extracts_images_from_user_message(self):
         """
         What it does: Verifies that images are extracted from user messages.
         Purpose: Ensure OpenAI image_url content blocks are converted to unified format.
-        
+
         This test verifies the fix for Issue #30 - 422 Validation Error for image content.
         """
         print("Setup: User message with image_url content block...")
         # Base64 1x1 pixel JPEG
         test_image_base64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q=="
-        
+
         messages = [
             ChatMessage(
                 role="user",
@@ -213,33 +217,39 @@ class TestConvertOpenAIMessagesToUnified:
                         "type": "image_url",
                         "image_url": {
                             "url": f"data:image/jpeg;base64,{test_image_base64}"
-                        }
-                    }
-                ]
+                        },
+                    },
+                ],
             )
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Result: {unified}")
         print(f"Images: {unified[0].images}")
-        
+
         assert len(unified) == 1
         assert unified[0].role == "user"
         assert unified[0].content == "What's in this image?"
-        
+
         print("Checking images field...")
         assert unified[0].images is not None, "images field should not be None"
-        assert len(unified[0].images) == 1, f"Expected 1 image, got {len(unified[0].images)}"
-        
+        assert len(unified[0].images) == 1, (
+            f"Expected 1 image, got {len(unified[0].images)}"
+        )
+
         image = unified[0].images[0]
-        print(f"Comparing image: Expected media_type='image/jpeg', Got '{image.get('media_type')}'")
+        print(
+            f"Comparing image: Expected media_type='image/jpeg', Got '{image.get('media_type')}'"
+        )
         assert image["media_type"] == "image/jpeg"
-        
-        print(f"Comparing image data: Expected {test_image_base64[:20]}..., Got {image.get('data', '')[:20]}...")
+
+        print(
+            f"Comparing image data: Expected {test_image_base64[:20]}..., Got {image.get('data', '')[:20]}..."
+        )
         assert image["data"] == test_image_base64
-    
+
     def test_images_only_extracted_from_user_role(self):
         """
         What it does: Verifies that images are only extracted from user messages.
@@ -247,7 +257,7 @@ class TestConvertOpenAIMessagesToUnified:
         """
         print("Setup: Conversation with image in user message only...")
         test_image_base64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q=="
-        
+
         messages = [
             ChatMessage(
                 role="user",
@@ -255,28 +265,29 @@ class TestConvertOpenAIMessagesToUnified:
                     {"type": "text", "text": "Describe this image"},
                     {
                         "type": "image_url",
-                        "image_url": {"url": f"data:image/png;base64,{test_image_base64}"}
-                    }
-                ]
+                        "image_url": {
+                            "url": f"data:image/png;base64,{test_image_base64}"
+                        },
+                    },
+                ],
             ),
-            ChatMessage(
-                role="assistant",
-                content="I can see a small image."
-            )
+            ChatMessage(role="assistant", content="I can see a small image."),
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Result: {unified}")
-        
+
         print("Checking user message has images...")
         assert unified[0].images is not None
         assert len(unified[0].images) == 1
-        
+
         print("Checking assistant message has no images...")
-        assert unified[1].images is None, "Assistant messages should not have images extracted"
-    
+        assert unified[1].images is None, (
+            "Assistant messages should not have images extracted"
+        )
+
     def test_extracts_multiple_images_from_user_message(self):
         """
         What it does: Verifies extraction of multiple images from a single user message.
@@ -284,7 +295,7 @@ class TestConvertOpenAIMessagesToUnified:
         """
         print("Setup: User message with multiple images...")
         test_image_base64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q=="
-        
+
         messages = [
             ChatMessage(
                 role="user",
@@ -292,45 +303,55 @@ class TestConvertOpenAIMessagesToUnified:
                     {"type": "text", "text": "Compare these images"},
                     {
                         "type": "image_url",
-                        "image_url": {"url": f"data:image/jpeg;base64,{test_image_base64}"}
+                        "image_url": {
+                            "url": f"data:image/jpeg;base64,{test_image_base64}"
+                        },
                     },
                     {
                         "type": "image_url",
-                        "image_url": {"url": f"data:image/png;base64,{test_image_base64}"}
+                        "image_url": {
+                            "url": f"data:image/png;base64,{test_image_base64}"
+                        },
                     },
                     {
                         "type": "image_url",
-                        "image_url": {"url": f"data:image/webp;base64,{test_image_base64}"}
-                    }
-                ]
+                        "image_url": {
+                            "url": f"data:image/webp;base64,{test_image_base64}"
+                        },
+                    },
+                ],
             )
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
-        print(f"Result images count: {len(unified[0].images) if unified[0].images else 0}")
-        
+
+        print(
+            f"Result images count: {len(unified[0].images) if unified[0].images else 0}"
+        )
+
         assert unified[0].images is not None
-        assert len(unified[0].images) == 3, f"Expected 3 images, got {len(unified[0].images)}"
-        
+        assert len(unified[0].images) == 3, (
+            f"Expected 3 images, got {len(unified[0].images)}"
+        )
+
         print("Checking image media types...")
         media_types = [img["media_type"] for img in unified[0].images]
         print(f"Media types: {media_types}")
         assert "image/jpeg" in media_types
         assert "image/png" in media_types
         assert "image/webp" in media_types
-    
+
     def test_counts_images_in_debug_log(self, caplog):
         """
         What it does: Verifies that image count is logged in debug message.
         Purpose: Ensure logging includes image statistics for debugging.
         """
         import logging
-        
+
         print("Setup: User message with images for logging test...")
         test_image_base64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q=="
-        
+
         messages = [
             ChatMessage(
                 role="user",
@@ -338,26 +359,30 @@ class TestConvertOpenAIMessagesToUnified:
                     {"type": "text", "text": "Analyze this"},
                     {
                         "type": "image_url",
-                        "image_url": {"url": f"data:image/jpeg;base64,{test_image_base64}"}
+                        "image_url": {
+                            "url": f"data:image/jpeg;base64,{test_image_base64}"
+                        },
                     },
                     {
                         "type": "image_url",
-                        "image_url": {"url": f"data:image/png;base64,{test_image_base64}"}
-                    }
-                ]
+                        "image_url": {
+                            "url": f"data:image/png;base64,{test_image_base64}"
+                        },
+                    },
+                ],
             )
         ]
-        
+
         print("Action: Converting messages with logging enabled...")
         with caplog.at_level(logging.DEBUG):
             system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Log records: {[r.message for r in caplog.records]}")
-        
+
         # Check that images were extracted
         assert unified[0].images is not None
         assert len(unified[0].images) == 2
-        
+
         # Note: loguru doesn't integrate with caplog by default
         # The function logs "Converted X OpenAI messages: Y tool_calls, Z tool_results, W images"
         # We verify the images are extracted correctly, which proves the counting works
@@ -368,77 +393,88 @@ class TestConvertOpenAIMessagesToUnified:
 # Tests for convert_openai_tools_to_unified
 # ==================================================================================================
 
+
 class TestConvertOpenAIToolsToUnified:
     """Tests for convert_openai_tools_to_unified function."""
-    
+
     def test_returns_none_for_none(self):
         """
         What it does: Verifies handling of None.
         Purpose: Ensure None returns None.
         """
         print("Setup: None tools...")
-        
+
         print("Action: Converting tools...")
         result = convert_openai_tools_to_unified(None)
-        
+
         print(f"Result: {result}")
         assert result is None
-    
+
     def test_returns_none_for_empty_list(self):
         """
         What it does: Verifies handling of empty list.
         Purpose: Ensure empty list returns None.
         """
         print("Setup: Empty tools list...")
-        
+
         print("Action: Converting tools...")
         result = convert_openai_tools_to_unified([])
-        
+
         print(f"Result: {result}")
         assert result is None
-    
+
     def test_converts_function_tool(self):
         """
         What it does: Verifies conversion of function tool.
         Purpose: Ensure Tool is converted to UnifiedTool.
         """
         print("Setup: Function tool...")
-        tools = [Tool(
-            type="function",
-            function=ToolFunction(
-                name="get_weather",
-                description="Get weather for a location",
-                parameters={"type": "object", "properties": {"location": {"type": "string"}}}
+        tools = [
+            Tool(
+                type="function",
+                function=ToolFunction(
+                    name="get_weather",
+                    description="Get weather for a location",
+                    parameters={
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                    },
+                ),
             )
-        )]
-        
+        ]
+
         print("Action: Converting tools...")
         result = convert_openai_tools_to_unified(tools)
-        
+
         print(f"Result: {result}")
         assert result is not None
         assert len(result) == 1
         assert result[0].name == "get_weather"
         assert result[0].description == "Get weather for a location"
-        assert result[0].input_schema == {"type": "object", "properties": {"location": {"type": "string"}}}
-    
+        assert result[0].input_schema == {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+        }
+
     def test_skips_non_function_tools(self):
         """
         What it does: Verifies skipping of non-function tools.
         Purpose: Ensure only function tools are converted.
         """
         print("Setup: Non-function tool...")
-        tools = [Tool(
-            type="other_type",
-            function=ToolFunction(name="test", description="Test", parameters={})
-        )]
-        
+        tools = [
+            Tool(
+                type="other_type",
+                function=ToolFunction(name="test", description="Test", parameters={}),
+            )
+        ]
+
         print("Action: Converting tools...")
         result = convert_openai_tools_to_unified(tools)
-        
+
         print(f"Result: {result}")
         assert result is None  # No function tools, so None
-    
+
     def test_converts_multiple_tools(self):
         """
         What it does: Verifies conversion of multiple tools.
@@ -446,14 +482,29 @@ class TestConvertOpenAIToolsToUnified:
         """
         print("Setup: Multiple tools...")
         tools = [
-            Tool(type="function", function=ToolFunction(name="tool1", description="Tool 1", parameters={})),
-            Tool(type="function", function=ToolFunction(name="tool2", description="Tool 2", parameters={})),
-            Tool(type="function", function=ToolFunction(name="tool3", description="Tool 3", parameters={}))
+            Tool(
+                type="function",
+                function=ToolFunction(
+                    name="tool1", description="Tool 1", parameters={}
+                ),
+            ),
+            Tool(
+                type="function",
+                function=ToolFunction(
+                    name="tool2", description="Tool 2", parameters={}
+                ),
+            ),
+            Tool(
+                type="function",
+                function=ToolFunction(
+                    name="tool3", description="Tool 3", parameters={}
+                ),
+            ),
         ]
-        
+
         print("Action: Converting tools...")
         result = convert_openai_tools_to_unified(tools)
-        
+
         print(f"Result: {result}")
         assert len(result) == 3
         assert result[0].name == "tool1"
@@ -465,9 +516,10 @@ class TestConvertOpenAIToolsToUnified:
 # Tests for build_kiro_payload
 # ==================================================================================================
 
+
 class TestBuildKiroPayload:
     """Tests for build_kiro_payload function."""
-    
+
     def test_builds_simple_payload(self):
         """
         What it does: Verifies building of simple payload.
@@ -476,18 +528,18 @@ class TestBuildKiroPayload:
         print("Setup: Simple request...")
         request = ChatCompletionRequest(
             model="claude-sonnet-4-5",
-            messages=[ChatMessage(role="user", content="Hello")]
+            messages=[ChatMessage(role="user", content="Hello")],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "arn:aws:test")
-        
+
         print(f"Result: {result}")
         assert "conversationState" in result
         assert result["conversationState"]["conversationId"] == "conv-123"
         assert "currentMessage" in result["conversationState"]
         assert result["profileArn"] == "arn:aws:test"
-    
+
     def test_includes_system_prompt_in_first_message(self):
         """
         What it does: Verifies adding system prompt to first message.
@@ -498,18 +550,20 @@ class TestBuildKiroPayload:
             model="claude-sonnet-4-5",
             messages=[
                 ChatMessage(role="system", content="You are helpful"),
-                ChatMessage(role="user", content="Hello")
-            ]
+                ChatMessage(role="user", content="Hello"),
+            ],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Result: {result}")
-        current_content = result["conversationState"]["currentMessage"]["userInputMessage"]["content"]
+        current_content = result["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]["content"]
         assert "You are helpful" in current_content
         assert "Hello" in current_content
-    
+
     def test_builds_history_for_multi_turn(self):
         """
         What it does: Verifies building history for multi-turn.
@@ -521,17 +575,17 @@ class TestBuildKiroPayload:
             messages=[
                 ChatMessage(role="user", content="Hello"),
                 ChatMessage(role="assistant", content="Hi"),
-                ChatMessage(role="user", content="How are you?")
-            ]
+                ChatMessage(role="user", content="How are you?"),
+            ],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Result: {result}")
         assert "history" in result["conversationState"]
         assert len(result["conversationState"]["history"]) == 2
-    
+
     def test_handles_assistant_as_last_message(self):
         """
         What it does: Verifies handling of assistant as last message.
@@ -542,17 +596,19 @@ class TestBuildKiroPayload:
             model="claude-sonnet-4-5",
             messages=[
                 ChatMessage(role="user", content="Hello"),
-                ChatMessage(role="assistant", content="Hi there")
-            ]
+                ChatMessage(role="assistant", content="Hi there"),
+            ],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Result: {result}")
-        current_content = result["conversationState"]["currentMessage"]["userInputMessage"]["content"]
+        current_content = result["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]["content"]
         assert current_content == "Continue"
-    
+
     def test_raises_for_empty_messages(self):
         """
         What it does: Verifies exception raising for empty messages.
@@ -561,16 +617,16 @@ class TestBuildKiroPayload:
         print("Setup: Request with only system message...")
         request = ChatCompletionRequest(
             model="claude-sonnet-4-5",
-            messages=[ChatMessage(role="system", content="You are helpful")]
+            messages=[ChatMessage(role="system", content="You are helpful")],
         )
-        
+
         print("Action: Attempting to build payload...")
         with pytest.raises(ValueError) as exc_info:
             build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Exception: {exc_info.value}")
         assert "No messages to send" in str(exc_info.value)
-    
+
     def test_uses_continue_for_empty_content(self):
         """
         What it does: Verifies using "Continue" for empty content.
@@ -578,23 +634,24 @@ class TestBuildKiroPayload:
         """
         print("Setup: Request with empty content...")
         request = ChatCompletionRequest(
-            model="claude-sonnet-4-5",
-            messages=[ChatMessage(role="user", content="")]
+            model="claude-sonnet-4-5", messages=[ChatMessage(role="user", content="")]
         )
 
         print("Action: Building payload (with fake reasoning disabled)...")
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', False):
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
             result = build_kiro_payload(request, "conv-123", "")
 
         print(f"Result: {result}")
-        current_content = result["conversationState"]["currentMessage"]["userInputMessage"]["content"]
+        current_content = result["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]["content"]
         assert current_content == "Continue"
-    
+
     def test_normalizes_model_id_correctly(self):
         """
         What it does: Verifies normalization of external model ID to Kiro format.
         Purpose: Ensure model name normalization is applied (dashes→dots, strip dates).
-        
+
         Note: The new Dynamic Model Resolution System normalizes model names
         (e.g., claude-sonnet-4-5 → claude-sonnet-4.5) instead of mapping to
         internal IDs. Kiro API accepts the normalized format directly.
@@ -602,18 +659,20 @@ class TestBuildKiroPayload:
         print("Setup: Request with external model ID...")
         request = ChatCompletionRequest(
             model="claude-sonnet-4-5",
-            messages=[ChatMessage(role="user", content="Hello")]
+            messages=[ChatMessage(role="user", content="Hello")],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Result: {result}")
-        model_id = result["conversationState"]["currentMessage"]["userInputMessage"]["modelId"]
+        model_id = result["conversationState"]["currentMessage"]["userInputMessage"][
+            "modelId"
+        ]
         # claude-sonnet-4-5 should normalize to claude-sonnet-4.5 (dashes→dots)
         print(f"Comparing model_id: Expected 'claude-sonnet-4.5', Got '{model_id}'")
         assert model_id == "claude-sonnet-4.5"
-    
+
     def test_includes_tools_in_context(self):
         """
         What it does: Verifies including tools in userInputMessageContext.
@@ -623,25 +682,29 @@ class TestBuildKiroPayload:
         request = ChatCompletionRequest(
             model="claude-sonnet-4-5",
             messages=[ChatMessage(role="user", content="Hello")],
-            tools=[Tool(
-                type="function",
-                function=ToolFunction(
-                    name="get_weather",
-                    description="Get weather",
-                    parameters={"type": "object", "properties": {}}
+            tools=[
+                Tool(
+                    type="function",
+                    function=ToolFunction(
+                        name="get_weather",
+                        description="Get weather",
+                        parameters={"type": "object", "properties": {}},
+                    ),
                 )
-            )]
+            ],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Result: {result}")
-        context = result["conversationState"]["currentMessage"]["userInputMessage"]["userInputMessageContext"]
+        context = result["conversationState"]["currentMessage"]["userInputMessage"][
+            "userInputMessageContext"
+        ]
         assert "tools" in context
         assert len(context["tools"]) == 1
         assert context["tools"][0]["toolSpecification"]["name"] == "get_weather"
-    
+
     def test_injects_thinking_tags_even_when_tool_results_present(self):
         """
         What it does: Verifies thinking tags ARE injected even when toolResults are present.
@@ -655,13 +718,17 @@ class TestBuildKiroPayload:
                 ChatMessage(
                     role="assistant",
                     content="I'll run the command",
-                    tool_calls=[{
-                        "id": "tool_1",
-                        "type": "function",
-                        "function": {"name": "bash", "arguments": "{}"}
-                    }]
+                    tool_calls=[
+                        {
+                            "id": "tool_1",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": "{}"},
+                        }
+                    ],
                 ),
-                ChatMessage(role="tool", content="Command output here", tool_call_id="tool_1"),
+                ChatMessage(
+                    role="tool", content="Command output here", tool_call_id="tool_1"
+                ),
             ],
             # Tools must be defined for tool_results to be preserved
             tools=[
@@ -670,28 +737,32 @@ class TestBuildKiroPayload:
                     function=ToolFunction(
                         name="bash",
                         description="Run a bash command",
-                        parameters={"type": "object", "properties": {}}
-                    )
+                        parameters={"type": "object", "properties": {}},
+                    ),
                 )
-            ]
+            ],
         )
-        
+
         print("Action: Building payload with FAKE_REASONING_ENABLED=True...")
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-            with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 4000):
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 4000):
                 result = build_kiro_payload(request, "conv-123", "")
-        
+
         current_msg = result["conversationState"]["currentMessage"]["userInputMessage"]
         content = current_msg["content"]
         context = current_msg.get("userInputMessageContext", {})
-        
+
         print(f"Content: {repr(content[:100] if len(content) > 100 else content)}")
         print(f"Has toolResults: {'toolResults' in context}")
-        
+
         assert "toolResults" in context, "toolResults should be present"
-        assert "<thinking_mode>enabled</thinking_mode>" in content, "thinking tags SHOULD be injected even with toolResults"
-        assert "<max_thinking_length>4000</max_thinking_length>" in content, "max_thinking_length should be present"
-    
+        assert "<thinking_mode>enabled</thinking_mode>" in content, (
+            "thinking tags SHOULD be injected even with toolResults"
+        )
+        assert "<max_thinking_length>4000</max_thinking_length>" in content, (
+            "max_thinking_length should be present"
+        )
+
     def test_injects_thinking_tags_when_no_tool_results(self):
         """
         What it does: Verifies thinking tags ARE injected for normal user messages.
@@ -700,23 +771,25 @@ class TestBuildKiroPayload:
         print("Setup: Normal user message without tool results...")
         request = ChatCompletionRequest(
             model="claude-sonnet-4-5",
-            messages=[ChatMessage(role="user", content="Hello")]
+            messages=[ChatMessage(role="user", content="Hello")],
         )
-        
+
         print("Action: Building payload with FAKE_REASONING_ENABLED=True...")
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-            with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 4000):
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 4000):
                 result = build_kiro_payload(request, "conv-123", "")
-        
+
         current_msg = result["conversationState"]["currentMessage"]["userInputMessage"]
         content = current_msg["content"]
         context = current_msg.get("userInputMessageContext", {})
-        
+
         print(f"Content starts with thinking tags: {'<thinking_mode>' in content}")
         print(f"Has toolResults: {'toolResults' in context}")
-        
+
         assert "toolResults" not in context, "toolResults should NOT be present"
-        assert "<thinking_mode>" in content, "thinking tags SHOULD be injected for normal messages"
+        assert "<thinking_mode>" in content, (
+            "thinking tags SHOULD be injected for normal messages"
+        )
         assert "Hello" in content, "Original content should be preserved"
 
 
@@ -724,9 +797,10 @@ class TestBuildKiroPayload:
 # Tests for tool message handling
 # ==================================================================================================
 
+
 class TestToolMessageHandling:
     """Tests for OpenAI tool message (role="tool") handling."""
-    
+
     def test_converts_multiple_tool_messages_to_single_user_message(self):
         """
         What it does: Verifies merging of multiple tool messages into single user message.
@@ -736,26 +810,26 @@ class TestToolMessageHandling:
         messages = [
             ChatMessage(role="tool", content="Result 1", tool_call_id="call_1"),
             ChatMessage(role="tool", content="Result 2", tool_call_id="call_2"),
-            ChatMessage(role="tool", content="Result 3", tool_call_id="call_3")
+            ChatMessage(role="tool", content="Result 3", tool_call_id="call_3"),
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Result: {unified}")
         print(f"Comparing length: Expected 1, Got {len(unified)}")
         assert len(unified) == 1
         assert unified[0].role == "user"
-        
+
         print("Checking content contains all tool_results...")
         assert unified[0].tool_results is not None
         assert len(unified[0].tool_results) == 3
-        
+
         tool_use_ids = [item["tool_use_id"] for item in unified[0].tool_results]
         assert "call_1" in tool_use_ids
         assert "call_2" in tool_use_ids
         assert "call_3" in tool_use_ids
-    
+
     def test_assistant_tool_user_sequence(self):
         """
         What it does: Verifies assistant -> tool -> user sequence.
@@ -765,12 +839,12 @@ class TestToolMessageHandling:
         messages = [
             ChatMessage(role="assistant", content="I'll call a tool"),
             ChatMessage(role="tool", content="Tool output", tool_call_id="call_abc"),
-            ChatMessage(role="user", content="Thanks!")
+            ChatMessage(role="user", content="Thanks!"),
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Result: {unified}")
         # assistant stays, tool becomes user with tool_results, then user
         assert len(unified) == 3
@@ -778,37 +852,33 @@ class TestToolMessageHandling:
         assert unified[1].role == "user"
         assert unified[1].tool_results is not None
         assert unified[2].role == "user"
-    
+
     def test_tool_message_with_empty_content(self):
         """
         What it does: Verifies tool message with empty content.
         Purpose: Ensure empty result is replaced with "(empty result)".
         """
         print("Setup: Tool message with empty content...")
-        messages = [
-            ChatMessage(role="tool", content="", tool_call_id="call_empty")
-        ]
-        
+        messages = [ChatMessage(role="tool", content="", tool_call_id="call_empty")]
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Result: {unified}")
         assert len(unified) == 1
         assert unified[0].tool_results[0]["content"] == "(empty result)"
-    
+
     def test_tool_message_with_none_tool_call_id(self):
         """
         What it does: Verifies tool message without tool_call_id.
         Purpose: Ensure missing tool_call_id is replaced with empty string.
         """
         print("Setup: Tool message without tool_call_id...")
-        messages = [
-            ChatMessage(role="tool", content="Result", tool_call_id=None)
-        ]
-        
+        messages = [ChatMessage(role="tool", content="Result", tool_call_id=None)]
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Result: {unified}")
         assert len(unified) == 1
         assert unified[0].tool_results[0]["tool_use_id"] == ""
@@ -818,14 +888,15 @@ class TestToolMessageHandling:
 # Tests for tool description handling
 # ==================================================================================================
 
+
 class TestToolDescriptionHandling:
     """Tests for handling empty/whitespace tool descriptions."""
-    
+
     def test_empty_description_replaced_with_placeholder(self):
         """
         What it does: Verifies replacement of empty description with placeholder.
         Purpose: Ensure empty description is replaced with "Tool: {name}".
-        
+
         This is a critical test for a Cline bug where tool focus_chain had
         empty description "", which caused a 400 error from Kiro API.
         """
@@ -833,25 +904,29 @@ class TestToolDescriptionHandling:
         request = ChatCompletionRequest(
             model="claude-sonnet-4-5",
             messages=[ChatMessage(role="user", content="Hello")],
-            tools=[Tool(
-                type="function",
-                function=ToolFunction(
-                    name="focus_chain",
-                    description="",
-                    parameters={"type": "object", "properties": {}}
+            tools=[
+                Tool(
+                    type="function",
+                    function=ToolFunction(
+                        name="focus_chain",
+                        description="",
+                        parameters={"type": "object", "properties": {}},
+                    ),
                 )
-            )]
+            ],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Result: {result}")
         print("Checking that description is replaced with placeholder...")
-        context = result["conversationState"]["currentMessage"]["userInputMessage"]["userInputMessageContext"]
+        context = result["conversationState"]["currentMessage"]["userInputMessage"][
+            "userInputMessageContext"
+        ]
         tool_spec = context["tools"][0]["toolSpecification"]
         assert tool_spec["description"] == "Tool: focus_chain"
-    
+
     def test_whitespace_only_description_replaced_with_placeholder(self):
         """
         What it does: Verifies replacement of whitespace-only description with placeholder.
@@ -861,25 +936,27 @@ class TestToolDescriptionHandling:
         request = ChatCompletionRequest(
             model="claude-sonnet-4-5",
             messages=[ChatMessage(role="user", content="Hello")],
-            tools=[Tool(
-                type="function",
-                function=ToolFunction(
-                    name="whitespace_tool",
-                    description="   ",
-                    parameters={}
+            tools=[
+                Tool(
+                    type="function",
+                    function=ToolFunction(
+                        name="whitespace_tool", description="   ", parameters={}
+                    ),
                 )
-            )]
+            ],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Result: {result}")
         print("Checking that description is replaced with placeholder...")
-        context = result["conversationState"]["currentMessage"]["userInputMessage"]["userInputMessageContext"]
+        context = result["conversationState"]["currentMessage"]["userInputMessage"][
+            "userInputMessageContext"
+        ]
         tool_spec = context["tools"][0]["toolSpecification"]
         assert tool_spec["description"] == "Tool: whitespace_tool"
-    
+
     def test_none_description_replaced_with_placeholder(self):
         """
         What it does: Verifies replacement of None description with placeholder.
@@ -889,25 +966,27 @@ class TestToolDescriptionHandling:
         request = ChatCompletionRequest(
             model="claude-sonnet-4-5",
             messages=[ChatMessage(role="user", content="Hello")],
-            tools=[Tool(
-                type="function",
-                function=ToolFunction(
-                    name="none_desc_tool",
-                    description=None,
-                    parameters={}
+            tools=[
+                Tool(
+                    type="function",
+                    function=ToolFunction(
+                        name="none_desc_tool", description=None, parameters={}
+                    ),
                 )
-            )]
+            ],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Result: {result}")
         print("Checking that description is replaced with placeholder...")
-        context = result["conversationState"]["currentMessage"]["userInputMessage"]["userInputMessageContext"]
+        context = result["conversationState"]["currentMessage"]["userInputMessage"][
+            "userInputMessageContext"
+        ]
         tool_spec = context["tools"][0]["toolSpecification"]
         assert tool_spec["description"] == "Tool: none_desc_tool"
-    
+
     def test_non_empty_description_preserved(self):
         """
         What it does: Verifies preservation of non-empty description.
@@ -917,25 +996,29 @@ class TestToolDescriptionHandling:
         request = ChatCompletionRequest(
             model="claude-sonnet-4-5",
             messages=[ChatMessage(role="user", content="Hello")],
-            tools=[Tool(
-                type="function",
-                function=ToolFunction(
-                    name="get_weather",
-                    description="Get weather for a location",
-                    parameters={}
+            tools=[
+                Tool(
+                    type="function",
+                    function=ToolFunction(
+                        name="get_weather",
+                        description="Get weather for a location",
+                        parameters={},
+                    ),
                 )
-            )]
+            ],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Result: {result}")
         print("Checking that description is preserved...")
-        context = result["conversationState"]["currentMessage"]["userInputMessage"]["userInputMessageContext"]
+        context = result["conversationState"]["currentMessage"]["userInputMessage"][
+            "userInputMessageContext"
+        ]
         tool_spec = context["tools"][0]["toolSpecification"]
         assert tool_spec["description"] == "Get weather for a location"
-    
+
     def test_sanitizes_tool_parameters(self):
         """
         What it does: Verifies sanitization of parameters from problematic fields.
@@ -945,36 +1028,40 @@ class TestToolDescriptionHandling:
         request = ChatCompletionRequest(
             model="claude-sonnet-4-5",
             messages=[ChatMessage(role="user", content="Hello")],
-            tools=[Tool(
-                type="function",
-                function=ToolFunction(
-                    name="test_tool",
-                    description="Test tool",
-                    parameters={
-                        "type": "object",
-                        "properties": {},
-                        "required": [],
-                        "additionalProperties": False
-                    }
+            tools=[
+                Tool(
+                    type="function",
+                    function=ToolFunction(
+                        name="test_tool",
+                        description="Test tool",
+                        parameters={
+                            "type": "object",
+                            "properties": {},
+                            "required": [],
+                            "additionalProperties": False,
+                        },
+                    ),
                 )
-            )]
+            ],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Result: {result}")
         print("Checking that parameters are sanitized...")
-        context = result["conversationState"]["currentMessage"]["userInputMessage"]["userInputMessageContext"]
+        context = result["conversationState"]["currentMessage"]["userInputMessage"][
+            "userInputMessageContext"
+        ]
         input_schema = context["tools"][0]["toolSpecification"]["inputSchema"]["json"]
         assert "required" not in input_schema
         assert "additionalProperties" not in input_schema
-    
+
     def test_mixed_tools_with_empty_and_normal_descriptions(self):
         """
         What it does: Verifies handling of mixed tools list.
         Purpose: Ensure empty descriptions are replaced while normal ones are preserved.
-        
+
         This is a real scenario from Cline where most tools have
         normal descriptions, but focus_chain has an empty one.
         """
@@ -988,34 +1075,34 @@ class TestToolDescriptionHandling:
                     function=ToolFunction(
                         name="read_file",
                         description="Read contents of a file",
-                        parameters={}
-                    )
+                        parameters={},
+                    ),
                 ),
                 Tool(
                     type="function",
                     function=ToolFunction(
-                        name="focus_chain",
-                        description="",
-                        parameters={}
-                    )
+                        name="focus_chain", description="", parameters={}
+                    ),
                 ),
                 Tool(
                     type="function",
                     function=ToolFunction(
                         name="write_file",
                         description="Write content to a file",
-                        parameters={}
-                    )
-                )
-            ]
+                        parameters={},
+                    ),
+                ),
+            ],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Result: {result}")
         print("Checking descriptions...")
-        context = result["conversationState"]["currentMessage"]["userInputMessage"]["userInputMessageContext"]
+        context = result["conversationState"]["currentMessage"]["userInputMessage"][
+            "userInputMessageContext"
+        ]
         tools = context["tools"]
         assert tools[0]["toolSpecification"]["description"] == "Read contents of a file"
         assert tools[1]["toolSpecification"]["description"] == "Tool: focus_chain"
@@ -1026,12 +1113,13 @@ class TestToolDescriptionHandling:
 # Integration tests for full flow
 # ==================================================================================================
 
+
 class TestBuildKiroPayloadToolCallsIntegration:
     """
     Integration tests for build_kiro_payload with tool_calls.
     Tests full flow from OpenAI format to Kiro format.
     """
-    
+
     def test_multiple_assistant_tool_calls_with_results(self):
         """
         What it does: Verifies full scenario with multiple assistant tool_calls and their results.
@@ -1049,25 +1137,41 @@ class TestBuildKiroPayloadToolCallsIntegration:
                 ChatMessage(
                     role="assistant",
                     content=None,
-                    tool_calls=[{
-                        "id": "tooluse_first",
-                        "type": "function",
-                        "function": {"name": "shell", "arguments": '{"command": ["ls"]}'}
-                    }]
+                    tool_calls=[
+                        {
+                            "id": "tooluse_first",
+                            "type": "function",
+                            "function": {
+                                "name": "shell",
+                                "arguments": '{"command": ["ls"]}',
+                            },
+                        }
+                    ],
                 ),
                 # Second assistant with tool_call (consecutive!)
                 ChatMessage(
                     role="assistant",
                     content=None,
-                    tool_calls=[{
-                        "id": "tooluse_second",
-                        "type": "function",
-                        "function": {"name": "shell", "arguments": '{"command": ["pwd"]}'}
-                    }]
+                    tool_calls=[
+                        {
+                            "id": "tooluse_second",
+                            "type": "function",
+                            "function": {
+                                "name": "shell",
+                                "arguments": '{"command": ["pwd"]}',
+                            },
+                        }
+                    ],
                 ),
                 # Results of both tool_calls
-                ChatMessage(role="tool", content="file1.txt\nfile2.txt", tool_call_id="tooluse_first"),
-                ChatMessage(role="tool", content="/home/user", tool_call_id="tooluse_second")
+                ChatMessage(
+                    role="tool",
+                    content="file1.txt\nfile2.txt",
+                    tool_call_id="tooluse_first",
+                ),
+                ChatMessage(
+                    role="tool", content="/home/user", tool_call_id="tooluse_second"
+                ),
             ],
             # Tools must be defined for tool_results to be preserved
             tools=[
@@ -1076,55 +1180,64 @@ class TestBuildKiroPayloadToolCallsIntegration:
                     function=ToolFunction(
                         name="shell",
                         description="Run a shell command",
-                        parameters={"type": "object", "properties": {"command": {"type": "array"}}}
-                    )
+                        parameters={
+                            "type": "object",
+                            "properties": {"command": {"type": "array"}},
+                        },
+                    ),
                 )
-            ]
+            ],
         )
-        
+
         print("Action: Building Kiro payload...")
         result = build_kiro_payload(request, "conv-123", "arn:aws:test")
-        
+
         print(f"Result: {result}")
-        
+
         # Check history
         history = result["conversationState"].get("history", [])
         print(f"History: {history}")
-        
+
         # Should have userInputMessage and assistantResponseMessage in history
-        assert len(history) >= 2, f"Expected at least 2 elements in history, got {len(history)}"
-        
+        assert len(history) >= 2, (
+            f"Expected at least 2 elements in history, got {len(history)}"
+        )
+
         # Find assistantResponseMessage
         assistant_msgs = [h for h in history if "assistantResponseMessage" in h]
         print(f"Assistant messages in history: {assistant_msgs}")
-        assert len(assistant_msgs) >= 1, "Should have at least one assistantResponseMessage"
-        
+        assert len(assistant_msgs) >= 1, (
+            "Should have at least one assistantResponseMessage"
+        )
+
         # Check that assistantResponseMessage has both toolUses
         assistant_msg = assistant_msgs[0]["assistantResponseMessage"]
         tool_uses = assistant_msg.get("toolUses", [])
         print(f"ToolUses in assistant: {tool_uses}")
         print(f"Comparing toolUses count: Expected 2, Got {len(tool_uses)}")
         assert len(tool_uses) == 2, f"Should have 2 toolUses, got {len(tool_uses)}"
-        
+
         tool_use_ids = [tu["toolUseId"] for tu in tool_uses]
         print(f"ToolUse IDs: {tool_use_ids}")
         assert "tooluse_first" in tool_use_ids
         assert "tooluse_second" in tool_use_ids
-        
+
         # Check currentMessage contains toolResults
         current_msg = result["conversationState"]["currentMessage"]["userInputMessage"]
         context = current_msg.get("userInputMessageContext", {})
         tool_results = context.get("toolResults", [])
         print(f"ToolResults in currentMessage: {tool_results}")
         print(f"Comparing toolResults count: Expected 2, Got {len(tool_results)}")
-        assert len(tool_results) == 2, f"Should have 2 toolResults, got {len(tool_results)}"
-        
+        assert len(tool_results) == 2, (
+            f"Should have 2 toolResults, got {len(tool_results)}"
+        )
+
         # Note: tool_results in Kiro payload use camelCase (toolUseId)
         tool_result_ids = [tr["toolUseId"] for tr in tool_results]
         print(f"ToolResult IDs: {tool_result_ids}")
         assert "tooluse_first" in tool_result_ids
         assert "tooluse_second" in tool_result_ids
-    
+
     def test_long_tool_description_added_to_system_prompt(self):
         """
         What it does: Verifies integration of long tool descriptions into payload.
@@ -1136,28 +1249,35 @@ class TestBuildKiroPayloadToolCallsIntegration:
             model="claude-sonnet-4-5",
             messages=[
                 ChatMessage(role="system", content="You are helpful"),
-                ChatMessage(role="user", content="Hello")
+                ChatMessage(role="user", content="Hello"),
             ],
-            tools=[Tool(
-                type="function",
-                function=ToolFunction(
-                    name="long_tool",
-                    description=long_desc,
-                    parameters={}
+            tools=[
+                Tool(
+                    type="function",
+                    function=ToolFunction(
+                        name="long_tool", description=long_desc, parameters={}
+                    ),
                 )
-            )]
+            ],
         )
-        
+
         print("Action: Building payload...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 10000):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 10000):
             result = build_kiro_payload(request, "conv-123", "")
-        
+
         print("Checking that system prompt contains tool documentation...")
-        current_content = result["conversationState"]["currentMessage"]["userInputMessage"]["content"]
+        current_content = result["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]["content"]
         assert "You are helpful" in current_content
         assert "## Tool: long_tool" in current_content
         assert long_desc in current_content
-        
+
         print("Checking that tool in context has reference description...")
-        tools_context = result["conversationState"]["currentMessage"]["userInputMessage"]["userInputMessageContext"]["tools"]
-        assert "[Full documentation in system prompt" in tools_context[0]["toolSpecification"]["description"]
+        tools_context = result["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]["userInputMessageContext"]["tools"]
+        assert (
+            "[Full documentation in system prompt"
+            in tools_context[0]["toolSpecification"]["description"]
+        )

--- a/tests/unit/test_debug_logger.py
+++ b/tests/unit/test_debug_logger.py
@@ -6,58 +6,58 @@ Unit-тесты для DebugLogger.
 """
 
 import json
-import pytest
-from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 
 class TestDebugLoggerModeOff:
     """Тесты для режима DEBUG_MODE=off."""
-    
+
     def test_prepare_new_request_does_nothing(self, tmp_path):
         """
         Что он делает: Проверяет, что prepare_new_request ничего не делает в режиме off.
         Цель: Убедиться, что в режиме off директория не создаётся.
         """
         print("Настройка: Режим off...")
-        with patch('kiro.debug_logger.DEBUG_MODE', 'off'):
-            with patch('kiro.debug_logger.DEBUG_DIR', str(tmp_path / "debug_logs")):
+        with patch("kiro.debug_logger.DEBUG_MODE", "off"):
+            with patch("kiro.debug_logger.DEBUG_DIR", str(tmp_path / "debug_logs")):
                 # Пересоздаём экземпляр с новыми настройками
                 from kiro.debug_logger import DebugLogger
+
                 logger = DebugLogger.__new__(DebugLogger)
                 logger._initialized = False
                 logger.__init__()
                 logger.debug_dir = tmp_path / "debug_logs"
-                
+
                 print("Действие: Вызов prepare_new_request...")
                 logger.prepare_new_request()
-                
-                print(f"Проверяем, что директория не создана...")
+
+                print("Проверяем, что директория не создана...")
                 assert not (tmp_path / "debug_logs").exists()
-    
+
     def test_log_request_body_does_nothing(self, tmp_path):
         """
         Что он делает: Проверяет, что log_request_body ничего не делает в режиме off.
         Цель: Убедиться, что данные не записываются.
         """
         print("Настройка: Режим off...")
-        with patch('kiro.debug_logger.DEBUG_MODE', 'off'):
+        with patch("kiro.debug_logger.DEBUG_MODE", "off"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = tmp_path / "debug_logs"
-            
+
             print("Действие: Вызов log_request_body...")
             logger.log_request_body(b'{"test": "data"}')
-            
-            print(f"Проверяем, что файл не создан...")
+
+            print("Проверяем, что файл не создан...")
             assert not (tmp_path / "debug_logs" / "request_body.json").exists()
 
 
 class TestDebugLoggerModeAll:
     """Тесты для режима DEBUG_MODE=all."""
-    
+
     def test_prepare_new_request_clears_directory(self, tmp_path):
         """
         Что он делает: Проверяет, что prepare_new_request очищает директорию в режиме all.
@@ -68,22 +68,23 @@ class TestDebugLoggerModeAll:
         debug_dir.mkdir()
         old_file = debug_dir / "old_file.txt"
         old_file.write_text("old content")
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов prepare_new_request...")
             logger.prepare_new_request()
-            
-            print(f"Проверяем, что старый файл удалён...")
+
+            print("Проверяем, что старый файл удалён...")
             assert not old_file.exists()
-            print(f"Проверяем, что директория существует...")
+            print("Проверяем, что директория существует...")
             assert debug_dir.exists()
-    
+
     def test_log_request_body_writes_immediately(self, tmp_path):
         """
         Что он делает: Проверяет, что log_request_body пишет сразу в файл в режиме all.
@@ -92,26 +93,27 @@ class TestDebugLoggerModeAll:
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
         debug_dir.mkdir()
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_request_body...")
             test_data = b'{"model": "test", "messages": []}'
             logger.log_request_body(test_data)
-            
-            print(f"Проверяем, что файл создан...")
+
+            print("Проверяем, что файл создан...")
             file_path = debug_dir / "request_body.json"
             assert file_path.exists()
-            
-            print(f"Проверяем содержимое файла...")
+
+            print("Проверяем содержимое файла...")
             content = json.loads(file_path.read_text())
             assert content["model"] == "test"
-    
+
     def test_log_kiro_request_body_writes_immediately(self, tmp_path):
         """
         Что он делает: Проверяет, что log_kiro_request_body пишет сразу в файл в режиме all.
@@ -120,22 +122,23 @@ class TestDebugLoggerModeAll:
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
         debug_dir.mkdir()
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_kiro_request_body...")
             test_data = b'{"conversationState": {}}'
             logger.log_kiro_request_body(test_data)
-            
-            print(f"Проверяем, что файл создан...")
+
+            print("Проверяем, что файл создан...")
             file_path = debug_dir / "kiro_request_body.json"
             assert file_path.exists()
-    
+
     def test_log_raw_chunk_appends_to_file(self, tmp_path):
         """
         Что он делает: Проверяет, что log_raw_chunk дописывает в файл в режиме all.
@@ -144,27 +147,28 @@ class TestDebugLoggerModeAll:
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
         debug_dir.mkdir()
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_raw_chunk дважды...")
-            logger.log_raw_chunk(b'chunk1')
-            logger.log_raw_chunk(b'chunk2')
-            
-            print(f"Проверяем содержимое файла...")
+            logger.log_raw_chunk(b"chunk1")
+            logger.log_raw_chunk(b"chunk2")
+
+            print("Проверяем содержимое файла...")
             file_path = debug_dir / "response_stream_raw.txt"
             content = file_path.read_bytes()
-            assert content == b'chunk1chunk2'
+            assert content == b"chunk1chunk2"
 
 
 class TestDebugLoggerModeErrors:
     """Тесты для режима DEBUG_MODE=errors."""
-    
+
     def test_log_request_body_buffers_data(self, tmp_path):
         """
         Что он делает: Проверяет, что log_request_body буферизует данные в режиме errors.
@@ -172,24 +176,25 @@ class TestDebugLoggerModeErrors:
         """
         print("Настройка: Режим errors...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "errors"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_request_body...")
             test_data = b'{"test": "buffered"}'
             logger.log_request_body(test_data)
-            
-            print(f"Проверяем, что файл НЕ создан...")
+
+            print("Проверяем, что файл НЕ создан...")
             assert not debug_dir.exists()
-            
-            print(f"Проверяем, что данные в буфере...")
+
+            print("Проверяем, что данные в буфере...")
             assert logger._request_body_buffer == test_data
-    
+
     def test_flush_on_error_writes_buffers(self, tmp_path):
         """
         Что он делает: Проверяет, что flush_on_error записывает буферы в файлы.
@@ -197,35 +202,36 @@ class TestDebugLoggerModeErrors:
         """
         print("Настройка: Режим errors, заполняем буферы...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "errors"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             # Заполняем буферы
             logger.log_request_body(b'{"request": "body"}')
             logger.log_kiro_request_body(b'{"kiro": "request"}')
-            logger.log_raw_chunk(b'raw_chunk')
-            logger.log_modified_chunk(b'modified_chunk')
-            
+            logger.log_raw_chunk(b"raw_chunk")
+            logger.log_modified_chunk(b"modified_chunk")
+
             print("Действие: Вызов flush_on_error...")
             logger.flush_on_error(400, "Bad Request")
-            
-            print(f"Проверяем, что все файлы созданы...")
+
+            print("Проверяем, что все файлы созданы...")
             assert (debug_dir / "request_body.json").exists()
             assert (debug_dir / "kiro_request_body.json").exists()
             assert (debug_dir / "response_stream_raw.txt").exists()
             assert (debug_dir / "response_stream_modified.txt").exists()
             assert (debug_dir / "error_info.json").exists()
-            
-            print(f"Проверяем error_info.json...")
+
+            print("Проверяем error_info.json...")
             error_info = json.loads((debug_dir / "error_info.json").read_text())
             assert error_info["status_code"] == 400
             assert error_info["error_message"] == "Bad Request"
-    
+
     def test_flush_on_error_clears_buffers(self, tmp_path):
         """
         Что он делает: Проверяет, что flush_on_error очищает буферы после записи.
@@ -233,25 +239,26 @@ class TestDebugLoggerModeErrors:
         """
         print("Настройка: Режим errors...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "errors"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             logger.log_request_body(b'{"test": "data"}')
-            
+
             print("Действие: Вызов flush_on_error...")
             logger.flush_on_error(500, "Error")
-            
-            print(f"Проверяем, что буферы очищены...")
+
+            print("Проверяем, что буферы очищены...")
             assert logger._request_body_buffer is None
             assert logger._kiro_request_body_buffer is None
             assert len(logger._raw_chunks_buffer) == 0
             assert len(logger._modified_chunks_buffer) == 0
-    
+
     def test_discard_buffers_clears_without_writing(self, tmp_path):
         """
         Что он делает: Проверяет, что discard_buffers очищает буферы без записи.
@@ -259,27 +266,28 @@ class TestDebugLoggerModeErrors:
         """
         print("Настройка: Режим errors, заполняем буферы...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "errors"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             logger.log_request_body(b'{"test": "data"}')
-            logger.log_raw_chunk(b'chunk')
-            
+            logger.log_raw_chunk(b"chunk")
+
             print("Действие: Вызов discard_buffers...")
             logger.discard_buffers()
-            
-            print(f"Проверяем, что директория НЕ создана...")
+
+            print("Проверяем, что директория НЕ создана...")
             assert not debug_dir.exists()
-            
-            print(f"Проверяем, что буферы очищены...")
+
+            print("Проверяем, что буферы очищены...")
             assert logger._request_body_buffer is None
             assert len(logger._raw_chunks_buffer) == 0
-    
+
     def test_flush_on_error_writes_error_info_in_mode_all(self, tmp_path):
         """
         Что он делает: Проверяет, что flush_on_error записывает error_info.json в режиме all.
@@ -287,21 +295,22 @@ class TestDebugLoggerModeErrors:
         """
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов flush_on_error...")
             logger.flush_on_error(400, "Bad Request")
-            
-            print(f"Проверяем, что error_info.json создан...")
+
+            print("Проверяем, что error_info.json создан...")
             assert (debug_dir / "error_info.json").exists()
-            
-            print(f"Проверяем содержимое error_info.json...")
+
+            print("Проверяем содержимое error_info.json...")
             error_info = json.loads((debug_dir / "error_info.json").read_text())
             assert error_info["status_code"] == 400
             assert error_info["error_message"] == "Bad Request"
@@ -309,7 +318,7 @@ class TestDebugLoggerModeErrors:
 
 class TestDebugLoggerLogErrorInfo:
     """Тесты для метода log_error_info()."""
-    
+
     def test_log_error_info_writes_in_mode_all(self, tmp_path):
         """
         Что он делает: Проверяет, что log_error_info записывает файл в режиме all.
@@ -317,26 +326,27 @@ class TestDebugLoggerLogErrorInfo:
         """
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_error_info...")
             logger.log_error_info(500, "Internal Server Error")
-            
-            print(f"Проверяем, что error_info.json создан...")
+
+            print("Проверяем, что error_info.json создан...")
             error_file = debug_dir / "error_info.json"
             assert error_file.exists()
-            
-            print(f"Проверяем содержимое...")
+
+            print("Проверяем содержимое...")
             error_info = json.loads(error_file.read_text())
             assert error_info["status_code"] == 500
             assert error_info["error_message"] == "Internal Server Error"
-    
+
     def test_log_error_info_writes_in_mode_errors(self, tmp_path):
         """
         Что он делает: Проверяет, что log_error_info записывает файл в режиме errors.
@@ -344,21 +354,22 @@ class TestDebugLoggerLogErrorInfo:
         """
         print("Настройка: Режим errors...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "errors"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_error_info...")
             logger.log_error_info(404, "Not Found")
-            
-            print(f"Проверяем, что error_info.json создан...")
+
+            print("Проверяем, что error_info.json создан...")
             error_file = debug_dir / "error_info.json"
             assert error_file.exists()
-    
+
     def test_log_error_info_does_nothing_in_mode_off(self, tmp_path):
         """
         Что он делает: Проверяет, что log_error_info ничего не делает в режиме off.
@@ -366,103 +377,109 @@ class TestDebugLoggerLogErrorInfo:
         """
         print("Настройка: Режим off...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'off'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "off"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_error_info...")
             logger.log_error_info(500, "Error")
-            
-            print(f"Проверяем, что директория НЕ создана...")
+
+            print("Проверяем, что директория НЕ создана...")
             assert not debug_dir.exists()
 
 
 class TestDebugLoggerHelperMethods:
     """Тесты для вспомогательных методов DebugLogger."""
-    
+
     def test_is_enabled_returns_true_for_errors(self):
         """
         Что он делает: Проверяет _is_enabled() для режима errors.
         Цель: Убедиться, что режим errors считается включённым.
         """
         print("Настройка: Режим errors...")
-        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+        with patch("kiro.debug_logger.DEBUG_MODE", "errors"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
-            
-            print(f"Проверяем _is_enabled()...")
+
+            print("Проверяем _is_enabled()...")
             assert logger._is_enabled() is True
-    
+
     def test_is_enabled_returns_true_for_all(self):
         """
         Что он делает: Проверяет _is_enabled() для режима all.
         Цель: Убедиться, что режим all считается включённым.
         """
         print("Настройка: Режим all...")
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
-            
-            print(f"Проверяем _is_enabled()...")
+
+            print("Проверяем _is_enabled()...")
             assert logger._is_enabled() is True
-    
+
     def test_is_enabled_returns_false_for_off(self):
         """
         Что он делает: Проверяет _is_enabled() для режима off.
         Цель: Убедиться, что режим off считается выключенным.
         """
         print("Настройка: Режим off...")
-        with patch('kiro.debug_logger.DEBUG_MODE', 'off'):
+        with patch("kiro.debug_logger.DEBUG_MODE", "off"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
-            
-            print(f"Проверяем _is_enabled()...")
+
+            print("Проверяем _is_enabled()...")
             assert logger._is_enabled() is False
-    
+
     def test_is_immediate_write_returns_true_for_all(self):
         """
         Что он делает: Проверяет _is_immediate_write() для режима all.
         Цель: Убедиться, что режим all пишет сразу.
         """
         print("Настройка: Режим all...")
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
-            
-            print(f"Проверяем _is_immediate_write()...")
+
+            print("Проверяем _is_immediate_write()...")
             assert logger._is_immediate_write() is True
-    
+
     def test_is_immediate_write_returns_false_for_errors(self):
         """
         Что он делает: Проверяет _is_immediate_write() для режима errors.
         Цель: Убедиться, что режим errors буферизует.
         """
         print("Настройка: Режим errors...")
-        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+        with patch("kiro.debug_logger.DEBUG_MODE", "errors"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
-            
-            print(f"Проверяем _is_immediate_write()...")
+
+            print("Проверяем _is_immediate_write()...")
             assert logger._is_immediate_write() is False
 
 
 class TestDebugLoggerJsonHandling:
     """Тесты для обработки JSON в DebugLogger."""
-    
+
     def test_log_request_body_formats_json_pretty(self, tmp_path):
         """
         Что он делает: Проверяет, что JSON форматируется красиво.
@@ -471,22 +488,23 @@ class TestDebugLoggerJsonHandling:
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
         debug_dir.mkdir()
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_request_body с JSON...")
             logger.log_request_body(b'{"key":"value"}')
-            
-            print(f"Проверяем форматирование...")
+
+            print("Проверяем форматирование...")
             content = (debug_dir / "request_body.json").read_text()
             # Должен быть отформатирован с отступами
             assert "  " in content or "\n" in content
-    
+
     def test_log_request_body_handles_invalid_json(self, tmp_path):
         """
         Что он делает: Проверяет обработку невалидного JSON.
@@ -495,26 +513,27 @@ class TestDebugLoggerJsonHandling:
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
         debug_dir.mkdir()
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_request_body с невалидным JSON...")
-            invalid_data = b'not a json {{'
+            invalid_data = b"not a json {{"
             logger.log_request_body(invalid_data)
-            
-            print(f"Проверяем, что данные записаны как есть...")
+
+            print("Проверяем, что данные записаны как есть...")
             content = (debug_dir / "request_body.json").read_bytes()
             assert content == invalid_data
 
 
 class TestDebugLoggerAppLogsCapture:
     """Тесты для захвата логов приложения (app_logs.txt)."""
-    
+
     def test_prepare_new_request_sets_up_log_capture(self, tmp_path):
         """
         Что он делает: Проверяет, что prepare_new_request настраивает захват логов.
@@ -522,23 +541,24 @@ class TestDebugLoggerAppLogsCapture:
         """
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             dbg_logger = DebugLogger.__new__(DebugLogger)
             dbg_logger._initialized = False
             dbg_logger.__init__()
             dbg_logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов prepare_new_request...")
             dbg_logger.prepare_new_request()
-            
-            print(f"Проверяем, что sink создан...")
+
+            print("Проверяем, что sink создан...")
             assert dbg_logger._loguru_sink_id is not None
-            
+
             # Очистка
             dbg_logger._clear_app_logs_buffer()
-    
+
     def test_flush_on_error_writes_app_logs_in_mode_errors(self, tmp_path):
         """
         Что он делает: Проверяет, что flush_on_error записывает app_logs.txt в режиме errors.
@@ -546,36 +566,35 @@ class TestDebugLoggerAppLogsCapture:
         """
         print("Настройка: Режим errors...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "errors"):
             from kiro.debug_logger import DebugLogger
-            from loguru import logger as loguru_logger
-            
+
             dbg_logger = DebugLogger.__new__(DebugLogger)
             dbg_logger._initialized = False
             dbg_logger.__init__()
             dbg_logger.debug_dir = debug_dir
-            
+
             # Настраиваем захват логов
             dbg_logger.prepare_new_request()
-            
+
             # Добавляем данные в буфер чтобы flush сработал
             dbg_logger.log_request_body(b'{"test": "data"}')
-            
+
             # Пишем тестовый лог напрямую в буфер (имитация)
             dbg_logger._app_logs_buffer.write("Test log message\n")
-            
+
             print("Действие: Вызов flush_on_error...")
             dbg_logger.flush_on_error(500, "Test Error")
-            
-            print(f"Проверяем, что app_logs.txt создан...")
+
+            print("Проверяем, что app_logs.txt создан...")
             app_logs_file = debug_dir / "app_logs.txt"
             assert app_logs_file.exists()
-            
-            print(f"Проверяем содержимое...")
+
+            print("Проверяем содержимое...")
             content = app_logs_file.read_text()
             assert "Test log message" in content
-    
+
     def test_discard_buffers_saves_logs_in_mode_all(self, tmp_path):
         """
         Что он делает: Проверяет, что discard_buffers сохраняет логи в режиме all.
@@ -584,32 +603,32 @@ class TestDebugLoggerAppLogsCapture:
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
         debug_dir.mkdir()
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
-            
+
             dbg_logger = DebugLogger.__new__(DebugLogger)
             dbg_logger._initialized = False
             dbg_logger.__init__()
             dbg_logger.debug_dir = debug_dir
-            
+
             # Настраиваем захват логов
             dbg_logger.prepare_new_request()
-            
+
             # Пишем тестовый лог напрямую в буфер
             dbg_logger._app_logs_buffer.write("Success log message\n")
-            
+
             print("Действие: Вызов discard_buffers...")
             dbg_logger.discard_buffers()
-            
-            print(f"Проверяем, что app_logs.txt создан...")
+
+            print("Проверяем, что app_logs.txt создан...")
             app_logs_file = debug_dir / "app_logs.txt"
             assert app_logs_file.exists()
-            
-            print(f"Проверяем содержимое...")
+
+            print("Проверяем содержимое...")
             content = app_logs_file.read_text()
             assert "Success log message" in content
-    
+
     def test_discard_buffers_does_not_save_logs_in_mode_errors(self, tmp_path):
         """
         Что он делает: Проверяет, что discard_buffers НЕ сохраняет логи в режиме errors.
@@ -617,52 +636,52 @@ class TestDebugLoggerAppLogsCapture:
         """
         print("Настройка: Режим errors...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "errors"):
             from kiro.debug_logger import DebugLogger
-            
+
             dbg_logger = DebugLogger.__new__(DebugLogger)
             dbg_logger._initialized = False
             dbg_logger.__init__()
             dbg_logger.debug_dir = debug_dir
-            
+
             # Настраиваем захват логов
             dbg_logger.prepare_new_request()
-            
+
             # Пишем тестовый лог напрямую в буфер
             dbg_logger._app_logs_buffer.write("Should not be saved\n")
-            
+
             print("Действие: Вызов discard_buffers...")
             dbg_logger.discard_buffers()
-            
-            print(f"Проверяем, что директория НЕ создана...")
+
+            print("Проверяем, что директория НЕ создана...")
             assert not debug_dir.exists()
-    
+
     def test_clear_app_logs_buffer_removes_sink(self, tmp_path):
         """
         Что он делает: Проверяет, что _clear_app_logs_buffer удаляет sink.
         Цель: Убедиться, что sink корректно удаляется.
         """
         print("Настройка: Режим all...")
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
-            
+
             dbg_logger = DebugLogger.__new__(DebugLogger)
             dbg_logger._initialized = False
             dbg_logger.__init__()
             dbg_logger.debug_dir = tmp_path / "debug_logs"
-            
+
             # Настраиваем захват логов
             dbg_logger.prepare_new_request()
             sink_id = dbg_logger._loguru_sink_id
             assert sink_id is not None
-            
+
             print("Действие: Вызов _clear_app_logs_buffer...")
             dbg_logger._clear_app_logs_buffer()
-            
-            print(f"Проверяем, что sink_id сброшен...")
+
+            print("Проверяем, что sink_id сброшен...")
             assert dbg_logger._loguru_sink_id is None
-    
+
     def test_app_logs_not_saved_when_empty(self, tmp_path):
         """
         Что он делает: Проверяет, что пустые логи не создают файл.
@@ -671,20 +690,20 @@ class TestDebugLoggerAppLogsCapture:
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
         debug_dir.mkdir()
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
-            
+
             dbg_logger = DebugLogger.__new__(DebugLogger)
             dbg_logger._initialized = False
             dbg_logger.__init__()
             dbg_logger.debug_dir = debug_dir
-            
+
             # НЕ пишем ничего в буфер
-            
+
             print("Действие: Вызов _write_app_logs_to_file...")
             dbg_logger._write_app_logs_to_file()
-            
-            print(f"Проверяем, что app_logs.txt НЕ создан...")
+
+            print("Проверяем, что app_logs.txt НЕ создан...")
             app_logs_file = debug_dir / "app_logs.txt"
             assert not app_logs_file.exists()

--- a/tests/unit/test_debug_middleware.py
+++ b/tests/unit/test_debug_middleware.py
@@ -13,7 +13,7 @@ from starlette.responses import Response
 
 class TestDebugLoggerMiddlewareEndpointFiltering:
     """Tests for endpoint filtering in middleware."""
-    
+
     @pytest.mark.asyncio
     async def test_skips_health_endpoint(self):
         """
@@ -21,34 +21,34 @@ class TestDebugLoggerMiddlewareEndpointFiltering:
         Purpose: Ensure health checks are not logged.
         """
         print("Setup: Creating mock request for /health...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             # Mock request
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/health"
-            
+
             # Mock call_next
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
+
             # Mock debug_logger at the source module
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch for /health...")
                 response = await middleware.dispatch(mock_request, mock_call_next)
-                
+
                 print("Verifying prepare_new_request was NOT called...")
                 mock_logger.prepare_new_request.assert_not_called()
-                
+
                 print("Verifying call_next was called...")
                 mock_call_next.assert_called_once_with(mock_request)
-                
+
                 print(f"Comparing response: Expected {mock_response}, Got {response}")
                 assert response == mock_response
-    
+
     @pytest.mark.asyncio
     async def test_skips_docs_endpoint(self):
         """
@@ -56,25 +56,25 @@ class TestDebugLoggerMiddlewareEndpointFiltering:
         Purpose: Ensure documentation is not logged.
         """
         print("Setup: Creating mock request for /docs...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/docs"
-            
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch for /docs...")
-                response = await middleware.dispatch(mock_request, mock_call_next)
-                
+                await middleware.dispatch(mock_request, mock_call_next)
+
                 print("Verifying prepare_new_request was NOT called...")
                 mock_logger.prepare_new_request.assert_not_called()
-    
+
     @pytest.mark.asyncio
     async def test_skips_root_endpoint(self):
         """
@@ -82,25 +82,25 @@ class TestDebugLoggerMiddlewareEndpointFiltering:
         Purpose: Ensure root endpoint is not logged.
         """
         print("Setup: Creating mock request for /...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/"
-            
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch for /...")
                 await middleware.dispatch(mock_request, mock_call_next)
-                
+
                 print("Verifying prepare_new_request was NOT called...")
                 mock_logger.prepare_new_request.assert_not_called()
-    
+
     @pytest.mark.asyncio
     async def test_processes_chat_completions_endpoint(self):
         """
@@ -108,29 +108,31 @@ class TestDebugLoggerMiddlewareEndpointFiltering:
         Purpose: Ensure OpenAI endpoint is logged.
         """
         print("Setup: Creating mock request for /v1/chat/completions...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/v1/chat/completions"
             mock_request.body = AsyncMock(return_value=b'{"model": "test"}')
-            
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch for /v1/chat/completions...")
                 await middleware.dispatch(mock_request, mock_call_next)
-                
+
                 print("Verifying prepare_new_request was called...")
                 mock_logger.prepare_new_request.assert_called_once()
-                
+
                 print("Verifying log_request_body was called...")
-                mock_logger.log_request_body.assert_called_once_with(b'{"model": "test"}')
-    
+                mock_logger.log_request_body.assert_called_once_with(
+                    b'{"model": "test"}'
+                )
+
     @pytest.mark.asyncio
     async def test_processes_messages_endpoint(self):
         """
@@ -138,30 +140,30 @@ class TestDebugLoggerMiddlewareEndpointFiltering:
         Purpose: Ensure Anthropic endpoint is logged.
         """
         print("Setup: Creating mock request for /v1/messages...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/v1/messages"
             mock_request.body = AsyncMock(return_value=b'{"model": "claude"}')
-            
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch for /v1/messages...")
                 await middleware.dispatch(mock_request, mock_call_next)
-                
+
                 print("Verifying prepare_new_request was called...")
                 mock_logger.prepare_new_request.assert_called_once()
 
 
 class TestDebugLoggerMiddlewareModeHandling:
     """Tests for DEBUG_MODE handling in middleware."""
-    
+
     @pytest.mark.asyncio
     async def test_skips_when_debug_mode_off(self):
         """
@@ -169,28 +171,28 @@ class TestDebugLoggerMiddlewareModeHandling:
         Purpose: Ensure logging is disabled in off mode.
         """
         print("Setup: DEBUG_MODE=off...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'off'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "off"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/v1/chat/completions"
-            
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch with DEBUG_MODE=off...")
-                response = await middleware.dispatch(mock_request, mock_call_next)
-                
+                await middleware.dispatch(mock_request, mock_call_next)
+
                 print("Verifying prepare_new_request was NOT called...")
                 mock_logger.prepare_new_request.assert_not_called()
-                
+
                 print("Verifying call_next was called...")
                 mock_call_next.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_processes_when_debug_mode_errors(self):
         """
@@ -198,26 +200,26 @@ class TestDebugLoggerMiddlewareModeHandling:
         Purpose: Ensure errors mode activates logging.
         """
         print("Setup: DEBUG_MODE=errors...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'errors'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "errors"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/v1/chat/completions"
             mock_request.body = AsyncMock(return_value=b'{"test": "data"}')
-            
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch with DEBUG_MODE=errors...")
                 await middleware.dispatch(mock_request, mock_call_next)
-                
+
                 print("Verifying prepare_new_request was called...")
                 mock_logger.prepare_new_request.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_processes_when_debug_mode_all(self):
         """
@@ -225,30 +227,30 @@ class TestDebugLoggerMiddlewareModeHandling:
         Purpose: Ensure all mode activates logging.
         """
         print("Setup: DEBUG_MODE=all...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/v1/messages"
             mock_request.body = AsyncMock(return_value=b'{"test": "data"}')
-            
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch with DEBUG_MODE=all...")
                 await middleware.dispatch(mock_request, mock_call_next)
-                
+
                 print("Verifying prepare_new_request was called...")
                 mock_logger.prepare_new_request.assert_called_once()
 
 
 class TestDebugLoggerMiddlewareErrorHandling:
     """Tests for error handling in middleware."""
-    
+
     @pytest.mark.asyncio
     async def test_handles_body_read_error_gracefully(self):
         """
@@ -256,32 +258,32 @@ class TestDebugLoggerMiddlewareErrorHandling:
         Purpose: Ensure body read errors don't break the request.
         """
         print("Setup: Simulating body read error...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/v1/chat/completions"
             mock_request.body = AsyncMock(side_effect=Exception("Body read error"))
-            
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch with body read error...")
-                response = await middleware.dispatch(mock_request, mock_call_next)
-                
+                await middleware.dispatch(mock_request, mock_call_next)
+
                 print("Verifying prepare_new_request was called...")
                 mock_logger.prepare_new_request.assert_called_once()
-                
+
                 print("Verifying log_request_body was NOT called (due to error)...")
                 mock_logger.log_request_body.assert_not_called()
-                
+
                 print("Verifying call_next was called (request continued)...")
                 mock_call_next.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_skips_empty_body(self):
         """
@@ -289,33 +291,33 @@ class TestDebugLoggerMiddlewareErrorHandling:
         Purpose: Ensure empty requests don't create unnecessary logs.
         """
         print("Setup: Creating request with empty body...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/v1/chat/completions"
-            mock_request.body = AsyncMock(return_value=b'')  # Empty body
-            
+            mock_request.body = AsyncMock(return_value=b"")  # Empty body
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch with empty body...")
                 await middleware.dispatch(mock_request, mock_call_next)
-                
+
                 print("Verifying prepare_new_request was called...")
                 mock_logger.prepare_new_request.assert_called_once()
-                
+
                 print("Verifying log_request_body was NOT called (body is empty)...")
                 mock_logger.log_request_body.assert_not_called()
 
 
 class TestDebugLoggerMiddlewareResponsePassthrough:
     """Tests for transparent response passthrough."""
-    
+
     @pytest.mark.asyncio
     async def test_returns_response_from_call_next(self):
         """
@@ -323,32 +325,36 @@ class TestDebugLoggerMiddlewareResponsePassthrough:
         Purpose: Ensure middleware doesn't modify the response.
         """
         print("Setup: Creating mock response...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/v1/chat/completions"
             mock_request.body = AsyncMock(return_value=b'{"test": "data"}')
-            
+
             expected_response = MagicMock(spec=Response)
             expected_response.status_code = 200
             mock_call_next = AsyncMock(return_value=expected_response)
-            
-            with patch('kiro.debug_logger.debug_logger'):
+
+            with patch("kiro.debug_logger.debug_logger"):
                 print("Action: Calling dispatch...")
-                actual_response = await middleware.dispatch(mock_request, mock_call_next)
-                
-                print(f"Comparing response: Expected {expected_response}, Got {actual_response}")
+                actual_response = await middleware.dispatch(
+                    mock_request, mock_call_next
+                )
+
+                print(
+                    f"Comparing response: Expected {expected_response}, Got {actual_response}"
+                )
                 assert actual_response == expected_response
                 assert actual_response.status_code == 200
 
 
 class TestLoggedEndpointsConstant:
     """Tests for LOGGED_ENDPOINTS constant."""
-    
+
     def test_logged_endpoints_contains_chat_completions(self):
         """
         What it does: Verifies that LOGGED_ENDPOINTS contains /v1/chat/completions.
@@ -356,10 +362,10 @@ class TestLoggedEndpointsConstant:
         """
         print("Checking LOGGED_ENDPOINTS...")
         from kiro.debug_middleware import LOGGED_ENDPOINTS
-        
+
         print(f"LOGGED_ENDPOINTS contents: {LOGGED_ENDPOINTS}")
         assert "/v1/chat/completions" in LOGGED_ENDPOINTS
-    
+
     def test_logged_endpoints_contains_messages(self):
         """
         What it does: Verifies that LOGGED_ENDPOINTS contains /v1/messages.
@@ -367,10 +373,10 @@ class TestLoggedEndpointsConstant:
         """
         print("Checking LOGGED_ENDPOINTS...")
         from kiro.debug_middleware import LOGGED_ENDPOINTS
-        
+
         print(f"LOGGED_ENDPOINTS contents: {LOGGED_ENDPOINTS}")
         assert "/v1/messages" in LOGGED_ENDPOINTS
-    
+
     def test_logged_endpoints_is_frozenset(self):
         """
         What it does: Verifies that LOGGED_ENDPOINTS is a frozenset.
@@ -378,6 +384,6 @@ class TestLoggedEndpointsConstant:
         """
         print("Checking LOGGED_ENDPOINTS type...")
         from kiro.debug_middleware import LOGGED_ENDPOINTS
-        
+
         print(f"LOGGED_ENDPOINTS type: {type(LOGGED_ENDPOINTS)}")
         assert isinstance(LOGGED_ENDPOINTS, frozenset)

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -13,7 +13,7 @@ from fastapi.exceptions import RequestValidationError
 
 class TestSanitizeValidationErrors:
     """Tests for sanitize_validation_errors function."""
-    
+
     def test_sanitizes_bytes_in_input_field(self):
         """
         What it does: Verifies that bytes in 'input' field are converted to strings.
@@ -21,23 +21,23 @@ class TestSanitizeValidationErrors:
         """
         print("Setup: Creating error with bytes in input field...")
         from kiro.exceptions import sanitize_validation_errors
-        
+
         errors = [
             {
                 "type": "json_invalid",
                 "loc": ["body", 0],
                 "msg": "Invalid JSON",
-                "input": b'{"invalid": json}'
+                "input": b'{"invalid": json}',
             }
         ]
-        
+
         print("Action: Calling sanitize_validation_errors...")
         result = sanitize_validation_errors(errors)
-        
+
         print(f"Comparing input type: Expected str, Got {type(result[0]['input'])}")
         assert isinstance(result[0]["input"], str)
         assert result[0]["input"] == '{"invalid": json}'
-    
+
     def test_sanitizes_bytes_in_list_values(self):
         """
         What it does: Verifies that bytes in list values are converted to strings.
@@ -45,22 +45,22 @@ class TestSanitizeValidationErrors:
         """
         print("Setup: Creating error with bytes in list...")
         from kiro.exceptions import sanitize_validation_errors
-        
+
         errors = [
             {
                 "type": "value_error",
                 "loc": ["body", "messages"],
                 "msg": "Invalid value",
-                "input": [b'bytes1', "string", b'bytes2']
+                "input": [b"bytes1", "string", b"bytes2"],
             }
         ]
-        
+
         print("Action: Calling sanitize_validation_errors...")
         result = sanitize_validation_errors(errors)
-        
-        print(f"Checking list values are converted...")
+
+        print("Checking list values are converted...")
         assert result[0]["input"] == ["bytes1", "string", "bytes2"]
-    
+
     def test_preserves_non_bytes_values(self):
         """
         What it does: Verifies that non-bytes values are preserved.
@@ -68,27 +68,27 @@ class TestSanitizeValidationErrors:
         """
         print("Setup: Creating error with normal values...")
         from kiro.exceptions import sanitize_validation_errors
-        
+
         errors = [
             {
                 "type": "missing",
                 "loc": ["body", "model"],
                 "msg": "Field required",
-                "input": {"messages": []}
+                "input": {"messages": []},
             }
         ]
-        
+
         print("Action: Calling sanitize_validation_errors...")
         result = sanitize_validation_errors(errors)
-        
-        print(f"Checking values are preserved...")
+
+        print("Checking values are preserved...")
         assert result[0]["input"] == {"messages": []}
         assert result[0]["type"] == "missing"
 
 
 class TestValidationExceptionHandler:
     """Tests for validation_exception_handler function."""
-    
+
     @pytest.mark.asyncio
     async def test_returns_422_status_code(self):
         """
@@ -97,23 +97,28 @@ class TestValidationExceptionHandler:
         """
         print("Setup: Creating mock request and exception...")
         from kiro.exceptions import validation_exception_handler
-        
+
         mock_request = MagicMock(spec=Request)
         mock_request.body = AsyncMock(return_value=b'{"invalid": json}')
-        
+
         mock_exc = MagicMock(spec=RequestValidationError)
         mock_exc.errors.return_value = [
-            {"type": "json_invalid", "loc": ["body"], "msg": "Invalid JSON", "input": {}}
+            {
+                "type": "json_invalid",
+                "loc": ["body"],
+                "msg": "Invalid JSON",
+                "input": {},
+            }
         ]
-        
+
         # Patch debug_logger at the source module
-        with patch('kiro.debug_logger.debug_logger') as mock_logger:
+        with patch("kiro.debug_logger.debug_logger"):
             print("Action: Calling validation_exception_handler...")
             response = await validation_exception_handler(mock_request, mock_exc)
-            
+
             print(f"Comparing status_code: Expected 422, Got {response.status_code}")
             assert response.status_code == 422
-    
+
     @pytest.mark.asyncio
     async def test_calls_flush_on_error_with_422(self):
         """
@@ -122,25 +127,30 @@ class TestValidationExceptionHandler:
         """
         print("Setup: Creating mock request and exception...")
         from kiro.exceptions import validation_exception_handler
-        
+
         mock_request = MagicMock(spec=Request)
         mock_request.body = AsyncMock(return_value=b'{"test": "data"}')
-        
+
         mock_exc = MagicMock(spec=RequestValidationError)
         mock_exc.errors.return_value = [
-            {"type": "missing", "loc": ["body", "model"], "msg": "Field required", "input": {}}
+            {
+                "type": "missing",
+                "loc": ["body", "model"],
+                "msg": "Field required",
+                "input": {},
+            }
         ]
-        
+
         # Patch debug_logger at the source module
-        with patch('kiro.debug_logger.debug_logger') as mock_logger:
+        with patch("kiro.debug_logger.debug_logger") as mock_logger:
             print("Action: Calling validation_exception_handler...")
             await validation_exception_handler(mock_request, mock_exc)
-            
+
             print("Verifying flush_on_error was called with 422...")
             mock_logger.flush_on_error.assert_called_once()
             call_args = mock_logger.flush_on_error.call_args
             assert call_args[0][0] == 422  # First positional argument is status_code
-    
+
     @pytest.mark.asyncio
     async def test_includes_sanitized_errors_in_response(self):
         """
@@ -150,27 +160,32 @@ class TestValidationExceptionHandler:
         print("Setup: Creating mock request and exception...")
         from kiro.exceptions import validation_exception_handler
         import json
-        
+
         mock_request = MagicMock(spec=Request)
         mock_request.body = AsyncMock(return_value=b'{"test": "data"}')
-        
+
         mock_exc = MagicMock(spec=RequestValidationError)
         mock_exc.errors.return_value = [
-            {"type": "missing", "loc": ["body", "model"], "msg": "Field required", "input": {}}
+            {
+                "type": "missing",
+                "loc": ["body", "model"],
+                "msg": "Field required",
+                "input": {},
+            }
         ]
-        
-        with patch('kiro.debug_logger.debug_logger'):
+
+        with patch("kiro.debug_logger.debug_logger"):
             print("Action: Calling validation_exception_handler...")
             response = await validation_exception_handler(mock_request, mock_exc)
-            
+
             print("Parsing response body...")
             body = json.loads(response.body.decode())
-            
-            print(f"Verifying 'detail' is in response...")
+
+            print("Verifying 'detail' is in response...")
             assert "detail" in body
             assert len(body["detail"]) == 1
             assert body["detail"][0]["type"] == "missing"
-    
+
     @pytest.mark.asyncio
     async def test_truncates_body_in_response(self):
         """
@@ -180,31 +195,31 @@ class TestValidationExceptionHandler:
         print("Setup: Creating mock request with large body...")
         from kiro.exceptions import validation_exception_handler
         import json
-        
-        large_body = b'{"data": "' + b'x' * 1000 + b'"}'
-        
+
+        large_body = b'{"data": "' + b"x" * 1000 + b'"}'
+
         mock_request = MagicMock(spec=Request)
         mock_request.body = AsyncMock(return_value=large_body)
-        
+
         mock_exc = MagicMock(spec=RequestValidationError)
         mock_exc.errors.return_value = [
             {"type": "json_invalid", "loc": ["body"], "msg": "Invalid", "input": {}}
         ]
-        
-        with patch('kiro.debug_logger.debug_logger'):
+
+        with patch("kiro.debug_logger.debug_logger"):
             print("Action: Calling validation_exception_handler...")
             response = await validation_exception_handler(mock_request, mock_exc)
-            
+
             print("Parsing response body...")
             body = json.loads(response.body.decode())
-            
-            print(f"Verifying body is truncated to 500 chars...")
+
+            print("Verifying body is truncated to 500 chars...")
             assert len(body["body"]) <= 500
 
 
 class TestValidationExceptionHandlerLogging:
     """Tests for logging behavior in validation_exception_handler."""
-    
+
     @pytest.mark.asyncio
     async def test_logs_error_at_error_level(self):
         """
@@ -213,27 +228,32 @@ class TestValidationExceptionHandlerLogging:
         """
         print("Setup: Creating mock request and exception...")
         from kiro.exceptions import validation_exception_handler
-        
+
         mock_request = MagicMock(spec=Request)
         mock_request.body = AsyncMock(return_value=b'{"test": "data"}')
-        
+
         mock_exc = MagicMock(spec=RequestValidationError)
         mock_exc.errors.return_value = [
-            {"type": "missing", "loc": ["body", "model"], "msg": "Field required", "input": {}}
+            {
+                "type": "missing",
+                "loc": ["body", "model"],
+                "msg": "Field required",
+                "input": {},
+            }
         ]
-        
-        with patch('kiro.debug_logger.debug_logger'):
-            with patch('kiro.exceptions.logger') as mock_logger:
+
+        with patch("kiro.debug_logger.debug_logger"):
+            with patch("kiro.exceptions.logger") as mock_logger:
                 print("Action: Calling validation_exception_handler...")
                 await validation_exception_handler(mock_request, mock_exc)
-                
+
                 print("Verifying logger.error was called...")
                 mock_logger.error.assert_called()
 
 
 class TestValidationExceptionHandlerEdgeCases:
     """Tests for edge cases in validation_exception_handler."""
-    
+
     @pytest.mark.asyncio
     async def test_handles_empty_errors_list(self):
         """
@@ -243,23 +263,23 @@ class TestValidationExceptionHandlerEdgeCases:
         print("Setup: Creating mock request with empty errors...")
         from kiro.exceptions import validation_exception_handler
         import json
-        
+
         mock_request = MagicMock(spec=Request)
-        mock_request.body = AsyncMock(return_value=b'{}')
-        
+        mock_request.body = AsyncMock(return_value=b"{}")
+
         mock_exc = MagicMock(spec=RequestValidationError)
         mock_exc.errors.return_value = []
-        
-        with patch('kiro.debug_logger.debug_logger'):
+
+        with patch("kiro.debug_logger.debug_logger"):
             print("Action: Calling validation_exception_handler...")
             response = await validation_exception_handler(mock_request, mock_exc)
-            
-            print(f"Verifying response is valid...")
+
+            print("Verifying response is valid...")
             assert response.status_code == 422
-            
+
             body = json.loads(response.body.decode())
             assert body["detail"] == []
-    
+
     @pytest.mark.asyncio
     async def test_handles_unicode_in_body(self):
         """
@@ -269,23 +289,28 @@ class TestValidationExceptionHandlerEdgeCases:
         print("Setup: Creating mock request with unicode body...")
         from kiro.exceptions import validation_exception_handler
         import json
-        
-        unicode_body = '{"message": "Привет мир 🌍"}'.encode('utf-8')
-        
+
+        unicode_body = '{"message": "Привет мир 🌍"}'.encode("utf-8")
+
         mock_request = MagicMock(spec=Request)
         mock_request.body = AsyncMock(return_value=unicode_body)
-        
+
         mock_exc = MagicMock(spec=RequestValidationError)
         mock_exc.errors.return_value = [
-            {"type": "missing", "loc": ["body", "model"], "msg": "Field required", "input": {}}
+            {
+                "type": "missing",
+                "loc": ["body", "model"],
+                "msg": "Field required",
+                "input": {},
+            }
         ]
-        
-        with patch('kiro.debug_logger.debug_logger'):
+
+        with patch("kiro.debug_logger.debug_logger"):
             print("Action: Calling validation_exception_handler...")
             response = await validation_exception_handler(mock_request, mock_exc)
-            
-            print(f"Verifying response is valid...")
+
+            print("Verifying response is valid...")
             assert response.status_code == 422
-            
+
             body = json.loads(response.body.decode())
             assert "Привет мир" in body["body"]

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -5,17 +5,20 @@ Unit tests for KiroHttpClient.
 Tests retry logic, error handling, and HTTP client management.
 """
 
-import asyncio
 import pytest
-from unittest.mock import AsyncMock, Mock, patch, MagicMock
-from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 from fastapi import HTTPException
 
 from kiro.http_client import KiroHttpClient
 from kiro.auth import KiroAuthManager
-from kiro.config import MAX_RETRIES, BASE_RETRY_DELAY, FIRST_TOKEN_MAX_RETRIES, STREAMING_READ_TIMEOUT
+from kiro.config import (
+    MAX_RETRIES,
+    BASE_RETRY_DELAY,
+    FIRST_TOKEN_MAX_RETRIES,
+    STREAMING_READ_TIMEOUT,
+)
 
 
 @pytest.fixture
@@ -31,7 +34,7 @@ def mock_auth_manager_for_http():
 
 class TestKiroHttpClientInitialization:
     """Tests for KiroHttpClient initialization."""
-    
+
     def test_initialization_stores_auth_manager(self, mock_auth_manager_for_http):
         """
         What it does: Verifies auth_manager is stored during initialization.
@@ -39,10 +42,10 @@ class TestKiroHttpClientInitialization:
         """
         print("Setup: Creating KiroHttpClient...")
         client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         print("Verification: auth_manager is stored...")
         assert client.auth_manager is mock_auth_manager_for_http
-    
+
     def test_initialization_client_is_none(self, mock_auth_manager_for_http):
         """
         What it does: Verifies that HTTP client is initially None.
@@ -50,14 +53,14 @@ class TestKiroHttpClientInitialization:
         """
         print("Setup: Creating KiroHttpClient...")
         client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         print("Verification: client is initially None...")
         assert client.client is None
 
 
 class TestKiroHttpClientGetClient:
     """Tests for _get_client method."""
-    
+
     @pytest.mark.asyncio
     async def test_get_client_creates_new_client(self, mock_auth_manager_for_http):
         """
@@ -66,19 +69,19 @@ class TestKiroHttpClientGetClient:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         print("Action: Getting client...")
-        with patch('kiro.http_client.httpx.AsyncClient') as mock_async_client:
+        with patch("kiro.http_client.httpx.AsyncClient") as mock_async_client:
             mock_instance = AsyncMock()
             mock_instance.is_closed = False
             mock_async_client.return_value = mock_instance
-            
+
             client = await http_client._get_client()
-            
+
             print("Verification: Client created...")
             mock_async_client.assert_called_once()
             assert client is mock_instance
-    
+
     @pytest.mark.asyncio
     async def test_get_client_reuses_existing_client(self, mock_auth_manager_for_http):
         """
@@ -87,17 +90,17 @@ class TestKiroHttpClientGetClient:
         """
         print("Setup: Creating KiroHttpClient with existing client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_existing = AsyncMock()
         mock_existing.is_closed = False
         http_client.client = mock_existing
-        
+
         print("Action: Getting client...")
         client = await http_client._get_client()
-        
+
         print("Verification: Existing client returned...")
         assert client is mock_existing
-    
+
     @pytest.mark.asyncio
     async def test_get_client_recreates_closed_client(self, mock_auth_manager_for_http):
         """
@@ -106,19 +109,19 @@ class TestKiroHttpClientGetClient:
         """
         print("Setup: Creating KiroHttpClient with closed client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_closed = AsyncMock()
         mock_closed.is_closed = True
         http_client.client = mock_closed
-        
+
         print("Action: Getting client...")
-        with patch('kiro.http_client.httpx.AsyncClient') as mock_async_client:
+        with patch("kiro.http_client.httpx.AsyncClient") as mock_async_client:
             mock_new = AsyncMock()
             mock_new.is_closed = False
             mock_async_client.return_value = mock_new
-            
+
             client = await http_client._get_client()
-            
+
             print("Verification: New client created...")
             mock_async_client.assert_called_once()
             assert client is mock_new
@@ -126,7 +129,7 @@ class TestKiroHttpClientGetClient:
 
 class TestKiroHttpClientClose:
     """Tests for close method."""
-    
+
     @pytest.mark.asyncio
     async def test_close_closes_client(self, mock_auth_manager_for_http):
         """
@@ -135,18 +138,18 @@ class TestKiroHttpClientClose:
         """
         print("Setup: Creating KiroHttpClient with client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.aclose = AsyncMock()
         http_client.client = mock_client
-        
+
         print("Action: Closing client...")
         await http_client.close()
-        
+
         print("Verification: aclose() called...")
         mock_client.aclose.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_close_does_nothing_for_none_client(self, mock_auth_manager_for_http):
         """
@@ -155,64 +158,66 @@ class TestKiroHttpClientClose:
         """
         print("Setup: Creating KiroHttpClient without client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         print("Action: Closing client...")
         await http_client.close()  # Should not raise an error
-        
+
         print("Verification: No errors...")
-    
+
     @pytest.mark.asyncio
-    async def test_close_does_nothing_for_closed_client(self, mock_auth_manager_for_http):
+    async def test_close_does_nothing_for_closed_client(
+        self, mock_auth_manager_for_http
+    ):
         """
         What it does: Verifies that close() doesn't fail for closed client.
         Purpose: Ensure safe repeated close() call.
         """
         print("Setup: Creating KiroHttpClient with closed client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = True
         http_client.client = mock_client
-        
+
         print("Action: Closing client...")
         await http_client.close()
-        
+
         print("Verification: aclose() NOT called...")
         mock_client.aclose.assert_not_called()
 
 
 class TestKiroHttpClientRequestWithRetry:
     """Tests for request_with_retry method."""
-    
+
     @pytest.mark.asyncio
-    async def test_successful_request_returns_response(self, mock_auth_manager_for_http):
+    async def test_successful_request_returns_response(
+        self, mock_auth_manager_for_http
+    ):
         """
         What it does: Verifies successful request.
         Purpose: Ensure 200 response is returned immediately.
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.request = AsyncMock(return_value=mock_response)
-        
+
         print("Action: Executing request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
                 response = await http_client.request_with_retry(
-                    "POST",
-                    "https://api.example.com/test",
-                    {"data": "value"}
+                    "POST", "https://api.example.com/test", {"data": "value"}
                 )
-        
+
         print("Verification: Response received...")
         assert response.status_code == 200
         mock_client.request.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_403_triggers_token_refresh(self, mock_auth_manager_for_http):
         """
@@ -221,30 +226,30 @@ class TestKiroHttpClientRequestWithRetry:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response_403 = AsyncMock()
         mock_response_403.status_code = 403
-        
+
         mock_response_200 = AsyncMock()
         mock_response_200.status_code = 200
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
-        mock_client.request = AsyncMock(side_effect=[mock_response_403, mock_response_200])
-        
+        mock_client.request = AsyncMock(
+            side_effect=[mock_response_403, mock_response_200]
+        )
+
         print("Action: Executing request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
                 response = await http_client.request_with_retry(
-                    "POST",
-                    "https://api.example.com/test",
-                    {"data": "value"}
+                    "POST", "https://api.example.com/test", {"data": "value"}
                 )
-        
+
         print("Verification: force_refresh() called...")
         mock_auth_manager_for_http.force_refresh.assert_called_once()
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_429_triggers_backoff(self, mock_auth_manager_for_http):
         """
@@ -253,31 +258,33 @@ class TestKiroHttpClientRequestWithRetry:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response_429 = AsyncMock()
         mock_response_429.status_code = 429
-        
+
         mock_response_200 = AsyncMock()
         mock_response_200.status_code = 200
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
-        mock_client.request = AsyncMock(side_effect=[mock_response_429, mock_response_200])
-        
+        mock_client.request = AsyncMock(
+            side_effect=[mock_response_429, mock_response_200]
+        )
+
         print("Action: Executing request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch(
+                    "kiro.http_client.asyncio.sleep", new_callable=AsyncMock
+                ) as mock_sleep:
                     response = await http_client.request_with_retry(
-                        "POST",
-                        "https://api.example.com/test",
-                        {"data": "value"}
+                        "POST", "https://api.example.com/test", {"data": "value"}
                     )
-        
+
         print("Verification: sleep() called for backoff...")
         mock_sleep.assert_called_once()
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_5xx_triggers_backoff(self, mock_auth_manager_for_http):
         """
@@ -286,31 +293,33 @@ class TestKiroHttpClientRequestWithRetry:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response_500 = AsyncMock()
         mock_response_500.status_code = 500
-        
+
         mock_response_200 = AsyncMock()
         mock_response_200.status_code = 200
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
-        mock_client.request = AsyncMock(side_effect=[mock_response_500, mock_response_200])
-        
+        mock_client.request = AsyncMock(
+            side_effect=[mock_response_500, mock_response_200]
+        )
+
         print("Action: Executing request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch(
+                    "kiro.http_client.asyncio.sleep", new_callable=AsyncMock
+                ) as mock_sleep:
                     response = await http_client.request_with_retry(
-                        "POST",
-                        "https://api.example.com/test",
-                        {"data": "value"}
+                        "POST", "https://api.example.com/test", {"data": "value"}
                     )
-        
+
         print("Verification: sleep() called for backoff...")
         mock_sleep.assert_called_once()
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_timeout_triggers_backoff(self, mock_auth_manager_for_http):
         """
@@ -319,31 +328,30 @@ class TestKiroHttpClientRequestWithRetry:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response_200 = AsyncMock()
         mock_response_200.status_code = 200
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
-        mock_client.request = AsyncMock(side_effect=[
-            httpx.TimeoutException("Timeout"),
-            mock_response_200
-        ])
-        
+        mock_client.request = AsyncMock(
+            side_effect=[httpx.TimeoutException("Timeout"), mock_response_200]
+        )
+
         print("Action: Executing request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch(
+                    "kiro.http_client.asyncio.sleep", new_callable=AsyncMock
+                ) as mock_sleep:
                     response = await http_client.request_with_retry(
-                        "POST",
-                        "https://api.example.com/test",
-                        {"data": "value"}
+                        "POST", "https://api.example.com/test", {"data": "value"}
                     )
-        
+
         print("Verification: sleep() called for backoff...")
         mock_sleep.assert_called_once()
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_request_error_triggers_backoff(self, mock_auth_manager_for_http):
         """
@@ -352,31 +360,30 @@ class TestKiroHttpClientRequestWithRetry:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response_200 = AsyncMock()
         mock_response_200.status_code = 200
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
-        mock_client.request = AsyncMock(side_effect=[
-            httpx.RequestError("Connection error"),
-            mock_response_200
-        ])
-        
+        mock_client.request = AsyncMock(
+            side_effect=[httpx.RequestError("Connection error"), mock_response_200]
+        )
+
         print("Action: Executing request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch(
+                    "kiro.http_client.asyncio.sleep", new_callable=AsyncMock
+                ) as mock_sleep:
                     response = await http_client.request_with_retry(
-                        "POST",
-                        "https://api.example.com/test",
-                        {"data": "value"}
+                        "POST", "https://api.example.com/test", {"data": "value"}
                     )
-        
+
         print("Verification: sleep() called for backoff...")
         mock_sleep.assert_called_once()
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_max_retries_exceeded_raises_502(self, mock_auth_manager_for_http):
         """
@@ -385,26 +392,24 @@ class TestKiroHttpClientRequestWithRetry:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.request = AsyncMock(side_effect=httpx.TimeoutException("Timeout"))
-        
+
         print("Action: Executing request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', new_callable=AsyncMock):
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.asyncio.sleep", new_callable=AsyncMock):
                     with pytest.raises(HTTPException) as exc_info:
                         await http_client.request_with_retry(
-                            "POST",
-                            "https://api.example.com/test",
-                            {"data": "value"}
+                            "POST", "https://api.example.com/test", {"data": "value"}
                         )
-        
-        print(f"Verification: HTTPException with code 502...")
+
+        print("Verification: HTTPException with code 502...")
         assert exc_info.value.status_code == 502
         assert str(MAX_RETRIES) in exc_info.value.detail
-    
+
     @pytest.mark.asyncio
     async def test_other_status_codes_returned_as_is(self, mock_auth_manager_for_http):
         """
@@ -413,27 +418,25 @@ class TestKiroHttpClientRequestWithRetry:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 400
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.request = AsyncMock(return_value=mock_response)
-        
+
         print("Action: Executing request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
                 response = await http_client.request_with_retry(
-                    "POST",
-                    "https://api.example.com/test",
-                    {"data": "value"}
+                    "POST", "https://api.example.com/test", {"data": "value"}
                 )
-        
+
         print("Verification: 400 response returned without retry...")
         assert response.status_code == 400
         mock_client.request.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_streaming_request_uses_send(self, mock_auth_manager_for_http):
         """
@@ -442,27 +445,27 @@ class TestKiroHttpClientRequestWithRetry:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         mock_request = Mock()
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.build_request = Mock(return_value=mock_request)
         mock_client.send = AsyncMock(return_value=mock_response)
-        
+
         print("Action: Executing streaming request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
                 response = await http_client.request_with_retry(
                     "POST",
                     "https://api.example.com/test",
                     {"data": "value"},
-                    stream=True
+                    stream=True,
                 )
-        
+
         print("Verification: build_request and send called...")
         mock_client.build_request.assert_called_once()
         mock_client.send.assert_called_once_with(mock_request, stream=True)
@@ -471,7 +474,7 @@ class TestKiroHttpClientRequestWithRetry:
 
 class TestKiroHttpClientContextManager:
     """Tests for async context manager."""
-    
+
     @pytest.mark.asyncio
     async def test_context_manager_returns_self(self, mock_auth_manager_for_http):
         """
@@ -480,13 +483,13 @@ class TestKiroHttpClientContextManager:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         print("Action: Entering context...")
         result = await http_client.__aenter__()
-        
+
         print("Verification: self returned...")
         assert result is http_client
-    
+
     @pytest.mark.asyncio
     async def test_context_manager_closes_on_exit(self, mock_auth_manager_for_http):
         """
@@ -495,191 +498,202 @@ class TestKiroHttpClientContextManager:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.aclose = AsyncMock()
         http_client.client = mock_client
-        
+
         print("Action: Exiting context...")
         await http_client.__aexit__(None, None, None)
-        
+
         print("Verification: aclose() called...")
         mock_client.aclose.assert_called_once()
 
 
 class TestKiroHttpClientExponentialBackoff:
     """Tests for exponential backoff logic."""
-    
+
     @pytest.mark.asyncio
-    async def test_backoff_delay_increases_exponentially(self, mock_auth_manager_for_http):
+    async def test_backoff_delay_increases_exponentially(
+        self, mock_auth_manager_for_http
+    ):
         """
         What it does: Verifies exponential delay increase.
         Purpose: Ensure delay = BASE_RETRY_DELAY * (2 ** attempt).
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response_429 = AsyncMock()
         mock_response_429.status_code = 429
-        
+
         mock_response_200 = AsyncMock()
         mock_response_200.status_code = 200
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         # 2 errors 429, then success (to verify 2 backoff delays)
-        mock_client.request = AsyncMock(side_effect=[
-            mock_response_429,
-            mock_response_429,
-            mock_response_200
-        ])
-        
+        mock_client.request = AsyncMock(
+            side_effect=[mock_response_429, mock_response_429, mock_response_200]
+        )
+
         sleep_delays = []
-        
+
         async def capture_sleep(delay):
             sleep_delays.append(delay)
-        
+
         print("Action: Executing request with multiple retries...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', side_effect=capture_sleep):
-                    response = await http_client.request_with_retry(
-                        "POST",
-                        "https://api.example.com/test",
-                        {"data": "value"}
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.asyncio.sleep", side_effect=capture_sleep):
+                    await http_client.request_with_retry(
+                        "POST", "https://api.example.com/test", {"data": "value"}
                     )
-        
-        print(f"Verification: Delays increase exponentially...")
+
+        print("Verification: Delays increase exponentially...")
         print(f"Delays: {sleep_delays}")
         assert len(sleep_delays) == 2
-        assert sleep_delays[0] == BASE_RETRY_DELAY * (2 ** 0)  # 1.0
-        assert sleep_delays[1] == BASE_RETRY_DELAY * (2 ** 1)  # 2.0
+        assert sleep_delays[0] == BASE_RETRY_DELAY * (2**0)  # 1.0
+        assert sleep_delays[1] == BASE_RETRY_DELAY * (2**1)  # 2.0
 
 
 class TestKiroHttpClientStreamingTimeout:
     """Tests for streaming request timeout logic."""
-    
+
     @pytest.mark.asyncio
-    async def test_streaming_uses_streaming_read_timeout(self, mock_auth_manager_for_http):
+    async def test_streaming_uses_streaming_read_timeout(
+        self, mock_auth_manager_for_http
+    ):
         """
         What it does: Verifies that streaming requests use STREAMING_READ_TIMEOUT.
         Purpose: Ensure stream=True uses httpx.Timeout with correct values.
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         mock_request = Mock()
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.build_request = Mock(return_value=mock_request)
         mock_client.send = AsyncMock(return_value=mock_response)
-        
+
         print("Action: Executing streaming request...")
-        with patch('kiro.http_client.httpx.AsyncClient') as mock_async_client:
+        with patch("kiro.http_client.httpx.AsyncClient") as mock_async_client:
             mock_async_client.return_value = mock_client
-            
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
+
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
                 response = await http_client.request_with_retry(
                     "POST",
                     "https://api.example.com/test",
                     {"data": "value"},
-                    stream=True
+                    stream=True,
                 )
-        
+
         print("Verification: AsyncClient created with httpx.Timeout for streaming...")
         call_args = mock_async_client.call_args
-        timeout_arg = call_args.kwargs.get('timeout')
+        timeout_arg = call_args.kwargs.get("timeout")
         assert timeout_arg is not None, f"timeout not found in call_args: {call_args}"
         print(f"Comparing connect: Expected 30.0, Got {timeout_arg.connect}")
-        assert timeout_arg.connect == 30.0, f"Expected connect=30.0, got {timeout_arg.connect}"
-        print(f"Comparing read: Expected {STREAMING_READ_TIMEOUT}, Got {timeout_arg.read}")
-        assert timeout_arg.read == STREAMING_READ_TIMEOUT, f"Expected read={STREAMING_READ_TIMEOUT}, got {timeout_arg.read}"
-        assert call_args.kwargs.get('follow_redirects') == True
+        assert timeout_arg.connect == 30.0, (
+            f"Expected connect=30.0, got {timeout_arg.connect}"
+        )
+        print(
+            f"Comparing read: Expected {STREAMING_READ_TIMEOUT}, Got {timeout_arg.read}"
+        )
+        assert timeout_arg.read == STREAMING_READ_TIMEOUT, (
+            f"Expected read={STREAMING_READ_TIMEOUT}, got {timeout_arg.read}"
+        )
+        assert call_args.kwargs.get("follow_redirects") is True
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
-    async def test_streaming_uses_first_token_max_retries(self, mock_auth_manager_for_http):
+    async def test_streaming_uses_first_token_max_retries(
+        self, mock_auth_manager_for_http
+    ):
         """
         What it does: Verifies that streaming requests use FIRST_TOKEN_MAX_RETRIES.
         Purpose: Ensure stream=True uses separate retry counter.
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_request = Mock()
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.build_request = Mock(return_value=mock_request)
         mock_client.send = AsyncMock(side_effect=httpx.TimeoutException("Timeout"))
-        
+
         print("Action: Executing streaming request with timeouts...")
-        with patch('kiro.http_client.httpx.AsyncClient', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
+        with patch("kiro.http_client.httpx.AsyncClient", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
                 with pytest.raises(HTTPException) as exc_info:
                     await http_client.request_with_retry(
                         "POST",
                         "https://api.example.com/test",
                         {"data": "value"},
-                        stream=True
+                        stream=True,
                     )
-        
-        print(f"Verification: HTTPException with code 504...")
+
+        print("Verification: HTTPException with code 504...")
         assert exc_info.value.status_code == 504
         assert str(FIRST_TOKEN_MAX_RETRIES) in exc_info.value.detail
-        
-        print(f"Verification: Attempt count = FIRST_TOKEN_MAX_RETRIES ({FIRST_TOKEN_MAX_RETRIES})...")
+
+        print(
+            f"Verification: Attempt count = FIRST_TOKEN_MAX_RETRIES ({FIRST_TOKEN_MAX_RETRIES})..."
+        )
         assert mock_client.send.call_count == FIRST_TOKEN_MAX_RETRIES
-    
+
     @pytest.mark.asyncio
-    async def test_streaming_timeout_retry_without_delay(self, mock_auth_manager_for_http):
+    async def test_streaming_timeout_retry_without_delay(
+        self, mock_auth_manager_for_http
+    ):
         """
         What it does: Verifies that streaming timeout retry happens without delay.
         Purpose: Ensure no exponential backoff on first token timeout.
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         mock_request = Mock()
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.build_request = Mock(return_value=mock_request)
         # First timeout, then success
-        mock_client.send = AsyncMock(side_effect=[
-            httpx.TimeoutException("Timeout"),
-            mock_response
-        ])
-        
+        mock_client.send = AsyncMock(
+            side_effect=[httpx.TimeoutException("Timeout"), mock_response]
+        )
+
         sleep_called = False
-        
+
         async def capture_sleep(delay):
             nonlocal sleep_called
             sleep_called = True
-        
+
         print("Action: Executing streaming request with one timeout...")
-        with patch('kiro.http_client.httpx.AsyncClient', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', side_effect=capture_sleep):
+        with patch("kiro.http_client.httpx.AsyncClient", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.asyncio.sleep", side_effect=capture_sleep):
                     response = await http_client.request_with_retry(
                         "POST",
                         "https://api.example.com/test",
                         {"data": "value"},
-                        stream=True
+                        stream=True,
                     )
-        
+
         print("Verification: sleep() NOT called for streaming timeout...")
         assert not sleep_called
         assert response.status_code == 200
-        
+
     @pytest.mark.asyncio
     async def test_non_streaming_uses_default_timeout(self, mock_auth_manager_for_http):
         """
@@ -688,36 +702,38 @@ class TestKiroHttpClientStreamingTimeout:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.request = AsyncMock(return_value=mock_response)
-        
+
         print("Action: Executing non-streaming request...")
-        with patch('kiro.http_client.httpx.AsyncClient') as mock_async_client:
+        with patch("kiro.http_client.httpx.AsyncClient") as mock_async_client:
             mock_async_client.return_value = mock_client
-            
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
+
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
                 response = await http_client.request_with_retry(
                     "POST",
                     "https://api.example.com/test",
                     {"data": "value"},
-                    stream=False
+                    stream=False,
                 )
-        
+
         print("Verification: AsyncClient created with httpx.Timeout(timeout=300)...")
         call_args = mock_async_client.call_args
-        timeout_arg = call_args.kwargs.get('timeout')
+        timeout_arg = call_args.kwargs.get("timeout")
         assert timeout_arg is not None, f"timeout not found in call_args: {call_args}"
         # httpx.Timeout(timeout=300) sets all timeouts to 300
-        print(f"Comparing timeout: Expected 300.0 for all, Got connect={timeout_arg.connect}")
+        print(
+            f"Comparing timeout: Expected 300.0 for all, Got connect={timeout_arg.connect}"
+        )
         assert timeout_arg.connect == 300.0
         assert timeout_arg.read == 300.0
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_connect_timeout_logged_correctly(self, mock_auth_manager_for_http):
         """
@@ -726,37 +742,38 @@ class TestKiroHttpClientStreamingTimeout:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         mock_request = Mock()
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.build_request = Mock(return_value=mock_request)
         # First ConnectTimeout, then success
-        mock_client.send = AsyncMock(side_effect=[
-            httpx.ConnectTimeout("Connection timeout"),
-            mock_response
-        ])
-        
+        mock_client.send = AsyncMock(
+            side_effect=[httpx.ConnectTimeout("Connection timeout"), mock_response]
+        )
+
         print("Action: Executing streaming request with ConnectTimeout...")
-        with patch('kiro.http_client.httpx.AsyncClient', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.logger') as mock_logger:
+        with patch("kiro.http_client.httpx.AsyncClient", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.logger") as mock_logger:
                     response = await http_client.request_with_retry(
                         "POST",
                         "https://api.example.com/test",
                         {"data": "value"},
-                        stream=True
+                        stream=True,
                     )
-        
+
         print("Verification: logger.warning called with [ConnectTimeout]...")
         warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
-        assert any("ConnectTimeout" in call for call in warning_calls), f"ConnectTimeout not found in: {warning_calls}"
+        assert any("ConnectTimeout" in call for call in warning_calls), (
+            f"ConnectTimeout not found in: {warning_calls}"
+        )
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_read_timeout_logged_correctly(self, mock_auth_manager_for_http):
         """
@@ -765,72 +782,79 @@ class TestKiroHttpClientStreamingTimeout:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         mock_request = Mock()
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.build_request = Mock(return_value=mock_request)
         # First ReadTimeout, then success
-        mock_client.send = AsyncMock(side_effect=[
-            httpx.ReadTimeout("Read timeout"),
-            mock_response
-        ])
-        
+        mock_client.send = AsyncMock(
+            side_effect=[httpx.ReadTimeout("Read timeout"), mock_response]
+        )
+
         print("Action: Executing streaming request with ReadTimeout...")
-        with patch('kiro.http_client.httpx.AsyncClient', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.logger') as mock_logger:
+        with patch("kiro.http_client.httpx.AsyncClient", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.logger") as mock_logger:
                     response = await http_client.request_with_retry(
                         "POST",
                         "https://api.example.com/test",
                         {"data": "value"},
-                        stream=True
+                        stream=True,
                     )
-        
-        print("Verification: logger.warning called with [ReadTimeout] and STREAMING_READ_TIMEOUT...")
+
+        print(
+            "Verification: logger.warning called with [ReadTimeout] and STREAMING_READ_TIMEOUT..."
+        )
         warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
-        assert any("ReadTimeout" in call for call in warning_calls), f"ReadTimeout not found in: {warning_calls}"
-        assert any(str(STREAMING_READ_TIMEOUT) in call for call in warning_calls), f"STREAMING_READ_TIMEOUT not found in: {warning_calls}"
+        assert any("ReadTimeout" in call for call in warning_calls), (
+            f"ReadTimeout not found in: {warning_calls}"
+        )
+        assert any(str(STREAMING_READ_TIMEOUT) in call for call in warning_calls), (
+            f"STREAMING_READ_TIMEOUT not found in: {warning_calls}"
+        )
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
-    async def test_streaming_timeout_returns_504_with_error_type(self, mock_auth_manager_for_http):
+    async def test_streaming_timeout_returns_504_with_error_type(
+        self, mock_auth_manager_for_http
+    ):
         """
         What it does: Verifies that streaming timeout returns 504 with error type.
         Purpose: Ensure 504 is returned with error info after exhausting retries.
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_request = Mock()
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.build_request = Mock(return_value=mock_request)
         mock_client.send = AsyncMock(side_effect=httpx.ReadTimeout("Timeout"))
-        
+
         print("Action: Executing streaming request with persistent timeouts...")
-        with patch('kiro.http_client.httpx.AsyncClient', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
+        with patch("kiro.http_client.httpx.AsyncClient", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
                 with pytest.raises(HTTPException) as exc_info:
                     await http_client.request_with_retry(
                         "POST",
                         "https://api.example.com/test",
                         {"data": "value"},
-                        stream=True
+                        stream=True,
                     )
-        
+
         print("Verification: HTTPException with code 504 and error type...")
         print(f"Comparing status_code: Expected 504, Got {exc_info.value.status_code}")
         assert exc_info.value.status_code == 504
         print(f"Comparing detail: Expected 'ReadTimeout' in '{exc_info.value.detail}'")
         assert "ReadTimeout" in exc_info.value.detail
         assert "Streaming failed" in exc_info.value.detail
-    
+
     @pytest.mark.asyncio
     async def test_non_streaming_timeout_returns_502(self, mock_auth_manager_for_http):
         """
@@ -839,30 +863,30 @@ class TestKiroHttpClientStreamingTimeout:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.request = AsyncMock(side_effect=httpx.TimeoutException("Timeout"))
-        
+
         print("Action: Executing non-streaming request with persistent timeouts...")
-        with patch('kiro.http_client.httpx.AsyncClient', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', new_callable=AsyncMock):
+        with patch("kiro.http_client.httpx.AsyncClient", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.asyncio.sleep", new_callable=AsyncMock):
                     with pytest.raises(HTTPException) as exc_info:
                         await http_client.request_with_retry(
                             "POST",
                             "https://api.example.com/test",
                             {"data": "value"},
-                            stream=False
+                            stream=False,
                         )
-        
+
         print("Verification: HTTPException with code 502...")
         assert exc_info.value.status_code == 502
 
 
 class TestKiroHttpClientSharedClient:
     """Tests for shared client functionality (connection pooling support)."""
-    
+
     def test_initialization_with_shared_client(self, mock_auth_manager_for_http):
         """
         What it does: Verifies shared_client is stored during initialization.
@@ -871,31 +895,41 @@ class TestKiroHttpClientSharedClient:
         print("Setup: Creating mock shared client...")
         mock_shared = AsyncMock()
         mock_shared.is_closed = False
-        
+
         print("Action: Creating KiroHttpClient with shared client...")
-        http_client = KiroHttpClient(mock_auth_manager_for_http, shared_client=mock_shared)
-        
+        http_client = KiroHttpClient(
+            mock_auth_manager_for_http, shared_client=mock_shared
+        )
+
         print("Verification: shared_client is stored...")
-        print(f"Comparing _shared_client: Expected mock_shared, Got {http_client._shared_client}")
+        print(
+            f"Comparing _shared_client: Expected mock_shared, Got {http_client._shared_client}"
+        )
         assert http_client._shared_client is mock_shared
         print(f"Comparing client: Expected mock_shared, Got {http_client.client}")
         assert http_client.client is mock_shared
-    
-    def test_initialization_without_shared_client_owns_client(self, mock_auth_manager_for_http):
+
+    def test_initialization_without_shared_client_owns_client(
+        self, mock_auth_manager_for_http
+    ):
         """
         What it does: Verifies _owns_client is True when no shared client provided.
         Purpose: Ensure client ownership is tracked correctly for cleanup.
         """
         print("Setup: Creating KiroHttpClient without shared client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         print("Verification: _owns_client is True...")
         print(f"Comparing _owns_client: Expected True, Got {http_client._owns_client}")
         assert http_client._owns_client is True
-        print(f"Comparing _shared_client: Expected None, Got {http_client._shared_client}")
+        print(
+            f"Comparing _shared_client: Expected None, Got {http_client._shared_client}"
+        )
         assert http_client._shared_client is None
-    
-    def test_initialization_with_shared_client_does_not_own(self, mock_auth_manager_for_http):
+
+    def test_initialization_with_shared_client_does_not_own(
+        self, mock_auth_manager_for_http
+    ):
         """
         What it does: Verifies _owns_client is False when shared client provided.
         Purpose: Ensure shared client is not closed by this instance.
@@ -903,14 +937,16 @@ class TestKiroHttpClientSharedClient:
         print("Setup: Creating mock shared client...")
         mock_shared = AsyncMock()
         mock_shared.is_closed = False
-        
+
         print("Action: Creating KiroHttpClient with shared client...")
-        http_client = KiroHttpClient(mock_auth_manager_for_http, shared_client=mock_shared)
-        
+        http_client = KiroHttpClient(
+            mock_auth_manager_for_http, shared_client=mock_shared
+        )
+
         print("Verification: _owns_client is False...")
         print(f"Comparing _owns_client: Expected False, Got {http_client._owns_client}")
         assert http_client._owns_client is False
-    
+
     @pytest.mark.asyncio
     async def test_get_client_returns_shared_client(self, mock_auth_manager_for_http):
         """
@@ -920,19 +956,21 @@ class TestKiroHttpClientSharedClient:
         print("Setup: Creating mock shared client...")
         mock_shared = AsyncMock()
         mock_shared.is_closed = False
-        
+
         print("Action: Creating KiroHttpClient with shared client...")
-        http_client = KiroHttpClient(mock_auth_manager_for_http, shared_client=mock_shared)
-        
+        http_client = KiroHttpClient(
+            mock_auth_manager_for_http, shared_client=mock_shared
+        )
+
         print("Action: Getting client...")
-        with patch('kiro.http_client.httpx.AsyncClient') as mock_async_client:
+        with patch("kiro.http_client.httpx.AsyncClient") as mock_async_client:
             client = await http_client._get_client(stream=True)
-            
+
             print("Verification: Shared client returned, no new client created...")
             print(f"Comparing client: Expected mock_shared, Got {client}")
             assert client is mock_shared
             mock_async_client.assert_not_called()
-    
+
     @pytest.mark.asyncio
     async def test_close_does_not_close_shared_client(self, mock_auth_manager_for_http):
         """
@@ -943,16 +981,18 @@ class TestKiroHttpClientSharedClient:
         mock_shared = AsyncMock()
         mock_shared.is_closed = False
         mock_shared.aclose = AsyncMock()
-        
+
         print("Action: Creating KiroHttpClient with shared client...")
-        http_client = KiroHttpClient(mock_auth_manager_for_http, shared_client=mock_shared)
-        
+        http_client = KiroHttpClient(
+            mock_auth_manager_for_http, shared_client=mock_shared
+        )
+
         print("Action: Closing client...")
         await http_client.close()
-        
+
         print("Verification: aclose() NOT called on shared client...")
         mock_shared.aclose.assert_not_called()
-    
+
     @pytest.mark.asyncio
     async def test_close_closes_owned_client(self, mock_auth_manager_for_http):
         """
@@ -961,44 +1001,46 @@ class TestKiroHttpClientSharedClient:
         """
         print("Setup: Creating KiroHttpClient without shared client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_owned = AsyncMock()
         mock_owned.is_closed = False
         mock_owned.aclose = AsyncMock()
         http_client.client = mock_owned
-        
+
         print("Action: Closing client...")
         await http_client.close()
-        
+
         print("Verification: aclose() called on owned client...")
         mock_owned.aclose.assert_called_once()
 
 
 class TestKiroHttpClientGracefulClose:
     """Tests for graceful exception handling in close() method."""
-    
+
     @pytest.mark.asyncio
-    async def test_close_handles_aclose_exception_gracefully(self, mock_auth_manager_for_http):
+    async def test_close_handles_aclose_exception_gracefully(
+        self, mock_auth_manager_for_http
+    ):
         """
         What it does: Verifies exception in aclose() is caught and doesn't propagate.
         Purpose: Ensure cleanup errors don't mask original exceptions.
         """
         print("Setup: Creating KiroHttpClient with client that raises on close...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.aclose = AsyncMock(side_effect=Exception("Connection reset"))
         http_client.client = mock_client
-        
+
         print("Action: Closing client (should not raise)...")
         # Should not raise - exception should be caught
         await http_client.close()
-        
+
         print("Verification: No exception propagated...")
         # If we get here, the test passed
         assert True
-    
+
     @pytest.mark.asyncio
     async def test_close_logs_warning_on_exception(self, mock_auth_manager_for_http):
         """
@@ -1007,18 +1049,21 @@ class TestKiroHttpClientGracefulClose:
         """
         print("Setup: Creating KiroHttpClient with client that raises on close...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.aclose = AsyncMock(side_effect=Exception("Connection reset"))
         http_client.client = mock_client
-        
+
         print("Action: Closing client with logger mock...")
-        with patch('kiro.http_client.logger') as mock_logger:
+        with patch("kiro.http_client.logger") as mock_logger:
             await http_client.close()
-            
+
             print("Verification: logger.warning called...")
             mock_logger.warning.assert_called_once()
             warning_message = str(mock_logger.warning.call_args)
             print(f"Warning message: {warning_message}")
-            assert "Connection reset" in warning_message or "Error closing" in warning_message
+            assert (
+                "Connection reset" in warning_message
+                or "Error closing" in warning_message
+            )

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -8,13 +8,12 @@ Tests for parse_cli_args(), resolve_server_config(), and print_startup_banner().
 import pytest
 import argparse
 import sys
-from unittest.mock import patch, MagicMock
-from io import StringIO
+from unittest.mock import patch
 
 
 class TestParseCliArgs:
     """Tests for parse_cli_args() function."""
-    
+
     def test_default_values_are_none(self):
         """
         What it does: Verifies that default values for host and port are None.
@@ -22,17 +21,17 @@ class TestParseCliArgs:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with no arguments...")
-        with patch.object(sys, 'argv', ['main.py']):
+        with patch.object(sys, "argv", ["main.py"]):
             args = parse_cli_args()
-        
+
         print(f"args.host: {args.host}")
         print(f"args.port: {args.port}")
-        print(f"Comparing: Expected host=None, port=None")
+        print("Comparing: Expected host=None, port=None")
         assert args.host is None
         assert args.port is None
-    
+
     def test_port_argument_long_form(self):
         """
         What it does: Verifies that --port argument is parsed correctly.
@@ -40,15 +39,15 @@ class TestParseCliArgs:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with --port 9000...")
-        with patch.object(sys, 'argv', ['main.py', '--port', '9000']):
+        with patch.object(sys, "argv", ["main.py", "--port", "9000"]):
             args = parse_cli_args()
-        
+
         print(f"args.port: {args.port}")
         print(f"Comparing: Expected 9000, Got {args.port}")
         assert args.port == 9000
-    
+
     def test_port_argument_short_form(self):
         """
         What it does: Verifies that -p argument is parsed correctly.
@@ -56,15 +55,15 @@ class TestParseCliArgs:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with -p 8080...")
-        with patch.object(sys, 'argv', ['main.py', '-p', '8080']):
+        with patch.object(sys, "argv", ["main.py", "-p", "8080"]):
             args = parse_cli_args()
-        
+
         print(f"args.port: {args.port}")
         print(f"Comparing: Expected 8080, Got {args.port}")
         assert args.port == 8080
-    
+
     def test_host_argument_long_form(self):
         """
         What it does: Verifies that --host argument is parsed correctly.
@@ -72,15 +71,15 @@ class TestParseCliArgs:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with --host 127.0.0.1...")
-        with patch.object(sys, 'argv', ['main.py', '--host', '127.0.0.1']):
+        with patch.object(sys, "argv", ["main.py", "--host", "127.0.0.1"]):
             args = parse_cli_args()
-        
+
         print(f"args.host: {args.host}")
         print(f"Comparing: Expected '127.0.0.1', Got '{args.host}'")
         assert args.host == "127.0.0.1"
-    
+
     def test_host_argument_short_form(self):
         """
         What it does: Verifies that -H argument is parsed correctly.
@@ -88,15 +87,15 @@ class TestParseCliArgs:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with -H 192.168.1.1...")
-        with patch.object(sys, 'argv', ['main.py', '-H', '192.168.1.1']):
+        with patch.object(sys, "argv", ["main.py", "-H", "192.168.1.1"]):
             args = parse_cli_args()
-        
+
         print(f"args.host: {args.host}")
         print(f"Comparing: Expected '192.168.1.1', Got '{args.host}'")
         assert args.host == "192.168.1.1"
-    
+
     def test_both_arguments_together(self):
         """
         What it does: Verifies that both --host and --port can be used together.
@@ -104,16 +103,18 @@ class TestParseCliArgs:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with --host 0.0.0.0 --port 3000...")
-        with patch.object(sys, 'argv', ['main.py', '--host', '0.0.0.0', '--port', '3000']):
+        with patch.object(
+            sys, "argv", ["main.py", "--host", "0.0.0.0", "--port", "3000"]
+        ):
             args = parse_cli_args()
-        
+
         print(f"args.host: {args.host}")
         print(f"args.port: {args.port}")
         assert args.host == "0.0.0.0"
         assert args.port == 3000
-    
+
     def test_short_forms_together(self):
         """
         What it does: Verifies that both -H and -p can be used together.
@@ -121,11 +122,11 @@ class TestParseCliArgs:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with -H 127.0.0.1 -p 5000...")
-        with patch.object(sys, 'argv', ['main.py', '-H', '127.0.0.1', '-p', '5000']):
+        with patch.object(sys, "argv", ["main.py", "-H", "127.0.0.1", "-p", "5000"]):
             args = parse_cli_args()
-        
+
         print(f"args.host: {args.host}")
         print(f"args.port: {args.port}")
         assert args.host == "127.0.0.1"
@@ -134,7 +135,7 @@ class TestParseCliArgs:
 
 class TestResolveServerConfig:
     """Tests for resolve_server_config() function - priority hierarchy."""
-    
+
     def test_cli_args_take_priority_over_env(self):
         """
         What it does: Verifies that CLI arguments have highest priority.
@@ -142,24 +143,26 @@ class TestResolveServerConfig:
         """
         print("Setup: Importing resolve_server_config...")
         from main import resolve_server_config
-        
+
         print("Setup: Creating args with host=127.0.0.1, port=9000...")
         args = argparse.Namespace(host="127.0.0.1", port=9000)
-        
+
         print("Action: Calling resolve_server_config with CLI args...")
         # Even if env vars are set, CLI should win
-        with patch('main.SERVER_HOST', '0.0.0.0'), \
-             patch('main.SERVER_PORT', 8000), \
-             patch('main.DEFAULT_SERVER_HOST', '0.0.0.0'), \
-             patch('main.DEFAULT_SERVER_PORT', 8000):
+        with (
+            patch("main.SERVER_HOST", "0.0.0.0"),
+            patch("main.SERVER_PORT", 8000),
+            patch("main.DEFAULT_SERVER_HOST", "0.0.0.0"),
+            patch("main.DEFAULT_SERVER_PORT", 8000),
+        ):
             host, port = resolve_server_config(args)
-        
+
         print(f"Resolved host: {host}")
         print(f"Resolved port: {port}")
-        print(f"Comparing: Expected ('127.0.0.1', 9000)")
+        print("Comparing: Expected ('127.0.0.1', 9000)")
         assert host == "127.0.0.1"
         assert port == 9000
-    
+
     def test_env_vars_take_priority_over_defaults(self):
         """
         What it does: Verifies that env vars have priority over defaults.
@@ -167,24 +170,26 @@ class TestResolveServerConfig:
         """
         print("Setup: Importing resolve_server_config...")
         from main import resolve_server_config
-        
+
         print("Setup: Creating args with host=None, port=None (no CLI args)...")
         args = argparse.Namespace(host=None, port=None)
-        
+
         print("Action: Calling resolve_server_config with env vars set...")
         # SERVER_HOST and SERVER_PORT are different from defaults
-        with patch('main.SERVER_HOST', '192.168.1.100'), \
-             patch('main.SERVER_PORT', 3000), \
-             patch('main.DEFAULT_SERVER_HOST', '0.0.0.0'), \
-             patch('main.DEFAULT_SERVER_PORT', 8000):
+        with (
+            patch("main.SERVER_HOST", "192.168.1.100"),
+            patch("main.SERVER_PORT", 3000),
+            patch("main.DEFAULT_SERVER_HOST", "0.0.0.0"),
+            patch("main.DEFAULT_SERVER_PORT", 8000),
+        ):
             host, port = resolve_server_config(args)
-        
+
         print(f"Resolved host: {host}")
         print(f"Resolved port: {port}")
-        print(f"Comparing: Expected ('192.168.1.100', 3000)")
+        print("Comparing: Expected ('192.168.1.100', 3000)")
         assert host == "192.168.1.100"
         assert port == 3000
-    
+
     def test_defaults_used_when_nothing_set(self):
         """
         What it does: Verifies that defaults are used when nothing else is set.
@@ -192,24 +197,26 @@ class TestResolveServerConfig:
         """
         print("Setup: Importing resolve_server_config...")
         from main import resolve_server_config
-        
+
         print("Setup: Creating args with host=None, port=None...")
         args = argparse.Namespace(host=None, port=None)
-        
+
         print("Action: Calling resolve_server_config with defaults...")
         # SERVER_HOST and SERVER_PORT equal to defaults (no env override)
-        with patch('main.SERVER_HOST', '0.0.0.0'), \
-             patch('main.SERVER_PORT', 8000), \
-             patch('main.DEFAULT_SERVER_HOST', '0.0.0.0'), \
-             patch('main.DEFAULT_SERVER_PORT', 8000):
+        with (
+            patch("main.SERVER_HOST", "0.0.0.0"),
+            patch("main.SERVER_PORT", 8000),
+            patch("main.DEFAULT_SERVER_HOST", "0.0.0.0"),
+            patch("main.DEFAULT_SERVER_PORT", 8000),
+        ):
             host, port = resolve_server_config(args)
-        
+
         print(f"Resolved host: {host}")
         print(f"Resolved port: {port}")
-        print(f"Comparing: Expected ('0.0.0.0', 8000)")
+        print("Comparing: Expected ('0.0.0.0', 8000)")
         assert host == "0.0.0.0"
         assert port == 8000
-    
+
     def test_cli_host_only_env_port(self):
         """
         What it does: Verifies mixed priority - CLI host with env port.
@@ -217,23 +224,25 @@ class TestResolveServerConfig:
         """
         print("Setup: Importing resolve_server_config...")
         from main import resolve_server_config
-        
+
         print("Setup: Creating args with host='127.0.0.1', port=None...")
         args = argparse.Namespace(host="127.0.0.1", port=None)
-        
+
         print("Action: Calling resolve_server_config...")
-        with patch('main.SERVER_HOST', '0.0.0.0'), \
-             patch('main.SERVER_PORT', 9000), \
-             patch('main.DEFAULT_SERVER_HOST', '0.0.0.0'), \
-             patch('main.DEFAULT_SERVER_PORT', 8000):
+        with (
+            patch("main.SERVER_HOST", "0.0.0.0"),
+            patch("main.SERVER_PORT", 9000),
+            patch("main.DEFAULT_SERVER_HOST", "0.0.0.0"),
+            patch("main.DEFAULT_SERVER_PORT", 8000),
+        ):
             host, port = resolve_server_config(args)
-        
+
         print(f"Resolved host: {host}")
         print(f"Resolved port: {port}")
-        print(f"Comparing: Expected ('127.0.0.1', 9000)")
+        print("Comparing: Expected ('127.0.0.1', 9000)")
         assert host == "127.0.0.1"  # From CLI
         assert port == 9000  # From env (different from default)
-    
+
     def test_cli_port_only_env_host(self):
         """
         What it does: Verifies mixed priority - CLI port with env host.
@@ -241,27 +250,29 @@ class TestResolveServerConfig:
         """
         print("Setup: Importing resolve_server_config...")
         from main import resolve_server_config
-        
+
         print("Setup: Creating args with host=None, port=5000...")
         args = argparse.Namespace(host=None, port=5000)
-        
+
         print("Action: Calling resolve_server_config...")
-        with patch('main.SERVER_HOST', '192.168.1.1'), \
-             patch('main.SERVER_PORT', 8000), \
-             patch('main.DEFAULT_SERVER_HOST', '0.0.0.0'), \
-             patch('main.DEFAULT_SERVER_PORT', 8000):
+        with (
+            patch("main.SERVER_HOST", "192.168.1.1"),
+            patch("main.SERVER_PORT", 8000),
+            patch("main.DEFAULT_SERVER_HOST", "0.0.0.0"),
+            patch("main.DEFAULT_SERVER_PORT", 8000),
+        ):
             host, port = resolve_server_config(args)
-        
+
         print(f"Resolved host: {host}")
         print(f"Resolved port: {port}")
-        print(f"Comparing: Expected ('192.168.1.1', 5000)")
+        print("Comparing: Expected ('192.168.1.1', 5000)")
         assert host == "192.168.1.1"  # From env (different from default)
         assert port == 5000  # From CLI
 
 
 class TestPrintStartupBanner:
     """Tests for print_startup_banner() function."""
-    
+
     def test_banner_contains_url(self, capsys):
         """
         What it does: Verifies that banner contains the server URL.
@@ -269,16 +280,16 @@ class TestPrintStartupBanner:
         """
         print("Setup: Importing print_startup_banner...")
         from main import print_startup_banner
-        
+
         print("Action: Calling print_startup_banner('0.0.0.0', 8000)...")
         print_startup_banner("0.0.0.0", 8000)
-        
+
         captured = capsys.readouterr()
         print(f"Captured output length: {len(captured.out)}")
-        
+
         # When host is 0.0.0.0, display should show localhost
         assert "localhost:8000" in captured.out or "8000" in captured.out
-    
+
     def test_banner_contains_custom_port(self, capsys):
         """
         What it does: Verifies that banner shows custom port.
@@ -286,15 +297,15 @@ class TestPrintStartupBanner:
         """
         print("Setup: Importing print_startup_banner...")
         from main import print_startup_banner
-        
+
         print("Action: Calling print_startup_banner('127.0.0.1', 9000)...")
         print_startup_banner("127.0.0.1", 9000)
-        
+
         captured = capsys.readouterr()
         print(f"Captured output contains '9000': {'9000' in captured.out}")
-        
+
         assert "9000" in captured.out
-    
+
     def test_banner_contains_docs_url(self, capsys):
         """
         What it does: Verifies that banner contains API docs URL.
@@ -302,15 +313,15 @@ class TestPrintStartupBanner:
         """
         print("Setup: Importing print_startup_banner...")
         from main import print_startup_banner
-        
+
         print("Action: Calling print_startup_banner('0.0.0.0', 8000)...")
         print_startup_banner("0.0.0.0", 8000)
-        
+
         captured = capsys.readouterr()
         print(f"Captured output contains '/docs': {'/docs' in captured.out}")
-        
+
         assert "/docs" in captured.out
-    
+
     def test_banner_contains_health_url(self, capsys):
         """
         What it does: Verifies that banner contains health check URL.
@@ -318,19 +329,19 @@ class TestPrintStartupBanner:
         """
         print("Setup: Importing print_startup_banner...")
         from main import print_startup_banner
-        
+
         print("Action: Calling print_startup_banner('0.0.0.0', 8000)...")
         print_startup_banner("0.0.0.0", 8000)
-        
+
         captured = capsys.readouterr()
         print(f"Captured output contains '/health': {'/health' in captured.out}")
-        
+
         assert "/health" in captured.out
 
 
 class TestCliHelp:
     """Tests for CLI help output."""
-    
+
     def test_help_shows_port_option(self):
         """
         What it does: Verifies that --help shows port option.
@@ -338,16 +349,16 @@ class TestCliHelp:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with --help...")
-        with patch.object(sys, 'argv', ['main.py', '--help']):
+        with patch.object(sys, "argv", ["main.py", "--help"]):
             with pytest.raises(SystemExit) as exc_info:
                 parse_cli_args()
-        
+
         print(f"Exit code: {exc_info.value.code}")
         # --help exits with code 0
         assert exc_info.value.code == 0
-    
+
     def test_help_shows_host_option(self, capsys):
         """
         What it does: Verifies that --help output contains host option.
@@ -355,23 +366,23 @@ class TestCliHelp:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with --help...")
-        with patch.object(sys, 'argv', ['main.py', '--help']):
+        with patch.object(sys, "argv", ["main.py", "--help"]):
             with pytest.raises(SystemExit):
                 parse_cli_args()
-        
+
         captured = capsys.readouterr()
         print(f"Help output contains '--host': {'--host' in captured.out}")
         print(f"Help output contains '-H': {'-H' in captured.out}")
-        
+
         assert "--host" in captured.out
         assert "-H" in captured.out
 
 
 class TestCliVersion:
     """Tests for CLI version output."""
-    
+
     def test_version_flag_exits_with_zero(self):
         """
         What it does: Verifies that --version exits with code 0.
@@ -379,15 +390,15 @@ class TestCliVersion:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with --version...")
-        with patch.object(sys, 'argv', ['main.py', '--version']):
+        with patch.object(sys, "argv", ["main.py", "--version"]):
             with pytest.raises(SystemExit) as exc_info:
                 parse_cli_args()
-        
+
         print(f"Exit code: {exc_info.value.code}")
         assert exc_info.value.code == 0
-    
+
     def test_version_shows_app_version(self, capsys):
         """
         What it does: Verifies that --version shows application version.
@@ -396,14 +407,14 @@ class TestCliVersion:
         print("Setup: Importing parse_cli_args and APP_VERSION...")
         from main import parse_cli_args
         from kiro.config import APP_VERSION
-        
+
         print("Action: Calling parse_cli_args with --version...")
-        with patch.object(sys, 'argv', ['main.py', '--version']):
+        with patch.object(sys, "argv", ["main.py", "--version"]):
             with pytest.raises(SystemExit):
                 parse_cli_args()
-        
+
         captured = capsys.readouterr()
         print(f"Version output: {captured.out}")
         print(f"APP_VERSION: {APP_VERSION}")
-        
+
         assert APP_VERSION in captured.out

--- a/tests/unit/test_model_resolver.py
+++ b/tests/unit/test_model_resolver.py
@@ -27,6 +27,7 @@ from kiro.cache import ModelInfoCache
 # Fixtures
 # =============================================================================
 
+
 @pytest.fixture
 def mock_model_cache():
     """
@@ -38,10 +39,22 @@ def mock_model_cache():
     # Directly populate cache (without async update)
     cache._cache = {
         "auto": {"modelId": "auto", "modelName": "Auto"},
-        "claude-sonnet-4.5": {"modelId": "claude-sonnet-4.5", "modelName": "Claude Sonnet 4.5"},
-        "claude-sonnet-4": {"modelId": "claude-sonnet-4", "modelName": "Claude Sonnet 4"},
-        "claude-haiku-4.5": {"modelId": "claude-haiku-4.5", "modelName": "Claude Haiku 4.5"},
-        "claude-opus-4.5": {"modelId": "claude-opus-4.5", "modelName": "Claude Opus 4.5"},
+        "claude-sonnet-4.5": {
+            "modelId": "claude-sonnet-4.5",
+            "modelName": "Claude Sonnet 4.5",
+        },
+        "claude-sonnet-4": {
+            "modelId": "claude-sonnet-4",
+            "modelName": "Claude Sonnet 4",
+        },
+        "claude-haiku-4.5": {
+            "modelId": "claude-haiku-4.5",
+            "modelName": "Claude Haiku 4.5",
+        },
+        "claude-opus-4.5": {
+            "modelId": "claude-opus-4.5",
+            "modelName": "Claude Opus 4.5",
+        },
     }
     return cache
 
@@ -79,19 +92,20 @@ def resolver_without_hidden(mock_model_cache):
 # TestNormalizeModelName - Tests for model name normalization
 # =============================================================================
 
+
 class TestNormalizeModelName:
     """
     Tests for normalize_model_name() function.
-    
+
     Checks conversion of client formats to Kiro format:
     - Dashes → dots for minor versions
     - Removal of date suffix (20251001)
     - Removal of 'latest' suffix
     - Legacy format (claude-3-7-sonnet)
     """
-    
+
     # === Standard format with minor version ===
-    
+
     def test_normalizes_haiku_dash_to_dot(self):
         """
         What it does: claude-haiku-4-5 → claude-haiku-4.5
@@ -99,10 +113,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-haiku-4-5'...")
         result = normalize_model_name("claude-haiku-4-5")
-        
+
         print(f"Comparing result: Expected 'claude-haiku-4.5', Got '{result}'")
         assert result == "claude-haiku-4.5"
-    
+
     def test_normalizes_sonnet_dash_to_dot(self):
         """
         What it does: claude-sonnet-4-5 → claude-sonnet-4.5
@@ -110,10 +124,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-sonnet-4-5'...")
         result = normalize_model_name("claude-sonnet-4-5")
-        
+
         print(f"Comparing result: Expected 'claude-sonnet-4.5', Got '{result}'")
         assert result == "claude-sonnet-4.5"
-    
+
     def test_normalizes_opus_dash_to_dot(self):
         """
         What it does: claude-opus-4-5 → claude-opus-4.5
@@ -121,12 +135,12 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-opus-4-5'...")
         result = normalize_model_name("claude-opus-4-5")
-        
+
         print(f"Comparing result: Expected 'claude-opus-4.5', Got '{result}'")
         assert result == "claude-opus-4.5"
-    
+
     # === Removal of date suffix ===
-    
+
     def test_strips_date_suffix_haiku(self):
         """
         What it does: claude-haiku-4-5-20251001 → claude-haiku-4.5
@@ -134,10 +148,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-haiku-4-5-20251001'...")
         result = normalize_model_name("claude-haiku-4-5-20251001")
-        
+
         print(f"Comparing result: Expected 'claude-haiku-4.5', Got '{result}'")
         assert result == "claude-haiku-4.5"
-    
+
     def test_strips_date_suffix_sonnet(self):
         """
         What it does: claude-sonnet-4-5-20250929 → claude-sonnet-4.5
@@ -145,10 +159,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-sonnet-4-5-20250929'...")
         result = normalize_model_name("claude-sonnet-4-5-20250929")
-        
+
         print(f"Comparing result: Expected 'claude-sonnet-4.5', Got '{result}'")
         assert result == "claude-sonnet-4.5"
-    
+
     def test_strips_date_suffix_opus(self):
         """
         What it does: claude-opus-4-5-20251101 → claude-opus-4.5
@@ -156,12 +170,12 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-opus-4-5-20251101'...")
         result = normalize_model_name("claude-opus-4-5-20251101")
-        
+
         print(f"Comparing result: Expected 'claude-opus-4.5', Got '{result}'")
         assert result == "claude-opus-4.5"
-    
+
     # === Removal of 'latest' suffix ===
-    
+
     def test_strips_latest_suffix(self):
         """
         What it does: claude-haiku-4-5-latest → claude-haiku-4.5
@@ -169,12 +183,12 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-haiku-4-5-latest'...")
         result = normalize_model_name("claude-haiku-4-5-latest")
-        
+
         print(f"Comparing result: Expected 'claude-haiku-4.5', Got '{result}'")
         assert result == "claude-haiku-4.5"
-    
+
     # === Standard format without minor version ===
-    
+
     def test_keeps_model_without_minor(self):
         """
         What it does: claude-sonnet-4 → claude-sonnet-4
@@ -182,10 +196,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-sonnet-4'...")
         result = normalize_model_name("claude-sonnet-4")
-        
+
         print(f"Comparing result: Expected 'claude-sonnet-4', Got '{result}'")
         assert result == "claude-sonnet-4"
-    
+
     def test_strips_date_from_model_without_minor(self):
         """
         What it does: claude-sonnet-4-20250514 → claude-sonnet-4
@@ -193,12 +207,12 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-sonnet-4-20250514'...")
         result = normalize_model_name("claude-sonnet-4-20250514")
-        
+
         print(f"Comparing result: Expected 'claude-sonnet-4', Got '{result}'")
         assert result == "claude-sonnet-4"
-    
+
     # === Legacy format (claude-X-Y-family) ===
-    
+
     def test_normalizes_legacy_format(self):
         """
         What it does: claude-3-7-sonnet → claude-3.7-sonnet
@@ -206,10 +220,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-3-7-sonnet'...")
         result = normalize_model_name("claude-3-7-sonnet")
-        
+
         print(f"Comparing result: Expected 'claude-3.7-sonnet', Got '{result}'")
         assert result == "claude-3.7-sonnet"
-    
+
     def test_normalizes_legacy_format_with_date(self):
         """
         What it does: claude-3-7-sonnet-20250219 → claude-3.7-sonnet
@@ -217,10 +231,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-3-7-sonnet-20250219'...")
         result = normalize_model_name("claude-3-7-sonnet-20250219")
-        
+
         print(f"Comparing result: Expected 'claude-3.7-sonnet', Got '{result}'")
         assert result == "claude-3.7-sonnet"
-    
+
     def test_normalizes_legacy_haiku(self):
         """
         What it does: claude-3-5-haiku → claude-3.5-haiku
@@ -228,10 +242,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-3-5-haiku'...")
         result = normalize_model_name("claude-3-5-haiku")
-        
+
         print(f"Comparing result: Expected 'claude-3.5-haiku', Got '{result}'")
         assert result == "claude-3.5-haiku"
-    
+
     def test_normalizes_legacy_opus(self):
         """
         What it does: claude-3-0-opus → claude-3.0-opus
@@ -239,12 +253,12 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-3-0-opus'...")
         result = normalize_model_name("claude-3-0-opus")
-        
+
         print(f"Comparing result: Expected 'claude-3.0-opus', Got '{result}'")
         assert result == "claude-3.0-opus"
-    
+
     # === Already normalized (passthrough) ===
-    
+
     def test_passthrough_already_normalized_haiku(self):
         """
         What it does: claude-haiku-4.5 → claude-haiku-4.5
@@ -252,10 +266,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-haiku-4.5'...")
         result = normalize_model_name("claude-haiku-4.5")
-        
+
         print(f"Comparing result: Expected 'claude-haiku-4.5', Got '{result}'")
         assert result == "claude-haiku-4.5"
-    
+
     def test_passthrough_already_normalized_sonnet(self):
         """
         What it does: claude-sonnet-4.5 → claude-sonnet-4.5
@@ -263,10 +277,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-sonnet-4.5'...")
         result = normalize_model_name("claude-sonnet-4.5")
-        
+
         print(f"Comparing result: Expected 'claude-sonnet-4.5', Got '{result}'")
         assert result == "claude-sonnet-4.5"
-    
+
     def test_passthrough_auto(self):
         """
         What it does: auto → auto
@@ -274,12 +288,12 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'auto'...")
         result = normalize_model_name("auto")
-        
+
         print(f"Comparing result: Expected 'auto', Got '{result}'")
         assert result == "auto"
-    
+
     # === Edge cases ===
-    
+
     def test_handles_empty_string(self):
         """
         What it does: "" → ""
@@ -287,10 +301,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing empty string...")
         result = normalize_model_name("")
-        
+
         print(f"Comparing result: Expected '', Got '{result}'")
         assert result == ""
-    
+
     def test_handles_unknown_format(self):
         """
         What it does: gpt-4 → gpt-4 (passthrough)
@@ -298,10 +312,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'gpt-4'...")
         result = normalize_model_name("gpt-4")
-        
+
         print(f"Comparing result: Expected 'gpt-4', Got '{result}'")
         assert result == "gpt-4"
-    
+
     def test_handles_random_model_name(self):
         """
         What it does: some-random-model → some-random-model
@@ -309,7 +323,7 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'some-random-model'...")
         result = normalize_model_name("some-random-model")
-        
+
         print(f"Comparing result: Expected 'some-random-model', Got '{result}'")
         assert result == "some-random-model"
 
@@ -318,39 +332,43 @@ class TestNormalizeModelName:
 # TestNormalizeModelNameParametrized - Parametrized tests
 # =============================================================================
 
+
 class TestNormalizeModelNameParametrized:
     """Parametrized tests for complete coverage of scenarios."""
-    
-    @pytest.mark.parametrize("input_model,expected", [
-        # Standard format with minor version
-        ("claude-haiku-4-5", "claude-haiku-4.5"),
-        ("claude-haiku-4-5-20251001", "claude-haiku-4.5"),
-        ("claude-haiku-4-5-latest", "claude-haiku-4.5"),
-        ("claude-sonnet-4-5", "claude-sonnet-4.5"),
-        ("claude-sonnet-4-5-20250929", "claude-sonnet-4.5"),
-        ("claude-opus-4-5", "claude-opus-4.5"),
-        ("claude-opus-4-5-20251101", "claude-opus-4.5"),
-        # Without minor version
-        ("claude-sonnet-4", "claude-sonnet-4"),
-        ("claude-sonnet-4-20250514", "claude-sonnet-4"),
-        ("claude-haiku-4", "claude-haiku-4"),
-        ("claude-opus-4", "claude-opus-4"),
-        # Legacy format
-        ("claude-3-7-sonnet", "claude-3.7-sonnet"),
-        ("claude-3-7-sonnet-20250219", "claude-3.7-sonnet"),
-        ("claude-3-5-haiku", "claude-3.5-haiku"),
-        ("claude-3-0-opus", "claude-3.0-opus"),
-        # Already normalized
-        ("claude-haiku-4.5", "claude-haiku-4.5"),
-        ("claude-sonnet-4.5", "claude-sonnet-4.5"),
-        ("claude-opus-4.5", "claude-opus-4.5"),
-        ("claude-3.7-sonnet", "claude-3.7-sonnet"),
-        ("auto", "auto"),
-        # Passthrough for unknown
-        ("gpt-4", "gpt-4"),
-        ("gpt-4-turbo", "gpt-4-turbo"),
-        ("unknown-model", "unknown-model"),
-    ])
+
+    @pytest.mark.parametrize(
+        "input_model,expected",
+        [
+            # Standard format with minor version
+            ("claude-haiku-4-5", "claude-haiku-4.5"),
+            ("claude-haiku-4-5-20251001", "claude-haiku-4.5"),
+            ("claude-haiku-4-5-latest", "claude-haiku-4.5"),
+            ("claude-sonnet-4-5", "claude-sonnet-4.5"),
+            ("claude-sonnet-4-5-20250929", "claude-sonnet-4.5"),
+            ("claude-opus-4-5", "claude-opus-4.5"),
+            ("claude-opus-4-5-20251101", "claude-opus-4.5"),
+            # Without minor version
+            ("claude-sonnet-4", "claude-sonnet-4"),
+            ("claude-sonnet-4-20250514", "claude-sonnet-4"),
+            ("claude-haiku-4", "claude-haiku-4"),
+            ("claude-opus-4", "claude-opus-4"),
+            # Legacy format
+            ("claude-3-7-sonnet", "claude-3.7-sonnet"),
+            ("claude-3-7-sonnet-20250219", "claude-3.7-sonnet"),
+            ("claude-3-5-haiku", "claude-3.5-haiku"),
+            ("claude-3-0-opus", "claude-3.0-opus"),
+            # Already normalized
+            ("claude-haiku-4.5", "claude-haiku-4.5"),
+            ("claude-sonnet-4.5", "claude-sonnet-4.5"),
+            ("claude-opus-4.5", "claude-opus-4.5"),
+            ("claude-3.7-sonnet", "claude-3.7-sonnet"),
+            ("auto", "auto"),
+            # Passthrough for unknown
+            ("gpt-4", "gpt-4"),
+            ("gpt-4-turbo", "gpt-4-turbo"),
+            ("unknown-model", "unknown-model"),
+        ],
+    )
     def test_normalize_model_name_all_scenarios(self, input_model, expected):
         """
         What it does: Checks all normalization scenarios.
@@ -358,7 +376,7 @@ class TestNormalizeModelNameParametrized:
         """
         print(f"Action: Normalizing '{input_model}'...")
         result = normalize_model_name(input_model)
-        
+
         print(f"Comparing result: Expected '{expected}', Got '{result}'")
         assert result == expected
 
@@ -367,13 +385,14 @@ class TestNormalizeModelNameParametrized:
 # TestExtractModelFamily - Tests for model family extraction
 # =============================================================================
 
+
 class TestExtractModelFamily:
     """
     Tests for extract_model_family() function.
-    
+
     Checks extraction of model family (haiku, sonnet, opus) from name.
     """
-    
+
     def test_extracts_haiku_from_standard_format(self):
         """
         What it does: claude-haiku-4.5 → haiku
@@ -381,10 +400,10 @@ class TestExtractModelFamily:
         """
         print("Action: Extracting family from 'claude-haiku-4.5'...")
         result = extract_model_family("claude-haiku-4.5")
-        
+
         print(f"Comparing result: Expected 'haiku', Got '{result}'")
         assert result == "haiku"
-    
+
     def test_extracts_sonnet_from_standard_format(self):
         """
         What it does: claude-sonnet-4.5 → sonnet
@@ -392,10 +411,10 @@ class TestExtractModelFamily:
         """
         print("Action: Extracting family from 'claude-sonnet-4.5'...")
         result = extract_model_family("claude-sonnet-4.5")
-        
+
         print(f"Comparing result: Expected 'sonnet', Got '{result}'")
         assert result == "sonnet"
-    
+
     def test_extracts_opus_from_standard_format(self):
         """
         What it does: claude-opus-4.5 → opus
@@ -403,10 +422,10 @@ class TestExtractModelFamily:
         """
         print("Action: Extracting family from 'claude-opus-4.5'...")
         result = extract_model_family("claude-opus-4.5")
-        
+
         print(f"Comparing result: Expected 'opus', Got '{result}'")
         assert result == "opus"
-    
+
     def test_extracts_sonnet_from_legacy_format(self):
         """
         What it does: claude-3.7-sonnet → sonnet
@@ -414,10 +433,10 @@ class TestExtractModelFamily:
         """
         print("Action: Extracting family from 'claude-3.7-sonnet'...")
         result = extract_model_family("claude-3.7-sonnet")
-        
+
         print(f"Comparing result: Expected 'sonnet', Got '{result}'")
         assert result == "sonnet"
-    
+
     def test_extracts_haiku_from_unnormalized(self):
         """
         What it does: claude-haiku-4-5-20251001 → haiku
@@ -425,10 +444,10 @@ class TestExtractModelFamily:
         """
         print("Action: Extracting family from 'claude-haiku-4-5-20251001'...")
         result = extract_model_family("claude-haiku-4-5-20251001")
-        
+
         print(f"Comparing result: Expected 'haiku', Got '{result}'")
         assert result == "haiku"
-    
+
     def test_returns_none_for_non_claude(self):
         """
         What it does: gpt-4 → None
@@ -436,10 +455,10 @@ class TestExtractModelFamily:
         """
         print("Action: Extracting family from 'gpt-4'...")
         result = extract_model_family("gpt-4")
-        
+
         print(f"Comparing result: Expected None, Got {result}")
         assert result is None
-    
+
     def test_returns_none_for_auto(self):
         """
         What it does: auto → None
@@ -447,10 +466,10 @@ class TestExtractModelFamily:
         """
         print("Action: Extracting family from 'auto'...")
         result = extract_model_family("auto")
-        
+
         print(f"Comparing result: Expected None, Got {result}")
         assert result is None
-    
+
     def test_case_insensitive(self):
         """
         What it does: CLAUDE-HAIKU-4.5 → haiku
@@ -458,7 +477,7 @@ class TestExtractModelFamily:
         """
         print("Action: Extracting family from 'CLAUDE-HAIKU-4.5'...")
         result = extract_model_family("CLAUDE-HAIKU-4.5")
-        
+
         print(f"Comparing result: Expected 'haiku', Got '{result}'")
         assert result == "haiku"
 
@@ -467,13 +486,14 @@ class TestExtractModelFamily:
 # TestGetModelIdForKiro - Tests for converter helper
 # =============================================================================
 
+
 class TestGetModelIdForKiro:
     """
     Tests for get_model_id_for_kiro() function.
-    
+
     Checks getting model ID for sending to Kiro API.
     """
-    
+
     def test_normalizes_without_hidden_models(self):
         """
         What it does: Normalizes model without hidden models.
@@ -481,49 +501,55 @@ class TestGetModelIdForKiro:
         """
         print("Action: get_model_id_for_kiro('claude-haiku-4-5-20251001', {})...")
         result = get_model_id_for_kiro("claude-haiku-4-5-20251001", {})
-        
+
         print(f"Comparing result: Expected 'claude-haiku-4.5', Got '{result}'")
         assert result == "claude-haiku-4.5"
-    
+
     def test_returns_internal_id_for_hidden_model(self):
         """
         What it does: Returns internal ID for hidden model.
         Goal: Check hidden model resolution.
         """
         hidden = {"claude-3.7-sonnet": "CLAUDE_3_7_SONNET_20250219_V1_0"}
-        
+
         print("Action: get_model_id_for_kiro('claude-3.7-sonnet', hidden)...")
         result = get_model_id_for_kiro("claude-3.7-sonnet", hidden)
-        
-        print(f"Comparing result: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0', Got '{result}'")
+
+        print(
+            f"Comparing result: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0', Got '{result}'"
+        )
         assert result == "CLAUDE_3_7_SONNET_20250219_V1_0"
-    
+
     def test_normalizes_then_checks_hidden(self):
         """
         What it does: Normalizes first, then checks hidden.
         Goal: Check operation order.
         """
         hidden = {"claude-3.7-sonnet": "CLAUDE_3_7_SONNET_20250219_V1_0"}
-        
+
         print("Action: get_model_id_for_kiro('claude-3-7-sonnet', hidden)...")
         result = get_model_id_for_kiro("claude-3-7-sonnet", hidden)
-        
-        print(f"Comparing result: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0', Got '{result}'")
+
+        print(
+            f"Comparing result: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0', Got '{result}'"
+        )
         assert result == "CLAUDE_3_7_SONNET_20250219_V1_0"
-    
+
     def test_normalizes_with_date_then_checks_hidden(self):
         """
         What it does: Normalizes with date suffix, then checks hidden.
         Goal: Check full normalization chain.
         """
         hidden = {"claude-3.7-sonnet": "CLAUDE_3_7_SONNET_20250219_V1_0"}
-        
+
         print("Action: get_model_id_for_kiro('claude-3-7-sonnet-20250219', hidden)...")
         result = get_model_id_for_kiro("claude-3-7-sonnet-20250219", hidden)
-        
-        print(f"Comparing result: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0', Got '{result}'")
+
+        print(
+            f"Comparing result: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0', Got '{result}'"
+        )
         assert result == "CLAUDE_3_7_SONNET_20250219_V1_0"
-    
+
     def test_passthrough_unknown_model(self):
         """
         What it does: Passthrough for unknown models.
@@ -531,7 +557,7 @@ class TestGetModelIdForKiro:
         """
         print("Action: get_model_id_for_kiro('claude-unknown-model', {})...")
         result = get_model_id_for_kiro("claude-unknown-model", {})
-        
+
         print(f"Comparing result: Expected 'claude-unknown-model', Got '{result}'")
         assert result == "claude-unknown-model"
 
@@ -540,9 +566,10 @@ class TestGetModelIdForKiro:
 # TestModelResolver - Tests for ModelResolver class
 # =============================================================================
 
+
 class TestModelResolverInitialization:
     """Tests for ModelResolver initialization."""
-    
+
     def test_init_with_cache_and_hidden_models(self, mock_model_cache, hidden_models):
         """
         What it does: Creates ModelResolver with cache and hidden models.
@@ -550,11 +577,11 @@ class TestModelResolverInitialization:
         """
         print("Action: Creating ModelResolver...")
         resolver = ModelResolver(cache=mock_model_cache, hidden_models=hidden_models)
-        
+
         print("Check: Attributes set correctly...")
         assert resolver.cache is mock_model_cache
         assert resolver.hidden_models == hidden_models
-    
+
     def test_init_with_empty_hidden_models(self, mock_model_cache):
         """
         What it does: Creates ModelResolver without hidden models.
@@ -562,10 +589,10 @@ class TestModelResolverInitialization:
         """
         print("Action: Creating ModelResolver without hidden models...")
         resolver = ModelResolver(cache=mock_model_cache, hidden_models={})
-        
+
         print("Check: hidden_models is empty...")
         assert resolver.hidden_models == {}
-    
+
     def test_init_with_none_hidden_models(self, mock_model_cache):
         """
         What it does: Creates ModelResolver with hidden_models=None.
@@ -573,14 +600,14 @@ class TestModelResolverInitialization:
         """
         print("Action: Creating ModelResolver with hidden_models=None...")
         resolver = ModelResolver(cache=mock_model_cache, hidden_models=None)
-        
+
         print("Check: hidden_models initialized as empty dict...")
         assert resolver.hidden_models == {}
 
 
 class TestModelResolverResolve:
     """Tests for resolve() method of ModelResolver class."""
-    
+
     def test_resolve_finds_model_in_cache(self, model_resolver):
         """
         What it does: Finds model in cache.
@@ -588,23 +615,29 @@ class TestModelResolverResolve:
         """
         print("Action: Resolving 'claude-haiku-4-5'...")
         result = model_resolver.resolve("claude-haiku-4-5")
-        
+
         print(f"Check result: {result}")
-        print(f"Comparing internal_id: Expected 'claude-haiku-4.5', Got '{result.internal_id}'")
+        print(
+            f"Comparing internal_id: Expected 'claude-haiku-4.5', Got '{result.internal_id}'"
+        )
         assert result.internal_id == "claude-haiku-4.5"
-        
+
         print(f"Comparing source: Expected 'cache', Got '{result.source}'")
         assert result.source == "cache"
-        
+
         print(f"Comparing is_verified: Expected True, Got {result.is_verified}")
         assert result.is_verified is True
-        
-        print(f"Comparing normalized: Expected 'claude-haiku-4.5', Got '{result.normalized}'")
+
+        print(
+            f"Comparing normalized: Expected 'claude-haiku-4.5', Got '{result.normalized}'"
+        )
         assert result.normalized == "claude-haiku-4.5"
-        
-        print(f"Comparing original_request: Expected 'claude-haiku-4-5', Got '{result.original_request}'")
+
+        print(
+            f"Comparing original_request: Expected 'claude-haiku-4-5', Got '{result.original_request}'"
+        )
         assert result.original_request == "claude-haiku-4-5"
-    
+
     def test_resolve_finds_model_in_hidden(self, model_resolver):
         """
         What it does: Finds model in hidden models.
@@ -612,17 +645,19 @@ class TestModelResolverResolve:
         """
         print("Action: Resolving 'claude-3-7-sonnet'...")
         result = model_resolver.resolve("claude-3-7-sonnet")
-        
+
         print(f"Check result: {result}")
-        print(f"Comparing internal_id: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0', Got '{result.internal_id}'")
+        print(
+            f"Comparing internal_id: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0', Got '{result.internal_id}'"
+        )
         assert result.internal_id == "CLAUDE_3_7_SONNET_20250219_V1_0"
-        
+
         print(f"Comparing source: Expected 'hidden', Got '{result.source}'")
         assert result.source == "hidden"
-        
+
         print(f"Comparing is_verified: Expected True, Got {result.is_verified}")
         assert result.is_verified is True
-    
+
     def test_resolve_passthrough_for_unknown(self, model_resolver):
         """
         What it does: Passthrough for unknown model.
@@ -630,17 +665,19 @@ class TestModelResolverResolve:
         """
         print("Action: Resolving 'claude-haiku-4-6' (does not exist)...")
         result = model_resolver.resolve("claude-haiku-4-6")
-        
+
         print(f"Check result: {result}")
-        print(f"Comparing internal_id: Expected 'claude-haiku-4.6', Got '{result.internal_id}'")
+        print(
+            f"Comparing internal_id: Expected 'claude-haiku-4.6', Got '{result.internal_id}'"
+        )
         assert result.internal_id == "claude-haiku-4.6"
-        
+
         print(f"Comparing source: Expected 'passthrough', Got '{result.source}'")
         assert result.source == "passthrough"
-        
+
         print(f"Comparing is_verified: Expected False, Got {result.is_verified}")
         assert result.is_verified is False
-    
+
     def test_resolve_normalizes_before_lookup(self, model_resolver):
         """
         What it does: Normalizes name before cache lookup.
@@ -648,35 +685,37 @@ class TestModelResolverResolve:
         """
         print("Action: Resolving 'claude-haiku-4-5-20251001'...")
         result = model_resolver.resolve("claude-haiku-4-5-20251001")
-        
-        print(f"Comparing normalized: Expected 'claude-haiku-4.5', Got '{result.normalized}'")
+
+        print(
+            f"Comparing normalized: Expected 'claude-haiku-4.5', Got '{result.normalized}'"
+        )
         assert result.normalized == "claude-haiku-4.5"
-        
+
         print(f"Comparing source: Expected 'cache', Got '{result.source}'")
         assert result.source == "cache"
-    
+
     def test_resolve_never_raises(self, model_resolver):
         """
         What it does: Never raises exception.
         Goal: Check that resolve() always returns ModelResolution.
         """
         print("Action: Resolving strange input data...")
-        
+
         # Empty string
         result1 = model_resolver.resolve("")
         print(f"Empty string: {result1}")
         assert isinstance(result1, ModelResolution)
-        
+
         # Special characters
         result2 = model_resolver.resolve("!@#$%^&*()")
         print(f"Special characters: {result2}")
         assert isinstance(result2, ModelResolution)
-        
+
         # Very long name
         result3 = model_resolver.resolve("a" * 1000)
         print(f"Long name: source={result3.source}")
         assert isinstance(result3, ModelResolution)
-    
+
     def test_resolve_auto_model(self, model_resolver):
         """
         What it does: Resolves 'auto' model.
@@ -684,13 +723,13 @@ class TestModelResolverResolve:
         """
         print("Action: Resolving 'auto'...")
         result = model_resolver.resolve("auto")
-        
+
         print(f"Comparing internal_id: Expected 'auto', Got '{result.internal_id}'")
         assert result.internal_id == "auto"
-        
+
         print(f"Comparing source: Expected 'cache', Got '{result.source}'")
         assert result.source == "cache"
-    
+
     def test_resolve_with_empty_cache(self, empty_model_cache, hidden_models):
         """
         What it does: Resolves model with empty cache.
@@ -698,23 +737,23 @@ class TestModelResolverResolve:
         """
         print("Setup: Creating resolver with empty cache...")
         resolver = ModelResolver(cache=empty_model_cache, hidden_models=hidden_models)
-        
+
         print("Action: Resolving 'claude-3.7-sonnet'...")
         result = resolver.resolve("claude-3.7-sonnet")
-        
+
         print(f"Comparing source: Expected 'hidden', Got '{result.source}'")
         assert result.source == "hidden"
-        
+
         print("Action: Resolving 'claude-haiku-4.5' (not in cache)...")
         result2 = resolver.resolve("claude-haiku-4.5")
-        
+
         print(f"Comparing source: Expected 'passthrough', Got '{result2.source}'")
         assert result2.source == "passthrough"
 
 
 class TestModelResolverGetAvailableModels:
     """Tests for get_available_models() method."""
-    
+
     def test_get_available_models_combines_cache_and_hidden(self, model_resolver):
         """
         What it does: Returns models from cache and hidden.
@@ -722,20 +761,20 @@ class TestModelResolverGetAvailableModels:
         """
         print("Action: Getting list of available models...")
         models = model_resolver.get_available_models()
-        
+
         print(f"Received models: {models}")
-        
+
         # Check cache models
         print("Check: Cache models present...")
         assert "claude-haiku-4.5" in models
         assert "claude-sonnet-4.5" in models
         assert "claude-opus-4.5" in models
         assert "auto" in models
-        
+
         # Check hidden models
         print("Check: Hidden models present...")
         assert "claude-3.7-sonnet" in models
-    
+
     def test_get_available_models_returns_sorted_list(self, model_resolver):
         """
         What it does: Returns sorted list.
@@ -743,12 +782,12 @@ class TestModelResolverGetAvailableModels:
         """
         print("Action: Getting list of available models...")
         models = model_resolver.get_available_models()
-        
+
         print(f"Received models: {models}")
         print(f"Sorted: {sorted(models)}")
-        
+
         assert models == sorted(models)
-    
+
     def test_get_available_models_no_duplicates(self, mock_model_cache):
         """
         What it does: Does not return duplicates.
@@ -757,19 +796,19 @@ class TestModelResolverGetAvailableModels:
         # Add hidden model that already exists in cache
         hidden = {"claude-haiku-4.5": "SOME_INTERNAL_ID"}
         resolver = ModelResolver(cache=mock_model_cache, hidden_models=hidden)
-        
+
         print("Action: Getting list with potential duplicate...")
         models = resolver.get_available_models()
-        
+
         print(f"Received models: {models}")
-        
+
         # Check uniqueness
         assert len(models) == len(set(models))
 
 
 class TestModelResolverGetModelsByFamily:
     """Tests for get_models_by_family() method."""
-    
+
     def test_get_models_by_family_haiku(self, model_resolver):
         """
         What it does: Returns only Haiku models.
@@ -777,13 +816,13 @@ class TestModelResolverGetModelsByFamily:
         """
         print("Action: Getting Haiku models...")
         models = model_resolver.get_models_by_family("haiku")
-        
+
         print(f"Received models: {models}")
-        
+
         assert "claude-haiku-4.5" in models
         assert "claude-sonnet-4.5" not in models
         assert "claude-opus-4.5" not in models
-    
+
     def test_get_models_by_family_sonnet(self, model_resolver):
         """
         What it does: Returns only Sonnet models.
@@ -791,14 +830,14 @@ class TestModelResolverGetModelsByFamily:
         """
         print("Action: Getting Sonnet models...")
         models = model_resolver.get_models_by_family("sonnet")
-        
+
         print(f"Received models: {models}")
-        
+
         assert "claude-sonnet-4.5" in models
         assert "claude-sonnet-4" in models
         assert "claude-3.7-sonnet" in models  # Hidden model
         assert "claude-haiku-4.5" not in models
-    
+
     def test_get_models_by_family_opus(self, model_resolver):
         """
         What it does: Returns only Opus models.
@@ -806,12 +845,12 @@ class TestModelResolverGetModelsByFamily:
         """
         print("Action: Getting Opus models...")
         models = model_resolver.get_models_by_family("opus")
-        
+
         print(f"Received models: {models}")
-        
+
         assert "claude-opus-4.5" in models
         assert "claude-sonnet-4.5" not in models
-    
+
     def test_get_models_by_family_case_insensitive(self, model_resolver):
         """
         What it does: Filtering is case insensitive.
@@ -819,15 +858,15 @@ class TestModelResolverGetModelsByFamily:
         """
         print("Action: Getting HAIKU models (uppercase)...")
         models = model_resolver.get_models_by_family("HAIKU")
-        
+
         print(f"Received models: {models}")
-        
+
         assert "claude-haiku-4.5" in models
 
 
 class TestModelResolverGetSuggestionsForModel:
     """Tests for get_suggestions_for_model() method."""
-    
+
     def test_get_suggestions_returns_same_family(self, model_resolver):
         """
         What it does: Returns models of same family.
@@ -835,14 +874,14 @@ class TestModelResolverGetSuggestionsForModel:
         """
         print("Action: Getting suggestions for 'claude-haiku-4-6'...")
         suggestions = model_resolver.get_suggestions_for_model("claude-haiku-4-6")
-        
+
         print(f"Received suggestions: {suggestions}")
-        
+
         # All suggestions should be Haiku
         for s in suggestions:
             print(f"Check: '{s}' contains 'haiku'...")
             assert "haiku" in s.lower()
-    
+
     def test_get_suggestions_no_cross_family(self, model_resolver):
         """
         What it does: NEVER suggests models from other family.
@@ -850,15 +889,15 @@ class TestModelResolverGetSuggestionsForModel:
         """
         print("Action: Getting suggestions for 'claude-opus-5'...")
         suggestions = model_resolver.get_suggestions_for_model("claude-opus-5")
-        
+
         print(f"Received suggestions: {suggestions}")
-        
+
         # Should NOT be Sonnet or Haiku
         for s in suggestions:
             print(f"Check: '{s}' does NOT contain 'sonnet' or 'haiku'...")
             assert "sonnet" not in s.lower()
             assert "haiku" not in s.lower()
-    
+
     def test_get_suggestions_returns_all_for_unknown_family(self, model_resolver):
         """
         What it does: Returns all models for unknown family.
@@ -866,9 +905,9 @@ class TestModelResolverGetSuggestionsForModel:
         """
         print("Action: Getting suggestions for 'gpt-4'...")
         suggestions = model_resolver.get_suggestions_for_model("gpt-4")
-        
+
         print(f"Received suggestions: {suggestions}")
-        
+
         # Should be all models
         all_models = model_resolver.get_available_models()
         assert set(suggestions) == set(all_models)
@@ -878,9 +917,10 @@ class TestModelResolverGetSuggestionsForModel:
 # TestModelResolution - Tests for ModelResolution dataclass
 # =============================================================================
 
+
 class TestModelResolution:
     """Tests for ModelResolution dataclass."""
-    
+
     def test_model_resolution_fields(self):
         """
         What it does: Checks all ModelResolution fields.
@@ -892,16 +932,16 @@ class TestModelResolution:
             source="cache",
             original_request="claude-haiku-4-5",
             normalized="claude-haiku-4.5",
-            is_verified=True
+            is_verified=True,
         )
-        
+
         print(f"Check fields: {resolution}")
         assert resolution.internal_id == "claude-haiku-4.5"
         assert resolution.source == "cache"
         assert resolution.original_request == "claude-haiku-4-5"
         assert resolution.normalized == "claude-haiku-4.5"
         assert resolution.is_verified is True
-    
+
     def test_model_resolution_is_frozen(self):
         """
         What it does: Checks that ModelResolution is immutable.
@@ -913,13 +953,13 @@ class TestModelResolution:
             source="cache",
             original_request="test",
             normalized="test",
-            is_verified=True
+            is_verified=True,
         )
-        
+
         print("Check: Attempt to modify field should raise error...")
         with pytest.raises(FrozenInstanceError):
             resolution.internal_id = "changed"
-    
+
     def test_model_resolution_equality(self):
         """
         What it does: Checks comparison of two ModelResolution objects.
@@ -931,19 +971,19 @@ class TestModelResolution:
             source="cache",
             original_request="test",
             normalized="test",
-            is_verified=True
+            is_verified=True,
         )
         resolution2 = ModelResolution(
             internal_id="test",
             source="cache",
             original_request="test",
             normalized="test",
-            is_verified=True
+            is_verified=True,
         )
-        
+
         print(f"Comparing: {resolution1} == {resolution2}")
         assert resolution1 == resolution2
-    
+
     def test_model_resolution_inequality(self):
         """
         What it does: Checks inequality of different ModelResolution objects.
@@ -955,16 +995,16 @@ class TestModelResolution:
             source="cache",
             original_request="test",
             normalized="test",
-            is_verified=True
+            is_verified=True,
         )
         resolution2 = ModelResolution(
             internal_id="test2",
             source="hidden",
             original_request="test",
             normalized="test",
-            is_verified=True
+            is_verified=True,
         )
-        
+
         print(f"Comparing: {resolution1} != {resolution2}")
         assert resolution1 != resolution2
 
@@ -973,9 +1013,10 @@ class TestModelResolution:
 # TestModelInfoCacheNewMethods - Tests for new cache methods
 # =============================================================================
 
+
 class TestModelInfoCacheIsValidModel:
     """Tests for is_valid_model() method in ModelInfoCache."""
-    
+
     @pytest.mark.asyncio
     async def test_is_valid_model_returns_true_for_cached(self):
         """
@@ -985,13 +1026,13 @@ class TestModelInfoCacheIsValidModel:
         print("Setup: Creating and populating cache...")
         cache = ModelInfoCache()
         await cache.update([{"modelId": "claude-sonnet-4.5"}])
-        
+
         print("Action: Checking is_valid_model('claude-sonnet-4.5')...")
         result = cache.is_valid_model("claude-sonnet-4.5")
-        
+
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     @pytest.mark.asyncio
     async def test_is_valid_model_returns_false_for_unknown(self):
         """
@@ -1001,13 +1042,13 @@ class TestModelInfoCacheIsValidModel:
         print("Setup: Creating and populating cache...")
         cache = ModelInfoCache()
         await cache.update([{"modelId": "claude-sonnet-4.5"}])
-        
+
         print("Action: Checking is_valid_model('unknown-model')...")
         result = cache.is_valid_model("unknown-model")
-        
+
         print(f"Comparing result: Expected False, Got {result}")
         assert result is False
-    
+
     def test_is_valid_model_on_empty_cache(self):
         """
         What it does: Returns False for empty cache.
@@ -1015,17 +1056,17 @@ class TestModelInfoCacheIsValidModel:
         """
         print("Setup: Creating empty cache...")
         cache = ModelInfoCache()
-        
+
         print("Action: Checking is_valid_model('any-model')...")
         result = cache.is_valid_model("any-model")
-        
+
         print(f"Comparing result: Expected False, Got {result}")
         assert result is False
 
 
 class TestModelInfoCacheAddHiddenModel:
     """Tests for add_hidden_model() method in ModelInfoCache."""
-    
+
     def test_add_hidden_model_adds_to_cache(self):
         """
         What it does: Adds hidden model to cache.
@@ -1033,13 +1074,13 @@ class TestModelInfoCacheAddHiddenModel:
         """
         print("Setup: Creating empty cache...")
         cache = ModelInfoCache()
-        
+
         print("Action: Adding hidden model...")
         cache.add_hidden_model("claude-3.7-sonnet", "CLAUDE_3_7_SONNET_20250219_V1_0")
-        
+
         print("Check: Model added to cache...")
         assert cache.is_valid_model("claude-3.7-sonnet") is True
-    
+
     def test_add_hidden_model_stores_internal_id(self):
         """
         What it does: Stores internal ID in _internal_id field.
@@ -1047,17 +1088,17 @@ class TestModelInfoCacheAddHiddenModel:
         """
         print("Setup: Creating empty cache...")
         cache = ModelInfoCache()
-        
+
         print("Action: Adding hidden model...")
         cache.add_hidden_model("claude-3.7-sonnet", "CLAUDE_3_7_SONNET_20250219_V1_0")
-        
+
         print("Check: _internal_id saved...")
         model_info = cache.get("claude-3.7-sonnet")
         print(f"model_info: {model_info}")
-        
+
         assert model_info["_internal_id"] == "CLAUDE_3_7_SONNET_20250219_V1_0"
         assert model_info["_is_hidden"] is True
-    
+
     def test_add_hidden_model_sets_model_id(self):
         """
         What it does: Sets modelId equal to display_name.
@@ -1065,16 +1106,16 @@ class TestModelInfoCacheAddHiddenModel:
         """
         print("Setup: Creating empty cache...")
         cache = ModelInfoCache()
-        
+
         print("Action: Adding hidden model...")
         cache.add_hidden_model("claude-3.7-sonnet", "INTERNAL_ID")
-        
+
         print("Check: modelId set...")
         model_info = cache.get("claude-3.7-sonnet")
-        
+
         assert model_info["modelId"] == "claude-3.7-sonnet"
         assert model_info["modelName"] == "claude-3.7-sonnet"
-    
+
     @pytest.mark.asyncio
     async def test_add_hidden_model_does_not_overwrite_existing(self):
         """
@@ -1083,21 +1124,25 @@ class TestModelInfoCacheAddHiddenModel:
         """
         print("Setup: Creating cache with model...")
         cache = ModelInfoCache()
-        await cache.update([{
-            "modelId": "claude-3.7-sonnet",
-            "modelName": "Original Name",
-            "tokenLimits": {"maxInputTokens": 200000}
-        }])
-        
+        await cache.update(
+            [
+                {
+                    "modelId": "claude-3.7-sonnet",
+                    "modelName": "Original Name",
+                    "tokenLimits": {"maxInputTokens": 200000},
+                }
+            ]
+        )
+
         print("Action: Attempting to add hidden model with same ID...")
         cache.add_hidden_model("claude-3.7-sonnet", "NEW_INTERNAL_ID")
-        
+
         print("Check: Original data preserved...")
         model_info = cache.get("claude-3.7-sonnet")
-        
+
         assert model_info["modelName"] == "Original Name"
         assert "_internal_id" not in model_info  # Should not be added
-    
+
     def test_add_hidden_model_appears_in_get_all_model_ids(self):
         """
         What it does: Hidden model appears in list of all models.
@@ -1105,13 +1150,13 @@ class TestModelInfoCacheAddHiddenModel:
         """
         print("Setup: Creating empty cache...")
         cache = ModelInfoCache()
-        
+
         print("Action: Adding hidden model...")
         cache.add_hidden_model("claude-3.7-sonnet", "INTERNAL_ID")
-        
+
         print("Check: Model in list...")
         model_ids = cache.get_all_model_ids()
-        
+
         assert "claude-3.7-sonnet" in model_ids
 
 
@@ -1119,13 +1164,14 @@ class TestModelInfoCacheAddHiddenModel:
 # TestCriticalSafetyPrinciple - Critical security tests
 # =============================================================================
 
+
 class TestCriticalSafetyPrinciple:
     """
     Critical security tests: Family Isolation.
-    
+
     IMPORTANT: Resolver MUST NEVER cross model family boundaries!
     """
-    
+
     def test_opus_never_becomes_sonnet(self, model_resolver):
         """
         What it does: Opus request NEVER becomes Sonnet.
@@ -1133,16 +1179,16 @@ class TestCriticalSafetyPrinciple:
         """
         print("Action: Resolving non-existent Opus model...")
         result = model_resolver.resolve("claude-opus-5")
-        
+
         print(f"Result: {result}")
-        
+
         # Should be passthrough, NOT fallback to Sonnet
         print("Check: Does NOT contain 'sonnet'...")
         assert "sonnet" not in result.internal_id.lower()
-        
+
         print("Check: Does NOT contain 'haiku'...")
         assert "haiku" not in result.internal_id.lower()
-    
+
     def test_haiku_never_becomes_opus(self, model_resolver):
         """
         What it does: Haiku request NEVER becomes Opus.
@@ -1150,16 +1196,16 @@ class TestCriticalSafetyPrinciple:
         """
         print("Action: Resolving non-existent Haiku model...")
         result = model_resolver.resolve("claude-haiku-5")
-        
+
         print(f"Result: {result}")
-        
+
         # Should be passthrough, NOT fallback to Opus
         print("Check: Does NOT contain 'opus'...")
         assert "opus" not in result.internal_id.lower()
-        
+
         print("Check: Does NOT contain 'sonnet'...")
         assert "sonnet" not in result.internal_id.lower()
-    
+
     def test_sonnet_never_becomes_haiku(self, model_resolver):
         """
         What it does: Sonnet request NEVER becomes Haiku.
@@ -1167,29 +1213,32 @@ class TestCriticalSafetyPrinciple:
         """
         print("Action: Resolving non-existent Sonnet model...")
         result = model_resolver.resolve("claude-sonnet-5")
-        
+
         print(f"Result: {result}")
-        
+
         # Should be passthrough, NOT fallback to Haiku
         print("Check: Does NOT contain 'haiku'...")
         assert "haiku" not in result.internal_id.lower()
-        
+
         print("Check: Does NOT contain 'opus'...")
         assert "opus" not in result.internal_id.lower()
-    
+
     def test_suggestions_respect_family_boundaries(self, model_resolver):
         """
         What it does: Suggestions only from same family.
         Goal: Check that get_suggestions_for_model() respects boundaries.
         """
         families = ["haiku", "sonnet", "opus"]
-        
+
         for family in families:
             print(f"Check family: {family}...")
-            suggestions = model_resolver.get_suggestions_for_model(f"claude-{family}-99")
-            
+            suggestions = model_resolver.get_suggestions_for_model(
+                f"claude-{family}-99"
+            )
+
             for suggestion in suggestions:
                 print(f"  Suggestion: {suggestion}")
                 # Each suggestion must contain same family
-                assert family in suggestion.lower(), \
+                assert family in suggestion.lower(), (
                     f"Suggestion '{suggestion}' not from family '{family}'!"
+                )

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -33,8 +33,6 @@ from kiro.models_anthropic import (
     ToolChoiceAuto,
     ToolChoiceAny,
     ToolChoiceTool,
-    ToolChoice,
-    # Request models
     SystemContentBlock,
     AnthropicMessagesRequest,
     # Response models
@@ -67,9 +65,10 @@ TEST_IMAGE_BASE64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAs
 # Tests for Base64ImageSource
 # ==================================================================================================
 
+
 class TestBase64ImageSource:
     """Tests for Base64ImageSource Pydantic model."""
-    
+
     def test_valid_base64_source(self):
         """
         What it does: Verifies creation of valid Base64ImageSource.
@@ -77,63 +76,60 @@ class TestBase64ImageSource:
         """
         print("Setup: Creating Base64ImageSource with valid data...")
         source = Base64ImageSource(
-            type="base64",
-            media_type="image/jpeg",
-            data=TEST_IMAGE_BASE64
+            type="base64", media_type="image/jpeg", data=TEST_IMAGE_BASE64
         )
-        
+
         print(f"Result: {source}")
         print(f"Comparing type: Expected 'base64', Got '{source.type}'")
         assert source.type == "base64"
-        
+
         print(f"Comparing media_type: Expected 'image/jpeg', Got '{source.media_type}'")
         assert source.media_type == "image/jpeg"
-        
-        print(f"Comparing data: Expected {TEST_IMAGE_BASE64[:20]}..., Got {source.data[:20]}...")
+
+        print(
+            f"Comparing data: Expected {TEST_IMAGE_BASE64[:20]}..., Got {source.data[:20]}..."
+        )
         assert source.data == TEST_IMAGE_BASE64
-    
+
     def test_type_defaults_to_base64(self):
         """
         What it does: Verifies that type defaults to "base64".
         Purpose: Ensure default value is set correctly.
         """
         print("Setup: Creating Base64ImageSource without explicit type...")
-        source = Base64ImageSource(
-            media_type="image/png",
-            data=TEST_IMAGE_BASE64
-        )
-        
+        source = Base64ImageSource(media_type="image/png", data=TEST_IMAGE_BASE64)
+
         print(f"Comparing type: Expected 'base64', Got '{source.type}'")
         assert source.type == "base64"
-    
+
     def test_requires_media_type(self):
         """
         What it does: Verifies that media_type is required.
         Purpose: Ensure validation fails without media_type.
         """
         print("Setup: Attempting to create Base64ImageSource without media_type...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             Base64ImageSource(data=TEST_IMAGE_BASE64)
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "media_type" in str(exc_info.value)
-    
+
     def test_requires_data(self):
         """
         What it does: Verifies that data is required.
         Purpose: Ensure validation fails without data.
         """
         print("Setup: Attempting to create Base64ImageSource without data...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             Base64ImageSource(media_type="image/jpeg")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "data" in str(exc_info.value)
-    
+
     def test_accepts_various_media_types(self):
         """
         What it does: Verifies acceptance of various image media types.
@@ -141,12 +137,12 @@ class TestBase64ImageSource:
         """
         print("Setup: Testing various media types...")
         media_types = ["image/jpeg", "image/png", "image/gif", "image/webp"]
-        
+
         for media_type in media_types:
             print(f"Testing media_type: {media_type}")
             source = Base64ImageSource(media_type=media_type, data=TEST_IMAGE_BASE64)
             assert source.media_type == media_type
-        
+
         print("All media types accepted successfully")
 
 
@@ -154,27 +150,27 @@ class TestBase64ImageSource:
 # Tests for URLImageSource
 # ==================================================================================================
 
+
 class TestURLImageSource:
     """Tests for URLImageSource Pydantic model."""
-    
+
     def test_valid_url_source(self):
         """
         What it does: Verifies creation of valid URLImageSource.
         Purpose: Ensure model accepts valid URL.
         """
         print("Setup: Creating URLImageSource with valid URL...")
-        source = URLImageSource(
-            type="url",
-            url="https://example.com/image.jpg"
-        )
-        
+        source = URLImageSource(type="url", url="https://example.com/image.jpg")
+
         print(f"Result: {source}")
         print(f"Comparing type: Expected 'url', Got '{source.type}'")
         assert source.type == "url"
-        
-        print(f"Comparing url: Expected 'https://example.com/image.jpg', Got '{source.url}'")
+
+        print(
+            f"Comparing url: Expected 'https://example.com/image.jpg', Got '{source.url}'"
+        )
         assert source.url == "https://example.com/image.jpg"
-    
+
     def test_type_defaults_to_url(self):
         """
         What it does: Verifies that type defaults to "url".
@@ -182,21 +178,21 @@ class TestURLImageSource:
         """
         print("Setup: Creating URLImageSource without explicit type...")
         source = URLImageSource(url="https://example.com/image.png")
-        
+
         print(f"Comparing type: Expected 'url', Got '{source.type}'")
         assert source.type == "url"
-    
+
     def test_requires_url(self):
         """
         What it does: Verifies that url is required.
         Purpose: Ensure validation fails without url.
         """
         print("Setup: Attempting to create URLImageSource without url...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             URLImageSource()
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "url" in str(exc_info.value)
 
@@ -205,9 +201,10 @@ class TestURLImageSource:
 # Tests for ImageContentBlock
 # ==================================================================================================
 
+
 class TestImageContentBlock:
     """Tests for ImageContentBlock Pydantic model."""
-    
+
     def test_with_base64_source(self):
         """
         What it does: Verifies creation of ImageContentBlock with base64 source.
@@ -216,20 +213,17 @@ class TestImageContentBlock:
         print("Setup: Creating ImageContentBlock with base64 source...")
         block = ImageContentBlock(
             type="image",
-            source=Base64ImageSource(
-                media_type="image/jpeg",
-                data=TEST_IMAGE_BASE64
-            )
+            source=Base64ImageSource(media_type="image/jpeg", data=TEST_IMAGE_BASE64),
         )
-        
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'image', Got '{block.type}'")
         assert block.type == "image"
-        
+
         print(f"Comparing source.type: Expected 'base64', Got '{block.source.type}'")
         assert block.source.type == "base64"
         assert block.source.media_type == "image/jpeg"
-    
+
     def test_with_url_source(self):
         """
         What it does: Verifies creation of ImageContentBlock with URL source.
@@ -237,18 +231,17 @@ class TestImageContentBlock:
         """
         print("Setup: Creating ImageContentBlock with URL source...")
         block = ImageContentBlock(
-            type="image",
-            source=URLImageSource(url="https://example.com/image.jpg")
+            type="image", source=URLImageSource(url="https://example.com/image.jpg")
         )
-        
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'image', Got '{block.type}'")
         assert block.type == "image"
-        
+
         print(f"Comparing source.type: Expected 'url', Got '{block.source.type}'")
         assert block.source.type == "url"
         assert block.source.url == "https://example.com/image.jpg"
-    
+
     def test_with_dict_base64_source(self):
         """
         What it does: Verifies creation of ImageContentBlock with dict source.
@@ -260,15 +253,15 @@ class TestImageContentBlock:
             source={
                 "type": "base64",
                 "media_type": "image/png",
-                "data": TEST_IMAGE_BASE64
-            }
+                "data": TEST_IMAGE_BASE64,
+            },
         )
-        
+
         print(f"Result: {block}")
         print(f"Comparing source.type: Expected 'base64', Got '{block.source.type}'")
         assert block.source.type == "base64"
         assert block.source.media_type == "image/png"
-    
+
     def test_with_dict_url_source(self):
         """
         What it does: Verifies creation of ImageContentBlock with dict URL source.
@@ -276,18 +269,14 @@ class TestImageContentBlock:
         """
         print("Setup: Creating ImageContentBlock with dict URL source...")
         block = ImageContentBlock(
-            type="image",
-            source={
-                "type": "url",
-                "url": "https://example.com/test.gif"
-            }
+            type="image", source={"type": "url", "url": "https://example.com/test.gif"}
         )
-        
+
         print(f"Result: {block}")
         print(f"Comparing source.type: Expected 'url', Got '{block.source.type}'")
         assert block.source.type == "url"
         assert block.source.url == "https://example.com/test.gif"
-    
+
     def test_type_literal_is_image(self):
         """
         What it does: Verifies that type must be "image".
@@ -297,21 +286,21 @@ class TestImageContentBlock:
         block = ImageContentBlock(
             source=Base64ImageSource(media_type="image/jpeg", data=TEST_IMAGE_BASE64)
         )
-        
+
         print(f"Comparing type: Expected 'image', Got '{block.type}'")
         assert block.type == "image"
-    
+
     def test_requires_source(self):
         """
         What it does: Verifies that source is required.
         Purpose: Ensure validation fails without source.
         """
         print("Setup: Attempting to create ImageContentBlock without source...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ImageContentBlock(type="image")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "source" in str(exc_info.value)
 
@@ -320,9 +309,10 @@ class TestImageContentBlock:
 # Tests for ContentBlock Union
 # ==================================================================================================
 
+
 class TestContentBlockUnion:
     """Tests for ContentBlock union type accepting ImageContentBlock."""
-    
+
     def test_accepts_text_content_block(self):
         """
         What it does: Verifies ContentBlock accepts TextContentBlock.
@@ -330,17 +320,17 @@ class TestContentBlockUnion:
         """
         print("Setup: Creating TextContentBlock...")
         block: ContentBlock = TextContentBlock(text="Hello, world!")
-        
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'text', Got '{block.type}'")
         assert block.type == "text"
         assert block.text == "Hello, world!"
-    
+
     def test_accepts_image_content_block(self):
         """
         What it does: Verifies ContentBlock accepts ImageContentBlock.
         Purpose: Ensure union includes image blocks (Issue #30 fix).
-        
+
         This is the key test that verifies the fix for Issue #30.
         Before the fix, ContentBlock union did not include ImageContentBlock,
         causing 422 Validation Error when image content was sent.
@@ -349,12 +339,12 @@ class TestContentBlockUnion:
         block: ContentBlock = ImageContentBlock(
             source=Base64ImageSource(media_type="image/jpeg", data=TEST_IMAGE_BASE64)
         )
-        
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'image', Got '{block.type}'")
         assert block.type == "image"
         assert block.source.type == "base64"
-    
+
     def test_accepts_tool_use_content_block(self):
         """
         What it does: Verifies ContentBlock accepts ToolUseContentBlock.
@@ -362,15 +352,13 @@ class TestContentBlockUnion:
         """
         print("Setup: Creating ToolUseContentBlock...")
         block: ContentBlock = ToolUseContentBlock(
-            id="call_123",
-            name="get_weather",
-            input={"location": "Moscow"}
+            id="call_123", name="get_weather", input={"location": "Moscow"}
         )
-        
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'tool_use', Got '{block.type}'")
         assert block.type == "tool_use"
-    
+
     def test_accepts_tool_result_content_block(self):
         """
         What it does: Verifies ContentBlock accepts ToolResultContentBlock.
@@ -378,10 +366,9 @@ class TestContentBlockUnion:
         """
         print("Setup: Creating ToolResultContentBlock...")
         block: ContentBlock = ToolResultContentBlock(
-            tool_use_id="call_123",
-            content="Weather: Sunny, 25°C"
+            tool_use_id="call_123", content="Weather: Sunny, 25°C"
         )
-        
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'tool_result', Got '{block.type}'")
         assert block.type == "tool_result"
@@ -391,19 +378,20 @@ class TestContentBlockUnion:
 # Tests for AnthropicMessage with Image Content (Issue #30 fix verification)
 # ==================================================================================================
 
+
 class TestAnthropicMessageWithImages:
     """
     Tests for AnthropicMessage with image content.
-    
+
     These tests verify the fix for Issue #30 - 422 Validation Error
     when sending image content blocks in messages.
     """
-    
+
     def test_message_with_image_content_validates(self):
         """
         What it does: Verifies AnthropicMessage accepts image content blocks.
         Purpose: This is the PRIMARY test for Issue #30 fix.
-        
+
         Before the fix, this would raise a ValidationError because
         ContentBlock union did not include ImageContentBlock.
         """
@@ -414,31 +402,34 @@ class TestAnthropicMessageWithImages:
                 TextContentBlock(text="What's in this image?"),
                 ImageContentBlock(
                     source=Base64ImageSource(
-                        media_type="image/jpeg",
-                        data=TEST_IMAGE_BASE64
+                        media_type="image/jpeg", data=TEST_IMAGE_BASE64
                     )
-                )
-            ]
+                ),
+            ],
         )
-        
+
         print(f"Result: {message}")
         print(f"Comparing role: Expected 'user', Got '{message.role}'")
         assert message.role == "user"
-        
+
         print(f"Comparing content length: Expected 2, Got {len(message.content)}")
         assert len(message.content) == 2
-        
-        print(f"Comparing content[0].type: Expected 'text', Got '{message.content[0].type}'")
+
+        print(
+            f"Comparing content[0].type: Expected 'text', Got '{message.content[0].type}'"
+        )
         assert message.content[0].type == "text"
-        
-        print(f"Comparing content[1].type: Expected 'image', Got '{message.content[1].type}'")
+
+        print(
+            f"Comparing content[1].type: Expected 'image', Got '{message.content[1].type}'"
+        )
         assert message.content[1].type == "image"
-    
+
     def test_message_with_dict_image_content_validates(self):
         """
         What it does: Verifies AnthropicMessage accepts dict image content.
         Purpose: Ensure raw dict format (as received from API) validates correctly.
-        
+
         This is how the actual API request comes in - as raw dicts, not Pydantic models.
         """
         print("Setup: Creating AnthropicMessage with dict image content...")
@@ -451,20 +442,22 @@ class TestAnthropicMessageWithImages:
                     "source": {
                         "type": "base64",
                         "media_type": "image/png",
-                        "data": TEST_IMAGE_BASE64
-                    }
-                }
-            ]
+                        "data": TEST_IMAGE_BASE64,
+                    },
+                },
+            ],
         )
-        
+
         print(f"Result: {message}")
         print(f"Comparing content length: Expected 2, Got {len(message.content)}")
         assert len(message.content) == 2
-        
-        print(f"Comparing content[1].type: Expected 'image', Got '{message.content[1].type}'")
+
+        print(
+            f"Comparing content[1].type: Expected 'image', Got '{message.content[1].type}'"
+        )
         assert message.content[1].type == "image"
         assert message.content[1].source.type == "base64"
-    
+
     def test_message_with_multiple_images_validates(self):
         """
         What it does: Verifies AnthropicMessage accepts multiple images.
@@ -477,26 +470,38 @@ class TestAnthropicMessageWithImages:
                 {"type": "text", "text": "Compare these images"},
                 {
                     "type": "image",
-                    "source": {"type": "base64", "media_type": "image/jpeg", "data": TEST_IMAGE_BASE64}
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": TEST_IMAGE_BASE64,
+                    },
                 },
                 {
                     "type": "image",
-                    "source": {"type": "base64", "media_type": "image/png", "data": TEST_IMAGE_BASE64}
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": TEST_IMAGE_BASE64,
+                    },
                 },
                 {
                     "type": "image",
-                    "source": {"type": "base64", "media_type": "image/webp", "data": TEST_IMAGE_BASE64}
-                }
-            ]
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/webp",
+                        "data": TEST_IMAGE_BASE64,
+                    },
+                },
+            ],
         )
-        
+
         print(f"Result content length: {len(message.content)}")
         assert len(message.content) == 4
-        
+
         image_blocks = [b for b in message.content if b.type == "image"]
         print(f"Image blocks count: {len(image_blocks)}")
         assert len(image_blocks) == 3
-    
+
     def test_message_with_url_image_validates(self):
         """
         What it does: Verifies AnthropicMessage accepts URL image source.
@@ -509,16 +514,15 @@ class TestAnthropicMessageWithImages:
                 {"type": "text", "text": "What's in this image?"},
                 {
                     "type": "image",
-                    "source": {
-                        "type": "url",
-                        "url": "https://example.com/image.jpg"
-                    }
-                }
-            ]
+                    "source": {"type": "url", "url": "https://example.com/image.jpg"},
+                },
+            ],
         )
-        
+
         print(f"Result: {message}")
-        print(f"Comparing content[1].source.type: Expected 'url', Got '{message.content[1].source.type}'")
+        print(
+            f"Comparing content[1].source.type: Expected 'url', Got '{message.content[1].source.type}'"
+        )
         assert message.content[1].source.type == "url"
         assert message.content[1].source.url == "https://example.com/image.jpg"
 
@@ -527,14 +531,15 @@ class TestAnthropicMessageWithImages:
 # Tests for AnthropicMessagesRequest with Image Content
 # ==================================================================================================
 
+
 class TestAnthropicMessagesRequestWithImages:
     """Tests for full AnthropicMessagesRequest with image content."""
-    
+
     def test_request_with_image_message_validates(self):
         """
         What it does: Verifies full request with image content validates.
         Purpose: End-to-end validation test for Issue #30 fix.
-        
+
         This simulates the actual request that was failing with 422 error.
         """
         print("Setup: Creating full AnthropicMessagesRequest with image...")
@@ -551,26 +556,28 @@ class TestAnthropicMessagesRequestWithImages:
                             "source": {
                                 "type": "base64",
                                 "media_type": "image/jpeg",
-                                "data": TEST_IMAGE_BASE64
-                            }
-                        }
-                    ]
+                                "data": TEST_IMAGE_BASE64,
+                            },
+                        },
+                    ],
                 )
-            ]
+            ],
         )
-        
+
         print(f"Result: {request}")
         print(f"Comparing model: Expected 'claude-sonnet-4-5', Got '{request.model}'")
         assert request.model == "claude-sonnet-4-5"
-        
+
         print(f"Comparing messages count: Expected 1, Got {len(request.messages)}")
         assert len(request.messages) == 1
-        
-        print(f"Comparing content count: Expected 2, Got {len(request.messages[0].content)}")
+
+        print(
+            f"Comparing content count: Expected 2, Got {len(request.messages[0].content)}"
+        )
         assert len(request.messages[0].content) == 2
-        
+
         print("Request with image content validated successfully!")
-    
+
     def test_request_with_conversation_including_images(self):
         """
         What it does: Verifies multi-turn conversation with images validates.
@@ -590,34 +597,32 @@ class TestAnthropicMessagesRequestWithImages:
                             "source": {
                                 "type": "base64",
                                 "media_type": "image/jpeg",
-                                "data": TEST_IMAGE_BASE64
-                            }
-                        }
-                    ]
+                                "data": TEST_IMAGE_BASE64,
+                            },
+                        },
+                    ],
                 ),
                 AnthropicMessage(
-                    role="assistant",
-                    content="I can see a small test image."
+                    role="assistant", content="I can see a small test image."
                 ),
                 AnthropicMessage(
-                    role="user",
-                    content="Can you describe it in more detail?"
-                )
-            ]
+                    role="user", content="Can you describe it in more detail?"
+                ),
+            ],
         )
-        
+
         print(f"Result messages count: {len(request.messages)}")
         assert len(request.messages) == 3
-        
+
         # First message has image
         assert request.messages[0].content[1].type == "image"
-        
+
         # Second message is string (assistant)
         assert request.messages[1].content == "I can see a small test image."
-        
+
         # Third message is string (user follow-up)
         assert request.messages[2].content == "Can you describe it in more detail?"
-        
+
         print("Multi-turn conversation with images validated successfully!")
 
 
@@ -625,9 +630,10 @@ class TestAnthropicMessagesRequestWithImages:
 # Tests for TextContentBlock
 # ==================================================================================================
 
+
 class TestTextContentBlock:
     """Tests for TextContentBlock Pydantic model."""
-    
+
     def test_valid_text_block(self):
         """
         What it does: Verifies creation of valid TextContentBlock.
@@ -635,14 +641,14 @@ class TestTextContentBlock:
         """
         print("Setup: Creating TextContentBlock with valid text...")
         block = TextContentBlock(text="Hello, world!")
-        
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'text', Got '{block.type}'")
         assert block.type == "text"
-        
+
         print(f"Comparing text: Expected 'Hello, world!', Got '{block.text}'")
         assert block.text == "Hello, world!"
-    
+
     def test_type_defaults_to_text(self):
         """
         What it does: Verifies that type defaults to "text".
@@ -650,24 +656,24 @@ class TestTextContentBlock:
         """
         print("Setup: Creating TextContentBlock without explicit type...")
         block = TextContentBlock(text="Test")
-        
+
         print(f"Comparing type: Expected 'text', Got '{block.type}'")
         assert block.type == "text"
-    
+
     def test_requires_text(self):
         """
         What it does: Verifies that text is required.
         Purpose: Ensure validation fails without text.
         """
         print("Setup: Attempting to create TextContentBlock without text...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             TextContentBlock()
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "text" in str(exc_info.value)
-    
+
     def test_accepts_empty_string(self):
         """
         What it does: Verifies that empty string is accepted.
@@ -675,10 +681,10 @@ class TestTextContentBlock:
         """
         print("Setup: Creating TextContentBlock with empty string...")
         block = TextContentBlock(text="")
-        
+
         print(f"Comparing text: Expected '', Got '{block.text}'")
         assert block.text == ""
-    
+
     def test_accepts_multiline_text(self):
         """
         What it does: Verifies that multiline text is accepted.
@@ -687,7 +693,7 @@ class TestTextContentBlock:
         print("Setup: Creating TextContentBlock with multiline text...")
         multiline = "Line 1\nLine 2\nLine 3"
         block = TextContentBlock(text=multiline)
-        
+
         print(f"Comparing text: Expected multiline, Got '{block.text}'")
         assert block.text == multiline
         assert "\n" in block.text
@@ -697,9 +703,10 @@ class TestTextContentBlock:
 # Tests for ThinkingContentBlock
 # ==================================================================================================
 
+
 class TestThinkingContentBlock:
     """Tests for ThinkingContentBlock Pydantic model."""
-    
+
     def test_valid_thinking_block(self):
         """
         What it does: Verifies creation of valid ThinkingContentBlock.
@@ -707,20 +714,19 @@ class TestThinkingContentBlock:
         """
         print("Setup: Creating ThinkingContentBlock with valid thinking...")
         block = ThinkingContentBlock(
-            thinking="Let me analyze this step by step...",
-            signature="abc123"
+            thinking="Let me analyze this step by step...", signature="abc123"
         )
-        
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'thinking', Got '{block.type}'")
         assert block.type == "thinking"
-        
+
         print(f"Comparing thinking: Got '{block.thinking[:30]}...'")
         assert block.thinking == "Let me analyze this step by step..."
-        
+
         print(f"Comparing signature: Expected 'abc123', Got '{block.signature}'")
         assert block.signature == "abc123"
-    
+
     def test_type_defaults_to_thinking(self):
         """
         What it does: Verifies that type defaults to "thinking".
@@ -728,10 +734,10 @@ class TestThinkingContentBlock:
         """
         print("Setup: Creating ThinkingContentBlock without explicit type...")
         block = ThinkingContentBlock(thinking="Test thinking")
-        
+
         print(f"Comparing type: Expected 'thinking', Got '{block.type}'")
         assert block.type == "thinking"
-    
+
     def test_signature_defaults_to_empty(self):
         """
         What it does: Verifies that signature defaults to empty string.
@@ -739,21 +745,21 @@ class TestThinkingContentBlock:
         """
         print("Setup: Creating ThinkingContentBlock without signature...")
         block = ThinkingContentBlock(thinking="Test")
-        
+
         print(f"Comparing signature: Expected '', Got '{block.signature}'")
         assert block.signature == ""
-    
+
     def test_requires_thinking(self):
         """
         What it does: Verifies that thinking is required.
         Purpose: Ensure validation fails without thinking.
         """
         print("Setup: Attempting to create ThinkingContentBlock without thinking...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ThinkingContentBlock()
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "thinking" in str(exc_info.value)
 
@@ -762,9 +768,10 @@ class TestThinkingContentBlock:
 # Tests for ToolUseContentBlock
 # ==================================================================================================
 
+
 class TestToolUseContentBlock:
     """Tests for ToolUseContentBlock Pydantic model."""
-    
+
     def test_valid_tool_use_block(self):
         """
         What it does: Verifies creation of valid ToolUseContentBlock.
@@ -774,22 +781,22 @@ class TestToolUseContentBlock:
         block = ToolUseContentBlock(
             id="call_123",
             name="get_weather",
-            input={"location": "Moscow", "units": "celsius"}
+            input={"location": "Moscow", "units": "celsius"},
         )
-        
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'tool_use', Got '{block.type}'")
         assert block.type == "tool_use"
-        
+
         print(f"Comparing id: Expected 'call_123', Got '{block.id}'")
         assert block.id == "call_123"
-        
+
         print(f"Comparing name: Expected 'get_weather', Got '{block.name}'")
         assert block.name == "get_weather"
-        
+
         print(f"Comparing input: Got {block.input}")
         assert block.input == {"location": "Moscow", "units": "celsius"}
-    
+
     def test_type_defaults_to_tool_use(self):
         """
         What it does: Verifies that type defaults to "tool_use".
@@ -797,52 +804,52 @@ class TestToolUseContentBlock:
         """
         print("Setup: Creating ToolUseContentBlock without explicit type...")
         block = ToolUseContentBlock(id="call_1", name="test", input={})
-        
+
         print(f"Comparing type: Expected 'tool_use', Got '{block.type}'")
         assert block.type == "tool_use"
-    
+
     def test_requires_id(self):
         """
         What it does: Verifies that id is required.
         Purpose: Ensure validation fails without id.
         """
         print("Setup: Attempting to create ToolUseContentBlock without id...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ToolUseContentBlock(name="test", input={})
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "id" in str(exc_info.value)
-    
+
     def test_requires_name(self):
         """
         What it does: Verifies that name is required.
         Purpose: Ensure validation fails without name.
         """
         print("Setup: Attempting to create ToolUseContentBlock without name...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ToolUseContentBlock(id="call_1", input={})
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "name" in str(exc_info.value)
-    
+
     def test_requires_input(self):
         """
         What it does: Verifies that input is required.
         Purpose: Ensure validation fails without input.
         """
         print("Setup: Attempting to create ToolUseContentBlock without input...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ToolUseContentBlock(id="call_1", name="test")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "input" in str(exc_info.value)
-    
+
     def test_accepts_empty_input(self):
         """
         What it does: Verifies that empty input dict is accepted.
@@ -850,10 +857,10 @@ class TestToolUseContentBlock:
         """
         print("Setup: Creating ToolUseContentBlock with empty input...")
         block = ToolUseContentBlock(id="call_1", name="no_params_tool", input={})
-        
+
         print(f"Comparing input: Expected {{}}, Got {block.input}")
         assert block.input == {}
-    
+
     def test_accepts_complex_input(self):
         """
         What it does: Verifies that complex nested input is accepted.
@@ -863,10 +870,10 @@ class TestToolUseContentBlock:
         complex_input = {
             "query": "test",
             "options": {"limit": 10, "offset": 0},
-            "filters": ["active", "recent"]
+            "filters": ["active", "recent"],
         }
         block = ToolUseContentBlock(id="call_1", name="search", input=complex_input)
-        
+
         print(f"Comparing input: Got {block.input}")
         assert block.input == complex_input
 
@@ -875,9 +882,10 @@ class TestToolUseContentBlock:
 # Tests for ToolResultContentBlock
 # ==================================================================================================
 
+
 class TestToolResultContentBlock:
     """Tests for ToolResultContentBlock Pydantic model."""
-    
+
     def test_valid_tool_result_block(self):
         """
         What it does: Verifies creation of valid ToolResultContentBlock.
@@ -885,20 +893,19 @@ class TestToolResultContentBlock:
         """
         print("Setup: Creating ToolResultContentBlock with valid data...")
         block = ToolResultContentBlock(
-            tool_use_id="call_123",
-            content="Weather in Moscow: Sunny, 25°C"
+            tool_use_id="call_123", content="Weather in Moscow: Sunny, 25°C"
         )
-        
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'tool_result', Got '{block.type}'")
         assert block.type == "tool_result"
-        
+
         print(f"Comparing tool_use_id: Expected 'call_123', Got '{block.tool_use_id}'")
         assert block.tool_use_id == "call_123"
-        
+
         print(f"Comparing content: Got '{block.content}'")
         assert block.content == "Weather in Moscow: Sunny, 25°C"
-    
+
     def test_type_defaults_to_tool_result(self):
         """
         What it does: Verifies that type defaults to "tool_result".
@@ -906,24 +913,26 @@ class TestToolResultContentBlock:
         """
         print("Setup: Creating ToolResultContentBlock without explicit type...")
         block = ToolResultContentBlock(tool_use_id="call_1")
-        
+
         print(f"Comparing type: Expected 'tool_result', Got '{block.type}'")
         assert block.type == "tool_result"
-    
+
     def test_requires_tool_use_id(self):
         """
         What it does: Verifies that tool_use_id is required.
         Purpose: Ensure validation fails without tool_use_id.
         """
-        print("Setup: Attempting to create ToolResultContentBlock without tool_use_id...")
-        
+        print(
+            "Setup: Attempting to create ToolResultContentBlock without tool_use_id..."
+        )
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ToolResultContentBlock(content="Result")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "tool_use_id" in str(exc_info.value)
-    
+
     def test_content_is_optional(self):
         """
         What it does: Verifies that content is optional.
@@ -931,10 +940,10 @@ class TestToolResultContentBlock:
         """
         print("Setup: Creating ToolResultContentBlock without content...")
         block = ToolResultContentBlock(tool_use_id="call_1")
-        
+
         print(f"Comparing content: Expected None, Got {block.content}")
         assert block.content is None
-    
+
     def test_accepts_list_content(self):
         """
         What it does: Verifies that list content is accepted.
@@ -943,13 +952,13 @@ class TestToolResultContentBlock:
         print("Setup: Creating ToolResultContentBlock with list content...")
         block = ToolResultContentBlock(
             tool_use_id="call_1",
-            content=[TextContentBlock(text="Part 1"), TextContentBlock(text="Part 2")]
+            content=[TextContentBlock(text="Part 1"), TextContentBlock(text="Part 2")],
         )
-        
+
         print(f"Comparing content type: Expected list, Got {type(block.content)}")
         assert isinstance(block.content, list)
         assert len(block.content) == 2
-    
+
     def test_is_error_field(self):
         """
         What it does: Verifies that is_error field works.
@@ -957,14 +966,12 @@ class TestToolResultContentBlock:
         """
         print("Setup: Creating ToolResultContentBlock with is_error=True...")
         block = ToolResultContentBlock(
-            tool_use_id="call_1",
-            content="Error: File not found",
-            is_error=True
+            tool_use_id="call_1", content="Error: File not found", is_error=True
         )
-        
+
         print(f"Comparing is_error: Expected True, Got {block.is_error}")
         assert block.is_error is True
-    
+
     def test_is_error_defaults_to_none(self):
         """
         What it does: Verifies that is_error defaults to None.
@@ -972,7 +979,7 @@ class TestToolResultContentBlock:
         """
         print("Setup: Creating ToolResultContentBlock without is_error...")
         block = ToolResultContentBlock(tool_use_id="call_1", content="Success")
-        
+
         print(f"Comparing is_error: Expected None, Got {block.is_error}")
         assert block.is_error is None
 
@@ -981,9 +988,10 @@ class TestToolResultContentBlock:
 # Tests for AnthropicTool
 # ==================================================================================================
 
+
 class TestAnthropicTool:
     """Tests for AnthropicTool Pydantic model."""
-    
+
     def test_valid_tool(self):
         """
         What it does: Verifies creation of valid AnthropicTool.
@@ -998,48 +1006,48 @@ class TestAnthropicTool:
                 "properties": {
                     "location": {"type": "string", "description": "City name"}
                 },
-                "required": ["location"]
-            }
+                "required": ["location"],
+            },
         )
-        
+
         print(f"Result: {tool}")
         print(f"Comparing name: Expected 'get_weather', Got '{tool.name}'")
         assert tool.name == "get_weather"
-        
+
         print(f"Comparing description: Got '{tool.description}'")
         assert tool.description == "Get weather for a location"
-        
+
         print(f"Comparing input_schema: Got {tool.input_schema}")
         assert "properties" in tool.input_schema
-    
+
     def test_requires_name(self):
         """
         What it does: Verifies that name is required.
         Purpose: Ensure validation fails without name.
         """
         print("Setup: Attempting to create AnthropicTool without name...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             AnthropicTool(input_schema={})
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "name" in str(exc_info.value)
-    
+
     def test_requires_input_schema(self):
         """
         What it does: Verifies that input_schema is required.
         Purpose: Ensure validation fails without input_schema.
         """
         print("Setup: Attempting to create AnthropicTool without input_schema...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             AnthropicTool(name="test")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "input_schema" in str(exc_info.value)
-    
+
     def test_description_is_optional(self):
         """
         What it does: Verifies that description is optional.
@@ -1047,7 +1055,7 @@ class TestAnthropicTool:
         """
         print("Setup: Creating AnthropicTool without description...")
         tool = AnthropicTool(name="simple_tool", input_schema={})
-        
+
         print(f"Comparing description: Expected None, Got {tool.description}")
         assert tool.description is None
 
@@ -1056,9 +1064,10 @@ class TestAnthropicTool:
 # Tests for ToolChoice models
 # ==================================================================================================
 
+
 class TestToolChoiceModels:
     """Tests for ToolChoice Pydantic models."""
-    
+
     def test_tool_choice_auto(self):
         """
         What it does: Verifies creation of ToolChoiceAuto.
@@ -1066,11 +1075,11 @@ class TestToolChoiceModels:
         """
         print("Setup: Creating ToolChoiceAuto...")
         choice = ToolChoiceAuto()
-        
+
         print(f"Result: {choice}")
         print(f"Comparing type: Expected 'auto', Got '{choice.type}'")
         assert choice.type == "auto"
-    
+
     def test_tool_choice_any(self):
         """
         What it does: Verifies creation of ToolChoiceAny.
@@ -1078,11 +1087,11 @@ class TestToolChoiceModels:
         """
         print("Setup: Creating ToolChoiceAny...")
         choice = ToolChoiceAny()
-        
+
         print(f"Result: {choice}")
         print(f"Comparing type: Expected 'any', Got '{choice.type}'")
         assert choice.type == "any"
-    
+
     def test_tool_choice_tool(self):
         """
         What it does: Verifies creation of ToolChoiceTool.
@@ -1090,25 +1099,25 @@ class TestToolChoiceModels:
         """
         print("Setup: Creating ToolChoiceTool...")
         choice = ToolChoiceTool(name="get_weather")
-        
+
         print(f"Result: {choice}")
         print(f"Comparing type: Expected 'tool', Got '{choice.type}'")
         assert choice.type == "tool"
-        
+
         print(f"Comparing name: Expected 'get_weather', Got '{choice.name}'")
         assert choice.name == "get_weather"
-    
+
     def test_tool_choice_tool_requires_name(self):
         """
         What it does: Verifies that ToolChoiceTool requires name.
         Purpose: Ensure validation fails without name.
         """
         print("Setup: Attempting to create ToolChoiceTool without name...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ToolChoiceTool()
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "name" in str(exc_info.value)
 
@@ -1117,9 +1126,10 @@ class TestToolChoiceModels:
 # Tests for SystemContentBlock
 # ==================================================================================================
 
+
 class TestSystemContentBlock:
     """Tests for SystemContentBlock Pydantic model."""
-    
+
     def test_valid_system_block(self):
         """
         What it does: Verifies creation of valid SystemContentBlock.
@@ -1127,14 +1137,14 @@ class TestSystemContentBlock:
         """
         print("Setup: Creating SystemContentBlock with valid data...")
         block = SystemContentBlock(text="You are a helpful assistant.")
-        
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'text', Got '{block.type}'")
         assert block.type == "text"
-        
+
         print(f"Comparing text: Got '{block.text}'")
         assert block.text == "You are a helpful assistant."
-    
+
     def test_with_cache_control(self):
         """
         What it does: Verifies SystemContentBlock with cache_control.
@@ -1142,14 +1152,13 @@ class TestSystemContentBlock:
         """
         print("Setup: Creating SystemContentBlock with cache_control...")
         block = SystemContentBlock(
-            text="You are helpful.",
-            cache_control={"type": "ephemeral"}
+            text="You are helpful.", cache_control={"type": "ephemeral"}
         )
-        
+
         print(f"Result: {block}")
         print(f"Comparing cache_control: Got {block.cache_control}")
         assert block.cache_control == {"type": "ephemeral"}
-    
+
     def test_cache_control_is_optional(self):
         """
         What it does: Verifies that cache_control is optional.
@@ -1157,21 +1166,21 @@ class TestSystemContentBlock:
         """
         print("Setup: Creating SystemContentBlock without cache_control...")
         block = SystemContentBlock(text="Test")
-        
+
         print(f"Comparing cache_control: Expected None, Got {block.cache_control}")
         assert block.cache_control is None
-    
+
     def test_requires_text(self):
         """
         What it does: Verifies that text is required.
         Purpose: Ensure validation fails without text.
         """
         print("Setup: Attempting to create SystemContentBlock without text...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             SystemContentBlock()
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "text" in str(exc_info.value)
 
@@ -1180,9 +1189,10 @@ class TestSystemContentBlock:
 # Tests for AnthropicUsage
 # ==================================================================================================
 
+
 class TestAnthropicUsage:
     """Tests for AnthropicUsage Pydantic model."""
-    
+
     def test_valid_usage(self):
         """
         What it does: Verifies creation of valid AnthropicUsage.
@@ -1190,39 +1200,39 @@ class TestAnthropicUsage:
         """
         print("Setup: Creating AnthropicUsage with valid data...")
         usage = AnthropicUsage(input_tokens=100, output_tokens=50)
-        
+
         print(f"Result: {usage}")
         print(f"Comparing input_tokens: Expected 100, Got {usage.input_tokens}")
         assert usage.input_tokens == 100
-        
+
         print(f"Comparing output_tokens: Expected 50, Got {usage.output_tokens}")
         assert usage.output_tokens == 50
-    
+
     def test_requires_input_tokens(self):
         """
         What it does: Verifies that input_tokens is required.
         Purpose: Ensure validation fails without input_tokens.
         """
         print("Setup: Attempting to create AnthropicUsage without input_tokens...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             AnthropicUsage(output_tokens=50)
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "input_tokens" in str(exc_info.value)
-    
+
     def test_requires_output_tokens(self):
         """
         What it does: Verifies that output_tokens is required.
         Purpose: Ensure validation fails without output_tokens.
         """
         print("Setup: Attempting to create AnthropicUsage without output_tokens...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             AnthropicUsage(input_tokens=100)
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "output_tokens" in str(exc_info.value)
 
@@ -1231,9 +1241,10 @@ class TestAnthropicUsage:
 # Tests for AnthropicMessagesResponse
 # ==================================================================================================
 
+
 class TestAnthropicMessagesResponse:
     """Tests for AnthropicMessagesResponse Pydantic model."""
-    
+
     def test_valid_response(self):
         """
         What it does: Verifies creation of valid AnthropicMessagesResponse.
@@ -1244,22 +1255,22 @@ class TestAnthropicMessagesResponse:
             id="msg_123",
             model="claude-sonnet-4-5",
             content=[TextContentBlock(text="Hello!")],
-            usage=AnthropicUsage(input_tokens=10, output_tokens=5)
+            usage=AnthropicUsage(input_tokens=10, output_tokens=5),
         )
-        
+
         print(f"Result: {response}")
         print(f"Comparing id: Expected 'msg_123', Got '{response.id}'")
         assert response.id == "msg_123"
-        
+
         print(f"Comparing type: Expected 'message', Got '{response.type}'")
         assert response.type == "message"
-        
+
         print(f"Comparing role: Expected 'assistant', Got '{response.role}'")
         assert response.role == "assistant"
-        
+
         print(f"Comparing model: Expected 'claude-sonnet-4-5', Got '{response.model}'")
         assert response.model == "claude-sonnet-4-5"
-    
+
     def test_stop_reason_values(self):
         """
         What it does: Verifies that stop_reason accepts valid values.
@@ -1267,7 +1278,7 @@ class TestAnthropicMessagesResponse:
         """
         print("Setup: Testing various stop_reason values...")
         stop_reasons = ["end_turn", "max_tokens", "stop_sequence", "tool_use"]
-        
+
         for reason in stop_reasons:
             print(f"Testing stop_reason: {reason}")
             response = AnthropicMessagesResponse(
@@ -1275,12 +1286,12 @@ class TestAnthropicMessagesResponse:
                 model="claude-sonnet-4-5",
                 content=[TextContentBlock(text="Test")],
                 usage=AnthropicUsage(input_tokens=1, output_tokens=1),
-                stop_reason=reason
+                stop_reason=reason,
             )
             assert response.stop_reason == reason
-        
+
         print("All stop_reason values accepted successfully")
-    
+
     def test_stop_reason_is_optional(self):
         """
         What it does: Verifies that stop_reason is optional.
@@ -1291,9 +1302,9 @@ class TestAnthropicMessagesResponse:
             id="msg_1",
             model="claude-sonnet-4-5",
             content=[TextContentBlock(text="Test")],
-            usage=AnthropicUsage(input_tokens=1, output_tokens=1)
+            usage=AnthropicUsage(input_tokens=1, output_tokens=1),
         )
-        
+
         print(f"Comparing stop_reason: Expected None, Got {response.stop_reason}")
         assert response.stop_reason is None
 
@@ -1302,9 +1313,10 @@ class TestAnthropicMessagesResponse:
 # Tests for Streaming Event Models
 # ==================================================================================================
 
+
 class TestStreamingEvents:
     """Tests for streaming event Pydantic models."""
-    
+
     def test_message_start_event(self):
         """
         What it does: Verifies creation of MessageStartEvent.
@@ -1314,12 +1326,12 @@ class TestStreamingEvents:
         event = MessageStartEvent(
             message={"id": "msg_1", "type": "message", "role": "assistant"}
         )
-        
+
         print(f"Result: {event}")
         print(f"Comparing type: Expected 'message_start', Got '{event.type}'")
         assert event.type == "message_start"
         assert event.message["id"] == "msg_1"
-    
+
     def test_content_block_start_event(self):
         """
         What it does: Verifies creation of ContentBlockStartEvent.
@@ -1327,15 +1339,14 @@ class TestStreamingEvents:
         """
         print("Setup: Creating ContentBlockStartEvent...")
         event = ContentBlockStartEvent(
-            index=0,
-            content_block={"type": "text", "text": ""}
+            index=0, content_block={"type": "text", "text": ""}
         )
-        
+
         print(f"Result: {event}")
         print(f"Comparing type: Expected 'content_block_start', Got '{event.type}'")
         assert event.type == "content_block_start"
         assert event.index == 0
-    
+
     def test_text_delta(self):
         """
         What it does: Verifies creation of TextDelta.
@@ -1343,12 +1354,12 @@ class TestStreamingEvents:
         """
         print("Setup: Creating TextDelta...")
         delta = TextDelta(text="Hello")
-        
+
         print(f"Result: {delta}")
         print(f"Comparing type: Expected 'text_delta', Got '{delta.type}'")
         assert delta.type == "text_delta"
         assert delta.text == "Hello"
-    
+
     def test_thinking_delta(self):
         """
         What it does: Verifies creation of ThinkingDelta.
@@ -1356,12 +1367,12 @@ class TestStreamingEvents:
         """
         print("Setup: Creating ThinkingDelta...")
         delta = ThinkingDelta(thinking="Let me think...")
-        
+
         print(f"Result: {delta}")
         print(f"Comparing type: Expected 'thinking_delta', Got '{delta.type}'")
         assert delta.type == "thinking_delta"
         assert delta.thinking == "Let me think..."
-    
+
     def test_input_json_delta(self):
         """
         What it does: Verifies creation of InputJsonDelta.
@@ -1369,28 +1380,25 @@ class TestStreamingEvents:
         """
         print("Setup: Creating InputJsonDelta...")
         delta = InputJsonDelta(partial_json='{"loc')
-        
+
         print(f"Result: {delta}")
         print(f"Comparing type: Expected 'input_json_delta', Got '{delta.type}'")
         assert delta.type == "input_json_delta"
         assert delta.partial_json == '{"loc'
-    
+
     def test_content_block_delta_event(self):
         """
         What it does: Verifies creation of ContentBlockDeltaEvent.
         Purpose: Ensure content_block_delta event works.
         """
         print("Setup: Creating ContentBlockDeltaEvent...")
-        event = ContentBlockDeltaEvent(
-            index=0,
-            delta=TextDelta(text="Hello")
-        )
-        
+        event = ContentBlockDeltaEvent(index=0, delta=TextDelta(text="Hello"))
+
         print(f"Result: {event}")
         print(f"Comparing type: Expected 'content_block_delta', Got '{event.type}'")
         assert event.type == "content_block_delta"
         assert event.index == 0
-    
+
     def test_content_block_stop_event(self):
         """
         What it does: Verifies creation of ContentBlockStopEvent.
@@ -1398,12 +1406,12 @@ class TestStreamingEvents:
         """
         print("Setup: Creating ContentBlockStopEvent...")
         event = ContentBlockStopEvent(index=0)
-        
+
         print(f"Result: {event}")
         print(f"Comparing type: Expected 'content_block_stop', Got '{event.type}'")
         assert event.type == "content_block_stop"
         assert event.index == 0
-    
+
     def test_message_delta_event(self):
         """
         What it does: Verifies creation of MessageDeltaEvent.
@@ -1411,15 +1419,14 @@ class TestStreamingEvents:
         """
         print("Setup: Creating MessageDeltaEvent...")
         event = MessageDeltaEvent(
-            delta={"stop_reason": "end_turn"},
-            usage=MessageDeltaUsage(output_tokens=10)
+            delta={"stop_reason": "end_turn"}, usage=MessageDeltaUsage(output_tokens=10)
         )
-        
+
         print(f"Result: {event}")
         print(f"Comparing type: Expected 'message_delta', Got '{event.type}'")
         assert event.type == "message_delta"
         assert event.delta["stop_reason"] == "end_turn"
-    
+
     def test_message_stop_event(self):
         """
         What it does: Verifies creation of MessageStopEvent.
@@ -1427,11 +1434,11 @@ class TestStreamingEvents:
         """
         print("Setup: Creating MessageStopEvent...")
         event = MessageStopEvent()
-        
+
         print(f"Result: {event}")
         print(f"Comparing type: Expected 'message_stop', Got '{event.type}'")
         assert event.type == "message_stop"
-    
+
     def test_ping_event(self):
         """
         What it does: Verifies creation of PingEvent.
@@ -1439,11 +1446,11 @@ class TestStreamingEvents:
         """
         print("Setup: Creating PingEvent...")
         event = PingEvent()
-        
+
         print(f"Result: {event}")
         print(f"Comparing type: Expected 'ping', Got '{event.type}'")
         assert event.type == "ping"
-    
+
     def test_error_event(self):
         """
         What it does: Verifies creation of ErrorEvent.
@@ -1451,7 +1458,7 @@ class TestStreamingEvents:
         """
         print("Setup: Creating ErrorEvent...")
         event = ErrorEvent(error={"type": "invalid_request", "message": "Bad request"})
-        
+
         print(f"Result: {event}")
         print(f"Comparing type: Expected 'error', Got '{event.type}'")
         assert event.type == "error"
@@ -1462,9 +1469,10 @@ class TestStreamingEvents:
 # Tests for Error Models
 # ==================================================================================================
 
+
 class TestErrorModels:
     """Tests for error Pydantic models."""
-    
+
     def test_anthropic_error_detail(self):
         """
         What it does: Verifies creation of AnthropicErrorDetail.
@@ -1472,17 +1480,16 @@ class TestErrorModels:
         """
         print("Setup: Creating AnthropicErrorDetail...")
         detail = AnthropicErrorDetail(
-            type="invalid_request_error",
-            message="Invalid API key"
+            type="invalid_request_error", message="Invalid API key"
         )
-        
+
         print(f"Result: {detail}")
         print(f"Comparing type: Expected 'invalid_request_error', Got '{detail.type}'")
         assert detail.type == "invalid_request_error"
-        
+
         print(f"Comparing message: Got '{detail.message}'")
         assert detail.message == "Invalid API key"
-    
+
     def test_anthropic_error_response(self):
         """
         What it does: Verifies creation of AnthropicErrorResponse.
@@ -1491,14 +1498,13 @@ class TestErrorModels:
         print("Setup: Creating AnthropicErrorResponse...")
         response = AnthropicErrorResponse(
             error=AnthropicErrorDetail(
-                type="authentication_error",
-                message="Invalid API key provided"
+                type="authentication_error", message="Invalid API key provided"
             )
         )
-        
+
         print(f"Result: {response}")
         print(f"Comparing type: Expected 'error', Got '{response.type}'")
         assert response.type == "error"
-        
+
         print(f"Comparing error.type: Got '{response.error.type}'")
         assert response.error.type == "authentication_error"

--- a/tests/unit/test_models_openai.py
+++ b/tests/unit/test_models_openai.py
@@ -41,9 +41,10 @@ from kiro.models_openai import (
 # Tests for OpenAIModel
 # ==================================================================================================
 
+
 class TestOpenAIModel:
     """Tests for OpenAIModel Pydantic model."""
-    
+
     def test_valid_model(self):
         """
         What it does: Verifies creation of valid OpenAIModel.
@@ -51,37 +52,36 @@ class TestOpenAIModel:
         """
         print("Setup: Creating OpenAIModel with valid data...")
         model = OpenAIModel(
-            id="claude-sonnet-4-5",
-            description="Claude Sonnet 4.5 model"
+            id="claude-sonnet-4-5", description="Claude Sonnet 4.5 model"
         )
-        
+
         print(f"Result: {model}")
         print(f"Comparing id: Expected 'claude-sonnet-4-5', Got '{model.id}'")
         assert model.id == "claude-sonnet-4-5"
-        
+
         print(f"Comparing object: Expected 'model', Got '{model.object}'")
         assert model.object == "model"
-        
+
         print(f"Comparing owned_by: Expected 'anthropic', Got '{model.owned_by}'")
         assert model.owned_by == "anthropic"
-        
+
         print(f"Comparing description: Got '{model.description}'")
         assert model.description == "Claude Sonnet 4.5 model"
-    
+
     def test_requires_id(self):
         """
         What it does: Verifies that id is required.
         Purpose: Ensure validation fails without id.
         """
         print("Setup: Attempting to create OpenAIModel without id...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             OpenAIModel()
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "id" in str(exc_info.value)
-    
+
     def test_object_defaults_to_model(self):
         """
         What it does: Verifies that object defaults to "model".
@@ -89,10 +89,10 @@ class TestOpenAIModel:
         """
         print("Setup: Creating OpenAIModel without explicit object...")
         model = OpenAIModel(id="test-model")
-        
+
         print(f"Comparing object: Expected 'model', Got '{model.object}'")
         assert model.object == "model"
-    
+
     def test_owned_by_defaults_to_anthropic(self):
         """
         What it does: Verifies that owned_by defaults to "anthropic".
@@ -100,10 +100,10 @@ class TestOpenAIModel:
         """
         print("Setup: Creating OpenAIModel without explicit owned_by...")
         model = OpenAIModel(id="test-model")
-        
+
         print(f"Comparing owned_by: Expected 'anthropic', Got '{model.owned_by}'")
         assert model.owned_by == "anthropic"
-    
+
     def test_created_is_auto_generated(self):
         """
         What it does: Verifies that created timestamp is auto-generated.
@@ -111,11 +111,11 @@ class TestOpenAIModel:
         """
         print("Setup: Creating OpenAIModel without explicit created...")
         model = OpenAIModel(id="test-model")
-        
+
         print(f"Comparing created: Got {model.created}")
         assert model.created > 0
         assert isinstance(model.created, int)
-    
+
     def test_description_is_optional(self):
         """
         What it does: Verifies that description is optional.
@@ -123,7 +123,7 @@ class TestOpenAIModel:
         """
         print("Setup: Creating OpenAIModel without description...")
         model = OpenAIModel(id="test-model")
-        
+
         print(f"Comparing description: Expected None, Got {model.description}")
         assert model.description is None
 
@@ -132,9 +132,10 @@ class TestOpenAIModel:
 # Tests for ModelList
 # ==================================================================================================
 
+
 class TestModelList:
     """Tests for ModelList Pydantic model."""
-    
+
     def test_valid_model_list(self):
         """
         What it does: Verifies creation of valid ModelList.
@@ -142,19 +143,16 @@ class TestModelList:
         """
         print("Setup: Creating ModelList with valid data...")
         model_list = ModelList(
-            data=[
-                OpenAIModel(id="claude-sonnet-4-5"),
-                OpenAIModel(id="claude-opus-4")
-            ]
+            data=[OpenAIModel(id="claude-sonnet-4-5"), OpenAIModel(id="claude-opus-4")]
         )
-        
+
         print(f"Result: {model_list}")
         print(f"Comparing object: Expected 'list', Got '{model_list.object}'")
         assert model_list.object == "list"
-        
+
         print(f"Comparing data length: Expected 2, Got {len(model_list.data)}")
         assert len(model_list.data) == 2
-    
+
     def test_object_defaults_to_list(self):
         """
         What it does: Verifies that object defaults to "list".
@@ -162,24 +160,24 @@ class TestModelList:
         """
         print("Setup: Creating ModelList without explicit object...")
         model_list = ModelList(data=[])
-        
+
         print(f"Comparing object: Expected 'list', Got '{model_list.object}'")
         assert model_list.object == "list"
-    
+
     def test_requires_data(self):
         """
         What it does: Verifies that data is required.
         Purpose: Ensure validation fails without data.
         """
         print("Setup: Attempting to create ModelList without data...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ModelList()
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "data" in str(exc_info.value)
-    
+
     def test_accepts_empty_list(self):
         """
         What it does: Verifies that empty list is accepted.
@@ -187,7 +185,7 @@ class TestModelList:
         """
         print("Setup: Creating ModelList with empty data...")
         model_list = ModelList(data=[])
-        
+
         print(f"Comparing data: Expected [], Got {model_list.data}")
         assert model_list.data == []
 
@@ -196,9 +194,10 @@ class TestModelList:
 # Tests for ChatMessage
 # ==================================================================================================
 
+
 class TestChatMessage:
     """Tests for ChatMessage Pydantic model."""
-    
+
     def test_valid_user_message(self):
         """
         What it does: Verifies creation of valid user message.
@@ -206,14 +205,14 @@ class TestChatMessage:
         """
         print("Setup: Creating ChatMessage with user role...")
         message = ChatMessage(role="user", content="Hello!")
-        
+
         print(f"Result: {message}")
         print(f"Comparing role: Expected 'user', Got '{message.role}'")
         assert message.role == "user"
-        
+
         print(f"Comparing content: Expected 'Hello!', Got '{message.content}'")
         assert message.content == "Hello!"
-    
+
     def test_valid_assistant_message(self):
         """
         What it does: Verifies creation of valid assistant message.
@@ -221,11 +220,11 @@ class TestChatMessage:
         """
         print("Setup: Creating ChatMessage with assistant role...")
         message = ChatMessage(role="assistant", content="Hi there!")
-        
+
         print(f"Result: {message}")
         print(f"Comparing role: Expected 'assistant', Got '{message.role}'")
         assert message.role == "assistant"
-    
+
     def test_valid_system_message(self):
         """
         What it does: Verifies creation of valid system message.
@@ -233,11 +232,11 @@ class TestChatMessage:
         """
         print("Setup: Creating ChatMessage with system role...")
         message = ChatMessage(role="system", content="You are helpful.")
-        
+
         print(f"Result: {message}")
         print(f"Comparing role: Expected 'system', Got '{message.role}'")
         assert message.role == "system"
-    
+
     def test_valid_tool_message(self):
         """
         What it does: Verifies creation of valid tool message.
@@ -245,32 +244,32 @@ class TestChatMessage:
         """
         print("Setup: Creating ChatMessage with tool role...")
         message = ChatMessage(
-            role="tool",
-            content="Tool result",
-            tool_call_id="call_123"
+            role="tool", content="Tool result", tool_call_id="call_123"
         )
-        
+
         print(f"Result: {message}")
         print(f"Comparing role: Expected 'tool', Got '{message.role}'")
         assert message.role == "tool"
-        
-        print(f"Comparing tool_call_id: Expected 'call_123', Got '{message.tool_call_id}'")
+
+        print(
+            f"Comparing tool_call_id: Expected 'call_123', Got '{message.tool_call_id}'"
+        )
         assert message.tool_call_id == "call_123"
-    
+
     def test_requires_role(self):
         """
         What it does: Verifies that role is required.
         Purpose: Ensure validation fails without role.
         """
         print("Setup: Attempting to create ChatMessage without role...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ChatMessage(content="Hello")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "role" in str(exc_info.value)
-    
+
     def test_content_is_optional(self):
         """
         What it does: Verifies that content is optional.
@@ -278,10 +277,10 @@ class TestChatMessage:
         """
         print("Setup: Creating ChatMessage without content...")
         message = ChatMessage(role="assistant")
-        
+
         print(f"Comparing content: Expected None, Got {message.content}")
         assert message.content is None
-    
+
     def test_accepts_list_content(self):
         """
         What it does: Verifies that list content is accepted.
@@ -292,15 +291,18 @@ class TestChatMessage:
             role="user",
             content=[
                 {"type": "text", "text": "What's in this image?"},
-                {"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}}
-            ]
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/img.jpg"},
+                },
+            ],
         )
-        
+
         print(f"Result: {message}")
         print(f"Comparing content type: Expected list, Got {type(message.content)}")
         assert isinstance(message.content, list)
         assert len(message.content) == 2
-    
+
     def test_accepts_tool_calls(self):
         """
         What it does: Verifies that tool_calls is accepted.
@@ -310,18 +312,23 @@ class TestChatMessage:
         message = ChatMessage(
             role="assistant",
             content="I'll call a tool",
-            tool_calls=[{
-                "id": "call_123",
-                "type": "function",
-                "function": {"name": "get_weather", "arguments": '{"location": "Moscow"}'}
-            }]
+            tool_calls=[
+                {
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"location": "Moscow"}',
+                    },
+                }
+            ],
         )
-        
+
         print(f"Result: {message}")
         print(f"Comparing tool_calls: Got {message.tool_calls}")
         assert message.tool_calls is not None
         assert len(message.tool_calls) == 1
-    
+
     def test_name_is_optional(self):
         """
         What it does: Verifies that name is optional.
@@ -329,10 +336,10 @@ class TestChatMessage:
         """
         print("Setup: Creating ChatMessage without name...")
         message = ChatMessage(role="user", content="Hello")
-        
+
         print(f"Comparing name: Expected None, Got {message.name}")
         assert message.name is None
-    
+
     def test_accepts_name(self):
         """
         What it does: Verifies that name is accepted.
@@ -340,10 +347,10 @@ class TestChatMessage:
         """
         print("Setup: Creating ChatMessage with name...")
         message = ChatMessage(role="user", content="Hello", name="John")
-        
+
         print(f"Comparing name: Expected 'John', Got '{message.name}'")
         assert message.name == "John"
-    
+
     def test_extra_fields_allowed(self):
         """
         What it does: Verifies that extra fields are allowed.
@@ -351,7 +358,7 @@ class TestChatMessage:
         """
         print("Setup: Creating ChatMessage with extra field...")
         message = ChatMessage(role="user", content="Hello", custom_field="value")
-        
+
         print(f"Comparing custom_field: Got '{message.custom_field}'")
         assert message.custom_field == "value"
 
@@ -360,9 +367,10 @@ class TestChatMessage:
 # Tests for ToolFunction
 # ==================================================================================================
 
+
 class TestToolFunction:
     """Tests for ToolFunction Pydantic model."""
-    
+
     def test_valid_tool_function(self):
         """
         What it does: Verifies creation of valid ToolFunction.
@@ -374,34 +382,34 @@ class TestToolFunction:
             description="Get weather for a location",
             parameters={
                 "type": "object",
-                "properties": {"location": {"type": "string"}}
-            }
+                "properties": {"location": {"type": "string"}},
+            },
         )
-        
+
         print(f"Result: {func}")
         print(f"Comparing name: Expected 'get_weather', Got '{func.name}'")
         assert func.name == "get_weather"
-        
+
         print(f"Comparing description: Got '{func.description}'")
         assert func.description == "Get weather for a location"
-        
+
         print(f"Comparing parameters: Got {func.parameters}")
         assert "properties" in func.parameters
-    
+
     def test_requires_name(self):
         """
         What it does: Verifies that name is required.
         Purpose: Ensure validation fails without name.
         """
         print("Setup: Attempting to create ToolFunction without name...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ToolFunction(description="Test")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "name" in str(exc_info.value)
-    
+
     def test_description_is_optional(self):
         """
         What it does: Verifies that description is optional.
@@ -409,10 +417,10 @@ class TestToolFunction:
         """
         print("Setup: Creating ToolFunction without description...")
         func = ToolFunction(name="test_func")
-        
+
         print(f"Comparing description: Expected None, Got {func.description}")
         assert func.description is None
-    
+
     def test_parameters_is_optional(self):
         """
         What it does: Verifies that parameters is optional.
@@ -420,7 +428,7 @@ class TestToolFunction:
         """
         print("Setup: Creating ToolFunction without parameters...")
         func = ToolFunction(name="no_params_func")
-        
+
         print(f"Comparing parameters: Expected None, Got {func.parameters}")
         assert func.parameters is None
 
@@ -429,9 +437,10 @@ class TestToolFunction:
 # Tests for Tool
 # ==================================================================================================
 
+
 class TestTool:
     """Tests for Tool Pydantic model."""
-    
+
     def test_valid_tool(self):
         """
         What it does: Verifies creation of valid Tool.
@@ -441,19 +450,19 @@ class TestTool:
         tool = Tool(
             type="function",
             function=ToolFunction(
-                name="get_weather",
-                description="Get weather",
-                parameters={}
-            )
+                name="get_weather", description="Get weather", parameters={}
+            ),
         )
-        
+
         print(f"Result: {tool}")
         print(f"Comparing type: Expected 'function', Got '{tool.type}'")
         assert tool.type == "function"
-        
-        print(f"Comparing function.name: Expected 'get_weather', Got '{tool.function.name}'")
+
+        print(
+            f"Comparing function.name: Expected 'get_weather', Got '{tool.function.name}'"
+        )
         assert tool.function.name == "get_weather"
-    
+
     def test_type_defaults_to_function(self):
         """
         What it does: Verifies that type defaults to "function".
@@ -461,21 +470,21 @@ class TestTool:
         """
         print("Setup: Creating Tool without explicit type...")
         tool = Tool(function=ToolFunction(name="test"))
-        
+
         print(f"Comparing type: Expected 'function', Got '{tool.type}'")
         assert tool.type == "function"
-    
+
     def test_requires_function(self):
         """
         What it does: Verifies that function is required.
         Purpose: Ensure validation fails without function.
         """
         print("Setup: Attempting to create Tool without function...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             Tool(type="function")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "function" in str(exc_info.value)
 
@@ -484,9 +493,10 @@ class TestTool:
 # Tests for ChatCompletionRequest
 # ==================================================================================================
 
+
 class TestChatCompletionRequest:
     """Tests for ChatCompletionRequest Pydantic model."""
-    
+
     def test_valid_request(self):
         """
         What it does: Verifies creation of valid ChatCompletionRequest.
@@ -495,60 +505,62 @@ class TestChatCompletionRequest:
         print("Setup: Creating ChatCompletionRequest with valid data...")
         request = ChatCompletionRequest(
             model="claude-sonnet-4-5",
-            messages=[ChatMessage(role="user", content="Hello")]
+            messages=[ChatMessage(role="user", content="Hello")],
         )
-        
+
         print(f"Result: {request}")
         print(f"Comparing model: Expected 'claude-sonnet-4-5', Got '{request.model}'")
         assert request.model == "claude-sonnet-4-5"
-        
+
         print(f"Comparing messages length: Expected 1, Got {len(request.messages)}")
         assert len(request.messages) == 1
-        
+
         print(f"Comparing stream: Expected False, Got {request.stream}")
         assert request.stream is False
-    
+
     def test_requires_model(self):
         """
         What it does: Verifies that model is required.
         Purpose: Ensure validation fails without model.
         """
         print("Setup: Attempting to create ChatCompletionRequest without model...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ChatCompletionRequest(messages=[ChatMessage(role="user", content="Hi")])
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "model" in str(exc_info.value)
-    
+
     def test_requires_messages(self):
         """
         What it does: Verifies that messages is required.
         Purpose: Ensure validation fails without messages.
         """
         print("Setup: Attempting to create ChatCompletionRequest without messages...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ChatCompletionRequest(model="claude-sonnet-4-5")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "messages" in str(exc_info.value)
-    
+
     def test_requires_at_least_one_message(self):
         """
         What it does: Verifies that at least one message is required.
         Purpose: Ensure validation fails with empty messages.
         """
-        print("Setup: Attempting to create ChatCompletionRequest with empty messages...")
-        
+        print(
+            "Setup: Attempting to create ChatCompletionRequest with empty messages..."
+        )
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ChatCompletionRequest(model="claude-sonnet-4-5", messages=[])
-        
+
         print(f"ValidationError raised: {exc_info.value}")
-    
+
     def test_stream_defaults_to_false(self):
         """
         What it does: Verifies that stream defaults to False.
@@ -556,13 +568,12 @@ class TestChatCompletionRequest:
         """
         print("Setup: Creating ChatCompletionRequest without explicit stream...")
         request = ChatCompletionRequest(
-            model="test",
-            messages=[ChatMessage(role="user", content="Hi")]
+            model="test", messages=[ChatMessage(role="user", content="Hi")]
         )
-        
+
         print(f"Comparing stream: Expected False, Got {request.stream}")
         assert request.stream is False
-    
+
     def test_accepts_stream_true(self):
         """
         What it does: Verifies that stream=True is accepted.
@@ -570,14 +581,12 @@ class TestChatCompletionRequest:
         """
         print("Setup: Creating ChatCompletionRequest with stream=True...")
         request = ChatCompletionRequest(
-            model="test",
-            messages=[ChatMessage(role="user", content="Hi")],
-            stream=True
+            model="test", messages=[ChatMessage(role="user", content="Hi")], stream=True
         )
-        
+
         print(f"Comparing stream: Expected True, Got {request.stream}")
         assert request.stream is True
-    
+
     def test_accepts_tools(self):
         """
         What it does: Verifies that tools are accepted.
@@ -587,13 +596,13 @@ class TestChatCompletionRequest:
         request = ChatCompletionRequest(
             model="test",
             messages=[ChatMessage(role="user", content="Hi")],
-            tools=[Tool(function=ToolFunction(name="test_tool"))]
+            tools=[Tool(function=ToolFunction(name="test_tool"))],
         )
-        
+
         print(f"Comparing tools: Got {request.tools}")
         assert request.tools is not None
         assert len(request.tools) == 1
-    
+
     def test_accepts_generation_parameters(self):
         """
         What it does: Verifies that generation parameters are accepted.
@@ -605,15 +614,15 @@ class TestChatCompletionRequest:
             messages=[ChatMessage(role="user", content="Hi")],
             temperature=0.7,
             top_p=0.9,
-            max_tokens=1000
+            max_tokens=1000,
         )
-        
+
         print(f"Comparing temperature: Expected 0.7, Got {request.temperature}")
         assert request.temperature == 0.7
-        
+
         print(f"Comparing top_p: Expected 0.9, Got {request.top_p}")
         assert request.top_p == 0.9
-        
+
         print(f"Comparing max_tokens: Expected 1000, Got {request.max_tokens}")
         assert request.max_tokens == 1000
 
@@ -622,9 +631,10 @@ class TestChatCompletionRequest:
 # Tests for ChatCompletionUsage
 # ==================================================================================================
 
+
 class TestChatCompletionUsage:
     """Tests for ChatCompletionUsage Pydantic model."""
-    
+
     def test_valid_usage(self):
         """
         What it does: Verifies creation of valid ChatCompletionUsage.
@@ -632,21 +642,21 @@ class TestChatCompletionUsage:
         """
         print("Setup: Creating ChatCompletionUsage with valid data...")
         usage = ChatCompletionUsage(
-            prompt_tokens=100,
-            completion_tokens=50,
-            total_tokens=150
+            prompt_tokens=100, completion_tokens=50, total_tokens=150
         )
-        
+
         print(f"Result: {usage}")
         print(f"Comparing prompt_tokens: Expected 100, Got {usage.prompt_tokens}")
         assert usage.prompt_tokens == 100
-        
-        print(f"Comparing completion_tokens: Expected 50, Got {usage.completion_tokens}")
+
+        print(
+            f"Comparing completion_tokens: Expected 50, Got {usage.completion_tokens}"
+        )
         assert usage.completion_tokens == 50
-        
+
         print(f"Comparing total_tokens: Expected 150, Got {usage.total_tokens}")
         assert usage.total_tokens == 150
-    
+
     def test_defaults_to_zero(self):
         """
         What it does: Verifies that all fields default to 0.
@@ -654,16 +664,16 @@ class TestChatCompletionUsage:
         """
         print("Setup: Creating ChatCompletionUsage without explicit values...")
         usage = ChatCompletionUsage()
-        
+
         print(f"Comparing prompt_tokens: Expected 0, Got {usage.prompt_tokens}")
         assert usage.prompt_tokens == 0
-        
+
         print(f"Comparing completion_tokens: Expected 0, Got {usage.completion_tokens}")
         assert usage.completion_tokens == 0
-        
+
         print(f"Comparing total_tokens: Expected 0, Got {usage.total_tokens}")
         assert usage.total_tokens == 0
-    
+
     def test_credits_used_is_optional(self):
         """
         What it does: Verifies that credits_used is optional.
@@ -671,7 +681,7 @@ class TestChatCompletionUsage:
         """
         print("Setup: Creating ChatCompletionUsage without credits_used...")
         usage = ChatCompletionUsage()
-        
+
         print(f"Comparing credits_used: Expected None, Got {usage.credits_used}")
         assert usage.credits_used is None
 
@@ -680,9 +690,10 @@ class TestChatCompletionUsage:
 # Tests for ChatCompletionChoice
 # ==================================================================================================
 
+
 class TestChatCompletionChoice:
     """Tests for ChatCompletionChoice Pydantic model."""
-    
+
     def test_valid_choice(self):
         """
         What it does: Verifies creation of valid ChatCompletionChoice.
@@ -692,19 +703,19 @@ class TestChatCompletionChoice:
         choice = ChatCompletionChoice(
             index=0,
             message={"role": "assistant", "content": "Hello!"},
-            finish_reason="stop"
+            finish_reason="stop",
         )
-        
+
         print(f"Result: {choice}")
         print(f"Comparing index: Expected 0, Got {choice.index}")
         assert choice.index == 0
-        
+
         print(f"Comparing message: Got {choice.message}")
         assert choice.message["role"] == "assistant"
-        
+
         print(f"Comparing finish_reason: Expected 'stop', Got '{choice.finish_reason}'")
         assert choice.finish_reason == "stop"
-    
+
     def test_index_defaults_to_zero(self):
         """
         What it does: Verifies that index defaults to 0.
@@ -712,24 +723,24 @@ class TestChatCompletionChoice:
         """
         print("Setup: Creating ChatCompletionChoice without explicit index...")
         choice = ChatCompletionChoice(message={"role": "assistant", "content": "Hi"})
-        
+
         print(f"Comparing index: Expected 0, Got {choice.index}")
         assert choice.index == 0
-    
+
     def test_requires_message(self):
         """
         What it does: Verifies that message is required.
         Purpose: Ensure validation fails without message.
         """
         print("Setup: Attempting to create ChatCompletionChoice without message...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ChatCompletionChoice(index=0, finish_reason="stop")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "message" in str(exc_info.value)
-    
+
     def test_finish_reason_is_optional(self):
         """
         What it does: Verifies that finish_reason is optional.
@@ -737,7 +748,7 @@ class TestChatCompletionChoice:
         """
         print("Setup: Creating ChatCompletionChoice without finish_reason...")
         choice = ChatCompletionChoice(message={"role": "assistant", "content": "Hi"})
-        
+
         print(f"Comparing finish_reason: Expected None, Got {choice.finish_reason}")
         assert choice.finish_reason is None
 
@@ -746,9 +757,10 @@ class TestChatCompletionChoice:
 # Tests for ChatCompletionResponse
 # ==================================================================================================
 
+
 class TestChatCompletionResponse:
     """Tests for ChatCompletionResponse Pydantic model."""
-    
+
     def test_valid_response(self):
         """
         What it does: Verifies creation of valid ChatCompletionResponse.
@@ -758,26 +770,30 @@ class TestChatCompletionResponse:
         response = ChatCompletionResponse(
             id="chatcmpl-123",
             model="claude-sonnet-4-5",
-            choices=[ChatCompletionChoice(
-                message={"role": "assistant", "content": "Hello!"},
-                finish_reason="stop"
-            )],
-            usage=ChatCompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+            choices=[
+                ChatCompletionChoice(
+                    message={"role": "assistant", "content": "Hello!"},
+                    finish_reason="stop",
+                )
+            ],
+            usage=ChatCompletionUsage(
+                prompt_tokens=10, completion_tokens=5, total_tokens=15
+            ),
         )
-        
+
         print(f"Result: {response}")
         print(f"Comparing id: Expected 'chatcmpl-123', Got '{response.id}'")
         assert response.id == "chatcmpl-123"
-        
+
         print(f"Comparing object: Expected 'chat.completion', Got '{response.object}'")
         assert response.object == "chat.completion"
-        
+
         print(f"Comparing model: Expected 'claude-sonnet-4-5', Got '{response.model}'")
         assert response.model == "claude-sonnet-4-5"
-        
+
         print(f"Comparing choices length: Expected 1, Got {len(response.choices)}")
         assert len(response.choices) == 1
-    
+
     def test_object_defaults_to_chat_completion(self):
         """
         What it does: Verifies that object defaults to "chat.completion".
@@ -787,13 +803,15 @@ class TestChatCompletionResponse:
         response = ChatCompletionResponse(
             id="test",
             model="test",
-            choices=[ChatCompletionChoice(message={"role": "assistant", "content": "Hi"})],
-            usage=ChatCompletionUsage()
+            choices=[
+                ChatCompletionChoice(message={"role": "assistant", "content": "Hi"})
+            ],
+            usage=ChatCompletionUsage(),
         )
-        
+
         print(f"Comparing object: Expected 'chat.completion', Got '{response.object}'")
         assert response.object == "chat.completion"
-    
+
     def test_created_is_auto_generated(self):
         """
         What it does: Verifies that created timestamp is auto-generated.
@@ -803,29 +821,33 @@ class TestChatCompletionResponse:
         response = ChatCompletionResponse(
             id="test",
             model="test",
-            choices=[ChatCompletionChoice(message={"role": "assistant", "content": "Hi"})],
-            usage=ChatCompletionUsage()
+            choices=[
+                ChatCompletionChoice(message={"role": "assistant", "content": "Hi"})
+            ],
+            usage=ChatCompletionUsage(),
         )
-        
+
         print(f"Comparing created: Got {response.created}")
         assert response.created > 0
         assert isinstance(response.created, int)
-    
+
     def test_requires_id(self):
         """
         What it does: Verifies that id is required.
         Purpose: Ensure validation fails without id.
         """
         print("Setup: Attempting to create ChatCompletionResponse without id...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ChatCompletionResponse(
                 model="test",
-                choices=[ChatCompletionChoice(message={"role": "assistant", "content": "Hi"})],
-                usage=ChatCompletionUsage()
+                choices=[
+                    ChatCompletionChoice(message={"role": "assistant", "content": "Hi"})
+                ],
+                usage=ChatCompletionUsage(),
             )
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "id" in str(exc_info.value)
 
@@ -834,9 +856,10 @@ class TestChatCompletionResponse:
 # Tests for Streaming Models
 # ==================================================================================================
 
+
 class TestChatCompletionChunkDelta:
     """Tests for ChatCompletionChunkDelta Pydantic model."""
-    
+
     def test_valid_delta_with_content(self):
         """
         What it does: Verifies creation of valid delta with content.
@@ -844,11 +867,11 @@ class TestChatCompletionChunkDelta:
         """
         print("Setup: Creating ChatCompletionChunkDelta with content...")
         delta = ChatCompletionChunkDelta(content="Hello")
-        
+
         print(f"Result: {delta}")
         print(f"Comparing content: Expected 'Hello', Got '{delta.content}'")
         assert delta.content == "Hello"
-    
+
     def test_valid_delta_with_role(self):
         """
         What it does: Verifies creation of valid delta with role.
@@ -856,11 +879,11 @@ class TestChatCompletionChunkDelta:
         """
         print("Setup: Creating ChatCompletionChunkDelta with role...")
         delta = ChatCompletionChunkDelta(role="assistant")
-        
+
         print(f"Result: {delta}")
         print(f"Comparing role: Expected 'assistant', Got '{delta.role}'")
         assert delta.role == "assistant"
-    
+
     def test_all_fields_optional(self):
         """
         What it does: Verifies that all fields are optional.
@@ -868,16 +891,16 @@ class TestChatCompletionChunkDelta:
         """
         print("Setup: Creating empty ChatCompletionChunkDelta...")
         delta = ChatCompletionChunkDelta()
-        
+
         print(f"Comparing role: Expected None, Got {delta.role}")
         assert delta.role is None
-        
+
         print(f"Comparing content: Expected None, Got {delta.content}")
         assert delta.content is None
-        
+
         print(f"Comparing tool_calls: Expected None, Got {delta.tool_calls}")
         assert delta.tool_calls is None
-    
+
     def test_accepts_tool_calls(self):
         """
         What it does: Verifies that tool_calls is accepted.
@@ -887,7 +910,7 @@ class TestChatCompletionChunkDelta:
         delta = ChatCompletionChunkDelta(
             tool_calls=[{"index": 0, "id": "call_1", "function": {"name": "test"}}]
         )
-        
+
         print(f"Comparing tool_calls: Got {delta.tool_calls}")
         assert delta.tool_calls is not None
         assert len(delta.tool_calls) == 1
@@ -895,7 +918,7 @@ class TestChatCompletionChunkDelta:
 
 class TestChatCompletionChunkChoice:
     """Tests for ChatCompletionChunkChoice Pydantic model."""
-    
+
     def test_valid_chunk_choice(self):
         """
         What it does: Verifies creation of valid chunk choice.
@@ -903,17 +926,18 @@ class TestChatCompletionChunkChoice:
         """
         print("Setup: Creating ChatCompletionChunkChoice with valid data...")
         choice = ChatCompletionChunkChoice(
-            index=0,
-            delta=ChatCompletionChunkDelta(content="Hello")
+            index=0, delta=ChatCompletionChunkDelta(content="Hello")
         )
-        
+
         print(f"Result: {choice}")
         print(f"Comparing index: Expected 0, Got {choice.index}")
         assert choice.index == 0
-        
-        print(f"Comparing delta.content: Expected 'Hello', Got '{choice.delta.content}'")
+
+        print(
+            f"Comparing delta.content: Expected 'Hello', Got '{choice.delta.content}'"
+        )
         assert choice.delta.content == "Hello"
-    
+
     def test_index_defaults_to_zero(self):
         """
         What it does: Verifies that index defaults to 0.
@@ -921,10 +945,10 @@ class TestChatCompletionChunkChoice:
         """
         print("Setup: Creating ChatCompletionChunkChoice without explicit index...")
         choice = ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta())
-        
+
         print(f"Comparing index: Expected 0, Got {choice.index}")
         assert choice.index == 0
-    
+
     def test_finish_reason_is_optional(self):
         """
         What it does: Verifies that finish_reason is optional.
@@ -932,10 +956,10 @@ class TestChatCompletionChunkChoice:
         """
         print("Setup: Creating ChatCompletionChunkChoice without finish_reason...")
         choice = ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta(content="Hi"))
-        
+
         print(f"Comparing finish_reason: Expected None, Got {choice.finish_reason}")
         assert choice.finish_reason is None
-    
+
     def test_accepts_finish_reason(self):
         """
         What it does: Verifies that finish_reason is accepted.
@@ -943,17 +967,16 @@ class TestChatCompletionChunkChoice:
         """
         print("Setup: Creating ChatCompletionChunkChoice with finish_reason...")
         choice = ChatCompletionChunkChoice(
-            delta=ChatCompletionChunkDelta(),
-            finish_reason="stop"
+            delta=ChatCompletionChunkDelta(), finish_reason="stop"
         )
-        
+
         print(f"Comparing finish_reason: Expected 'stop', Got '{choice.finish_reason}'")
         assert choice.finish_reason == "stop"
 
 
 class TestChatCompletionChunk:
     """Tests for ChatCompletionChunk Pydantic model."""
-    
+
     def test_valid_chunk(self):
         """
         What it does: Verifies creation of valid chunk.
@@ -963,21 +986,25 @@ class TestChatCompletionChunk:
         chunk = ChatCompletionChunk(
             id="chatcmpl-123",
             model="claude-sonnet-4-5",
-            choices=[ChatCompletionChunkChoice(
-                delta=ChatCompletionChunkDelta(content="Hello")
-            )]
+            choices=[
+                ChatCompletionChunkChoice(
+                    delta=ChatCompletionChunkDelta(content="Hello")
+                )
+            ],
         )
-        
+
         print(f"Result: {chunk}")
         print(f"Comparing id: Expected 'chatcmpl-123', Got '{chunk.id}'")
         assert chunk.id == "chatcmpl-123"
-        
-        print(f"Comparing object: Expected 'chat.completion.chunk', Got '{chunk.object}'")
+
+        print(
+            f"Comparing object: Expected 'chat.completion.chunk', Got '{chunk.object}'"
+        )
         assert chunk.object == "chat.completion.chunk"
-        
+
         print(f"Comparing model: Expected 'claude-sonnet-4-5', Got '{chunk.model}'")
         assert chunk.model == "claude-sonnet-4-5"
-    
+
     def test_object_defaults_to_chunk(self):
         """
         What it does: Verifies that object defaults to "chat.completion.chunk".
@@ -987,12 +1014,14 @@ class TestChatCompletionChunk:
         chunk = ChatCompletionChunk(
             id="test",
             model="test",
-            choices=[ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta())]
+            choices=[ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta())],
         )
-        
-        print(f"Comparing object: Expected 'chat.completion.chunk', Got '{chunk.object}'")
+
+        print(
+            f"Comparing object: Expected 'chat.completion.chunk', Got '{chunk.object}'"
+        )
         assert chunk.object == "chat.completion.chunk"
-    
+
     def test_usage_is_optional(self):
         """
         What it does: Verifies that usage is optional.
@@ -1002,12 +1031,12 @@ class TestChatCompletionChunk:
         chunk = ChatCompletionChunk(
             id="test",
             model="test",
-            choices=[ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta())]
+            choices=[ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta())],
         )
-        
+
         print(f"Comparing usage: Expected None, Got {chunk.usage}")
         assert chunk.usage is None
-    
+
     def test_accepts_usage(self):
         """
         What it does: Verifies that usage is accepted.
@@ -1017,13 +1046,16 @@ class TestChatCompletionChunk:
         chunk = ChatCompletionChunk(
             id="test",
             model="test",
-            choices=[ChatCompletionChunkChoice(
-                delta=ChatCompletionChunkDelta(),
-                finish_reason="stop"
-            )],
-            usage=ChatCompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+            choices=[
+                ChatCompletionChunkChoice(
+                    delta=ChatCompletionChunkDelta(), finish_reason="stop"
+                )
+            ],
+            usage=ChatCompletionUsage(
+                prompt_tokens=10, completion_tokens=5, total_tokens=15
+            ),
         )
-        
+
         print(f"Comparing usage: Got {chunk.usage}")
         assert chunk.usage is not None
         assert chunk.usage.total_tokens == 15

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -5,19 +5,17 @@ Unit-тесты для AwsEventStreamParser и вспомогательных ф
 Проверяет логику парсинга AWS SSE потока от Kiro API.
 """
 
-import pytest
-
 from kiro.parsers import (
     AwsEventStreamParser,
     find_matching_brace,
     parse_bracket_tool_calls,
-    deduplicate_tool_calls
+    deduplicate_tool_calls,
 )
 
 
 class TestFindMatchingBrace:
     """Тесты функции find_matching_brace."""
-    
+
     def test_simple_json_object(self):
         """
         Что он делает: Проверяет поиск закрывающей скобки для простого JSON.
@@ -25,13 +23,13 @@ class TestFindMatchingBrace:
         """
         print("Настройка: Простой JSON объект...")
         text = '{"key": "value"}'
-        
+
         print("Действие: Поиск закрывающей скобки...")
         result = find_matching_brace(text, 0)
-        
+
         print(f"Сравниваем результат: Ожидалось 15, Получено {result}")
         assert result == 15
-    
+
     def test_nested_json_object(self):
         """
         Что он делает: Проверяет поиск для вложенного JSON.
@@ -39,14 +37,14 @@ class TestFindMatchingBrace:
         """
         print("Настройка: Вложенный JSON объект...")
         text = '{"outer": {"inner": "value"}}'
-        
+
         print("Действие: Поиск закрывающей скобки...")
         result = find_matching_brace(text, 0)
-        
+
         # Длина строки 29, индекс последнего символа 28
         print(f"Сравниваем результат: Ожидалось 28, Получено {result}")
         assert result == 28
-    
+
     def test_json_with_braces_in_string(self):
         """
         Что он делает: Проверяет игнорирование скобок внутри строк.
@@ -54,13 +52,13 @@ class TestFindMatchingBrace:
         """
         print("Настройка: JSON со скобками в строке...")
         text = '{"text": "Hello {world}"}'
-        
+
         print("Действие: Поиск закрывающей скобки...")
         result = find_matching_brace(text, 0)
-        
+
         print(f"Сравниваем результат: Ожидалось 24, Получено {result}")
         assert result == 24
-    
+
     def test_json_with_escaped_quotes(self):
         """
         Что он делает: Проверяет обработку экранированных кавычек.
@@ -68,14 +66,14 @@ class TestFindMatchingBrace:
         """
         print("Настройка: JSON с экранированными кавычками...")
         text = '{"text": "Say \\"hello\\""}'
-        
+
         print("Действие: Поиск закрывающей скобки...")
         result = find_matching_brace(text, 0)
-        
+
         # Длина строки 25, индекс последнего символа 24
         print(f"Сравниваем результат: Ожидалось 24, Получено {result}")
         assert result == 24
-    
+
     def test_incomplete_json(self):
         """
         Что он делает: Проверяет обработку незавершённого JSON.
@@ -83,13 +81,13 @@ class TestFindMatchingBrace:
         """
         print("Настройка: Незавершённый JSON...")
         text = '{"key": "value"'
-        
+
         print("Действие: Поиск закрывающей скобки...")
         result = find_matching_brace(text, 0)
-        
+
         print(f"Сравниваем результат: Ожидалось -1, Получено {result}")
         assert result == -1
-    
+
     def test_invalid_start_position(self):
         """
         Что он делает: Проверяет обработку невалидной стартовой позиции.
@@ -97,13 +95,13 @@ class TestFindMatchingBrace:
         """
         print("Настройка: Текст без скобки на start_pos...")
         text = 'hello {"key": "value"}'
-        
+
         print("Действие: Поиск с позиции 0 (не скобка)...")
         result = find_matching_brace(text, 0)
-        
+
         print(f"Сравниваем результат: Ожидалось -1, Получено {result}")
         assert result == -1
-    
+
     def test_start_position_out_of_bounds(self):
         """
         Что он делает: Проверяет обработку позиции за пределами текста.
@@ -111,17 +109,17 @@ class TestFindMatchingBrace:
         """
         print("Настройка: Короткий текст...")
         text = '{"a":1}'
-        
+
         print("Действие: Поиск с позиции 100...")
         result = find_matching_brace(text, 100)
-        
+
         print(f"Сравниваем результат: Ожидалось -1, Получено {result}")
         assert result == -1
 
 
 class TestParseBracketToolCalls:
     """Тесты функции parse_bracket_tool_calls."""
-    
+
     def test_parses_single_tool_call(self):
         """
         Что он делает: Проверяет парсинг одного tool call.
@@ -129,35 +127,35 @@ class TestParseBracketToolCalls:
         """
         print("Настройка: Текст с одним tool call...")
         text = '[Called get_weather with args: {"location": "Moscow"}]'
-        
+
         print("Действие: Парсинг tool calls...")
         result = parse_bracket_tool_calls(text)
-        
+
         print(f"Результат: {result}")
         assert len(result) == 1
         assert result[0]["function"]["name"] == "get_weather"
         assert '"location"' in result[0]["function"]["arguments"]
-    
+
     def test_parses_multiple_tool_calls(self):
         """
         Что он делает: Проверяет парсинг нескольких tool calls.
         Цель: Убедиться, что все tool calls извлекаются.
         """
         print("Настройка: Текст с несколькими tool calls...")
-        text = '''
+        text = """
         [Called get_weather with args: {"location": "Moscow"}]
         Some text in between
         [Called get_time with args: {"timezone": "UTC"}]
-        '''
-        
+        """
+
         print("Действие: Парсинг tool calls...")
         result = parse_bracket_tool_calls(text)
-        
+
         print(f"Результат: {result}")
         assert len(result) == 2
         assert result[0]["function"]["name"] == "get_weather"
         assert result[1]["function"]["name"] == "get_time"
-    
+
     def test_returns_empty_for_no_tool_calls(self):
         """
         Что он делает: Проверяет возврат пустого списка без tool calls.
@@ -165,69 +163,71 @@ class TestParseBracketToolCalls:
         """
         print("Настройка: Обычный текст без tool calls...")
         text = "This is just regular text without any tool calls."
-        
+
         print("Действие: Парсинг tool calls...")
         result = parse_bracket_tool_calls(text)
-        
+
         print(f"Сравниваем результат: Ожидалось [], Получено {result}")
         assert result == []
-    
+
     def test_returns_empty_for_empty_string(self):
         """
         Что он делает: Проверяет обработку пустой строки.
         Цель: Убедиться, что пустая строка не вызывает ошибок.
         """
         print("Настройка: Пустая строка...")
-        
+
         print("Действие: Парсинг tool calls...")
         result = parse_bracket_tool_calls("")
-        
+
         print(f"Сравниваем результат: Ожидалось [], Получено {result}")
         assert result == []
-    
+
     def test_returns_empty_for_none(self):
         """
         Что он делает: Проверяет обработку None.
         Цель: Убедиться, что None не вызывает ошибок.
         """
         print("Настройка: None...")
-        
+
         print("Действие: Парсинг tool calls...")
         result = parse_bracket_tool_calls(None)
-        
+
         print(f"Сравниваем результат: Ожидалось [], Получено {result}")
         assert result == []
-    
+
     def test_handles_nested_json_in_args(self):
         """
         Что он делает: Проверяет парсинг вложенного JSON в аргументах.
         Цель: Убедиться, что сложные аргументы парсятся корректно.
         """
         print("Настройка: Tool call с вложенным JSON...")
-        text = '[Called complex_func with args: {"data": {"nested": {"deep": "value"}}}]'
-        
+        text = (
+            '[Called complex_func with args: {"data": {"nested": {"deep": "value"}}}]'
+        )
+
         print("Действие: Парсинг tool calls...")
         result = parse_bracket_tool_calls(text)
-        
+
         print(f"Результат: {result}")
         assert len(result) == 1
         assert result[0]["function"]["name"] == "complex_func"
         assert "nested" in result[0]["function"]["arguments"]
-    
+
     def test_generates_unique_ids(self):
         """
         Что он делает: Проверяет генерацию уникальных ID для tool calls.
         Цель: Убедиться, что каждый tool call имеет уникальный ID.
         """
         print("Настройка: Два одинаковых tool calls...")
-        text = '''
+        text = """
         [Called func with args: {"a": 1}]
         [Called func with args: {"a": 1}]
-        '''
-        
+        """
+
         print("Действие: Парсинг tool calls...")
         result = parse_bracket_tool_calls(text)
-        
+
         print(f"IDs: {[r['id'] for r in result]}")
         assert len(result) == 2
         assert result[0]["id"] != result[1]["id"]
@@ -235,7 +235,7 @@ class TestParseBracketToolCalls:
 
 class TestDeduplicateToolCalls:
     """Тесты функции deduplicate_tool_calls."""
-    
+
     def test_removes_duplicates(self):
         """
         Что он делает: Проверяет удаление дубликатов.
@@ -247,13 +247,13 @@ class TestDeduplicateToolCalls:
             {"id": "2", "function": {"name": "func", "arguments": '{"a": 1}'}},
             {"id": "3", "function": {"name": "other", "arguments": '{"b": 2}'}},
         ]
-        
+
         print("Действие: Дедупликация...")
         result = deduplicate_tool_calls(tool_calls)
-        
+
         print(f"Сравниваем длину: Ожидалось 2, Получено {len(result)}")
         assert len(result) == 2
-    
+
     def test_preserves_first_occurrence(self):
         """
         Что он делает: Проверяет сохранение первого вхождения.
@@ -264,47 +264,52 @@ class TestDeduplicateToolCalls:
             {"id": "first", "function": {"name": "func", "arguments": '{"a": 1}'}},
             {"id": "second", "function": {"name": "func", "arguments": '{"a": 1}'}},
         ]
-        
+
         print("Действие: Дедупликация...")
         result = deduplicate_tool_calls(tool_calls)
-        
+
         print(f"Сравниваем ID: Ожидалось 'first', Получено '{result[0]['id']}'")
         assert result[0]["id"] == "first"
-    
+
     def test_handles_empty_list(self):
         """
         Что он делает: Проверяет обработку пустого списка.
         Цель: Убедиться, что пустой список не вызывает ошибок.
         """
         print("Настройка: Пустой список...")
-        
+
         print("Действие: Дедупликация...")
         result = deduplicate_tool_calls([])
-        
+
         print(f"Сравниваем результат: Ожидалось [], Получено {result}")
         assert result == []
-    
+
     def test_deduplicates_by_id_keeps_one_with_arguments(self):
         """
         Что он делает: Проверяет дедупликацию по id с сохранением tool call с аргументами.
         Цель: Убедиться, что при дубликатах по id сохраняется тот, у которого есть аргументы.
         """
-        print("Настройка: Два tool calls с одинаковым id, один с аргументами, один пустой...")
+        print(
+            "Настройка: Два tool calls с одинаковым id, один с аргументами, один пустой..."
+        )
         tool_calls = [
             {"id": "call_123", "function": {"name": "func", "arguments": "{}"}},
-            {"id": "call_123", "function": {"name": "func", "arguments": '{"location": "Moscow"}'}},
+            {
+                "id": "call_123",
+                "function": {"name": "func", "arguments": '{"location": "Moscow"}'},
+            },
         ]
-        
+
         print("Действие: Дедупликация...")
         result = deduplicate_tool_calls(tool_calls)
-        
+
         print(f"Результат: {result}")
         print(f"Сравниваем длину: Ожидалось 1, Получено {len(result)}")
         assert len(result) == 1
-        
+
         print("Проверяем, что сохранился tool call с аргументами...")
         assert "Moscow" in result[0]["function"]["arguments"]
-    
+
     def test_deduplicates_by_id_prefers_longer_arguments(self):
         """
         Что он делает: Проверяет, что при дубликатах по id предпочитаются более длинные аргументы.
@@ -312,37 +317,51 @@ class TestDeduplicateToolCalls:
         """
         print("Настройка: Два tool calls с одинаковым id, разной длины аргументов...")
         tool_calls = [
-            {"id": "call_abc", "function": {"name": "search", "arguments": '{"q": "test"}'}},
-            {"id": "call_abc", "function": {"name": "search", "arguments": '{"q": "test", "limit": 10, "offset": 0}'}},
+            {
+                "id": "call_abc",
+                "function": {"name": "search", "arguments": '{"q": "test"}'},
+            },
+            {
+                "id": "call_abc",
+                "function": {
+                    "name": "search",
+                    "arguments": '{"q": "test", "limit": 10, "offset": 0}',
+                },
+            },
         ]
-        
+
         print("Действие: Дедупликация...")
         result = deduplicate_tool_calls(tool_calls)
-        
+
         print(f"Результат: {result}")
         assert len(result) == 1
-        
+
         print("Проверяем, что сохранился tool call с более длинными аргументами...")
         assert "limit" in result[0]["function"]["arguments"]
-    
+
     def test_deduplicates_empty_arguments_replaced_by_non_empty(self):
         """
         Что он делает: Проверяет замену пустых аргументов на непустые.
         Цель: Убедиться, что "{}" заменяется на реальные аргументы.
         """
-        print("Настройка: Первый tool call с пустыми аргументами, второй с реальными...")
+        print(
+            "Настройка: Первый tool call с пустыми аргументами, второй с реальными..."
+        )
         tool_calls = [
             {"id": "call_xyz", "function": {"name": "get_weather", "arguments": "{}"}},
-            {"id": "call_xyz", "function": {"name": "get_weather", "arguments": '{"city": "London"}'}},
+            {
+                "id": "call_xyz",
+                "function": {"name": "get_weather", "arguments": '{"city": "London"}'},
+            },
         ]
-        
+
         print("Действие: Дедупликация...")
         result = deduplicate_tool_calls(tool_calls)
-        
+
         print(f"Результат: {result}")
         assert len(result) == 1
         assert result[0]["function"]["arguments"] == '{"city": "London"}'
-    
+
     def test_handles_tool_calls_without_id(self):
         """
         Что он делает: Проверяет обработку tool calls без id.
@@ -354,14 +373,14 @@ class TestDeduplicateToolCalls:
             {"id": "", "function": {"name": "func", "arguments": '{"a": 1}'}},
             {"id": "", "function": {"name": "func", "arguments": '{"b": 2}'}},
         ]
-        
+
         print("Действие: Дедупликация...")
         result = deduplicate_tool_calls(tool_calls)
-        
+
         print(f"Результат: {result}")
         # Два уникальных по name+arguments
         assert len(result) == 2
-    
+
     def test_mixed_with_and_without_id(self):
         """
         Что он делает: Проверяет смешанный список с id и без.
@@ -370,18 +389,24 @@ class TestDeduplicateToolCalls:
         print("Настройка: Смешанный список...")
         tool_calls = [
             {"id": "call_1", "function": {"name": "func1", "arguments": '{"x": 1}'}},
-            {"id": "call_1", "function": {"name": "func1", "arguments": "{}"}},  # Дубликат по id
+            {
+                "id": "call_1",
+                "function": {"name": "func1", "arguments": "{}"},
+            },  # Дубликат по id
             {"id": "", "function": {"name": "func2", "arguments": '{"y": 2}'}},
-            {"id": "", "function": {"name": "func2", "arguments": '{"y": 2}'}},  # Дубликат по name+args
+            {
+                "id": "",
+                "function": {"name": "func2", "arguments": '{"y": 2}'},
+            },  # Дубликат по name+args
         ]
-        
+
         print("Действие: Дедупликация...")
         result = deduplicate_tool_calls(tool_calls)
-        
+
         print(f"Результат: {result}")
         # call_1 с аргументами + func2 один раз
         assert len(result) == 2
-        
+
         # Проверяем, что call_1 сохранил аргументы
         call_1 = next(tc for tc in result if tc["id"] == "call_1")
         assert call_1["function"]["arguments"] == '{"x": 1}'
@@ -389,7 +414,7 @@ class TestDeduplicateToolCalls:
 
 class TestAwsEventStreamParserInitialization:
     """Тесты инициализации AwsEventStreamParser."""
-    
+
     def test_initialization_creates_empty_state(self):
         """
         Что он делает: Проверяет начальное состояние парсера.
@@ -397,23 +422,23 @@ class TestAwsEventStreamParserInitialization:
         """
         print("Настройка: Создание парсера...")
         parser = AwsEventStreamParser()
-        
+
         print("Проверка: Буфер пуст...")
         assert parser.buffer == ""
-        
+
         print("Проверка: last_content is None...")
         assert parser.last_content is None
-        
+
         print("Проверка: current_tool_call is None...")
         assert parser.current_tool_call is None
-        
+
         print("Проверка: tool_calls пуст...")
         assert parser.tool_calls == []
 
 
 class TestAwsEventStreamParserFeed:
     """Тесты метода feed парсера."""
-    
+
     def test_parses_content_event(self, aws_event_parser):
         """
         Что он делает: Проверяет парсинг события с контентом.
@@ -421,15 +446,15 @@ class TestAwsEventStreamParserFeed:
         """
         print("Настройка: Chunk с контентом...")
         chunk = b'{"content":"Hello World"}'
-        
+
         print("Действие: Парсинг chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Результат: {events}")
         assert len(events) == 1
         assert events[0]["type"] == "content"
         assert events[0]["data"] == "Hello World"
-    
+
     def test_parses_multiple_content_events(self, aws_event_parser):
         """
         Что он делает: Проверяет парсинг нескольких событий контента.
@@ -437,33 +462,33 @@ class TestAwsEventStreamParserFeed:
         """
         print("Настройка: Chunk с несколькими событиями...")
         chunk = b'{"content":"First"}{"content":"Second"}'
-        
+
         print("Действие: Парсинг chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Результат: {events}")
         assert len(events) == 2
         assert events[0]["data"] == "First"
         assert events[1]["data"] == "Second"
-    
+
     def test_deduplicates_repeated_content(self, aws_event_parser):
         """
         Что он делает: Проверяет дедупликацию повторяющегося контента.
         Цель: Убедиться, что одинаковый контент не дублируется.
         """
         print("Настройка: Chunks с повторяющимся контентом...")
-        
+
         print("Действие: Парсинг первого chunk...")
         events1 = aws_event_parser.feed(b'{"content":"Same"}')
-        
+
         print("Действие: Парсинг второго chunk с тем же контентом...")
         events2 = aws_event_parser.feed(b'{"content":"Same"}')
-        
+
         print(f"Первый результат: {events1}")
         print(f"Второй результат: {events2}")
         assert len(events1) == 1
         assert len(events2) == 0  # Дубликат отфильтрован
-    
+
     def test_parses_usage_event(self, aws_event_parser):
         """
         Что он делает: Проверяет парсинг события usage.
@@ -471,15 +496,15 @@ class TestAwsEventStreamParserFeed:
         """
         print("Настройка: Chunk с usage...")
         chunk = b'{"usage":1.5}'
-        
+
         print("Действие: Парсинг chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Результат: {events}")
         assert len(events) == 1
         assert events[0]["type"] == "usage"
         assert events[0]["data"] == 1.5
-    
+
     def test_parses_context_usage_event(self, aws_event_parser):
         """
         Что он делает: Проверяет парсинг события context_usage.
@@ -487,15 +512,15 @@ class TestAwsEventStreamParserFeed:
         """
         print("Настройка: Chunk с context usage...")
         chunk = b'{"contextUsagePercentage":25.5}'
-        
+
         print("Действие: Парсинг chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Результат: {events}")
         assert len(events) == 1
         assert events[0]["type"] == "context_usage"
         assert events[0]["data"] == 25.5
-    
+
     def test_handles_incomplete_json(self, aws_event_parser):
         """
         Что он делает: Проверяет обработку неполного JSON.
@@ -503,16 +528,16 @@ class TestAwsEventStreamParserFeed:
         """
         print("Настройка: Неполный chunk...")
         chunk = b'{"content":"Hel'
-        
+
         print("Действие: Парсинг неполного chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Результат: {events}")
         assert len(events) == 0  # Ничего не распарсено
-        
+
         print("Проверка: Данные в буфере...")
-        assert 'content' in aws_event_parser.buffer
-    
+        assert "content" in aws_event_parser.buffer
+
     def test_completes_json_across_chunks(self, aws_event_parser):
         """
         Что он делает: Проверяет сборку JSON из нескольких chunks.
@@ -520,16 +545,16 @@ class TestAwsEventStreamParserFeed:
         """
         print("Настройка: Первая часть JSON...")
         events1 = aws_event_parser.feed(b'{"content":"Hel')
-        
+
         print("Действие: Вторая часть JSON...")
         events2 = aws_event_parser.feed(b'lo World"}')
-        
+
         print(f"Первый результат: {events1}")
         print(f"Второй результат: {events2}")
         assert len(events1) == 0
         assert len(events2) == 1
         assert events2[0]["data"] == "Hello World"
-    
+
     def test_decodes_escape_sequences(self, aws_event_parser):
         """
         Что он делает: Проверяет декодирование escape-последовательностей.
@@ -538,13 +563,14 @@ class TestAwsEventStreamParserFeed:
         print("Настройка: Chunk с escape-последовательностью...")
         # Используем правильный формат escape-последовательности
         chunk = b'{"content":"Line1\\nLine2"}'
-        
+
         print("Действие: Парсинг chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Результат: {events}")
         assert len(events) == 1
         assert "\n" in events[0]["data"]
+
     def test_handles_invalid_bytes(self, aws_event_parser):
         """
         Что он делает: Проверяет обработку невалидных байтов.
@@ -552,10 +578,10 @@ class TestAwsEventStreamParserFeed:
         """
         print("Настройка: Невалидные байты...")
         chunk = b'\xff\xfe{"content":"test"}'
-        
+
         print("Действие: Парсинг chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Результат: {events}")
         # Парсер должен продолжить работу
         assert len(events) == 1
@@ -563,7 +589,7 @@ class TestAwsEventStreamParserFeed:
 
 class TestAwsEventStreamParserToolCalls:
     """Тесты парсинга tool calls."""
-    
+
     def test_parses_tool_start_event(self, aws_event_parser):
         """
         Что он делает: Проверяет парсинг начала tool call.
@@ -571,17 +597,17 @@ class TestAwsEventStreamParserToolCalls:
         """
         print("Настройка: Chunk с началом tool call...")
         chunk = b'{"name":"get_weather","toolUseId":"call_123"}'
-        
+
         print("Действие: Парсинг chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Результат: {events}")
         print(f"current_tool_call: {aws_event_parser.current_tool_call}")
-        
+
         # tool_start не возвращает событие, но создаёт current_tool_call
         assert aws_event_parser.current_tool_call is not None
         assert aws_event_parser.current_tool_call["function"]["name"] == "get_weather"
-    
+
     def test_parses_tool_input_event(self, aws_event_parser):
         """
         Что он делает: Проверяет парсинг input для tool call.
@@ -589,13 +615,16 @@ class TestAwsEventStreamParserToolCalls:
         """
         print("Настройка: Начало tool call...")
         aws_event_parser.feed(b'{"name":"func","toolUseId":"call_1"}')
-        
+
         print("Действие: Парсинг input...")
         aws_event_parser.feed(b'{"input":"{\\"key\\": \\"value\\"}"}')
-        
+
         print(f"current_tool_call: {aws_event_parser.current_tool_call}")
-        assert '{"key": "value"}' in aws_event_parser.current_tool_call["function"]["arguments"]
-    
+        assert (
+            '{"key": "value"}'
+            in aws_event_parser.current_tool_call["function"]["arguments"]
+        )
+
     def test_parses_tool_stop_event(self, aws_event_parser):
         """
         Что он делает: Проверяет завершение tool call.
@@ -604,14 +633,14 @@ class TestAwsEventStreamParserToolCalls:
         print("Настройка: Полный tool call...")
         aws_event_parser.feed(b'{"name":"func","toolUseId":"call_1"}')
         aws_event_parser.feed(b'{"input":"{}"}')
-        
+
         print("Действие: Парсинг stop...")
         aws_event_parser.feed(b'{"stop":true}')
-        
+
         print(f"tool_calls: {aws_event_parser.tool_calls}")
         assert len(aws_event_parser.tool_calls) == 1
         assert aws_event_parser.current_tool_call is None
-    
+
     def test_get_tool_calls_returns_all(self, aws_event_parser):
         """
         Что он делает: Проверяет получение всех tool calls.
@@ -622,13 +651,13 @@ class TestAwsEventStreamParserToolCalls:
         aws_event_parser.feed(b'{"stop":true}')
         aws_event_parser.feed(b'{"name":"func2","toolUseId":"call_2"}')
         aws_event_parser.feed(b'{"stop":true}')
-        
+
         print("Действие: Получение tool calls...")
         tool_calls = aws_event_parser.get_tool_calls()
-        
+
         print(f"Результат: {tool_calls}")
         assert len(tool_calls) == 2
-    
+
     def test_get_tool_calls_finalizes_current(self, aws_event_parser):
         """
         Что он делает: Проверяет завершение незавершённого tool call.
@@ -636,10 +665,10 @@ class TestAwsEventStreamParserToolCalls:
         """
         print("Настройка: Незавершённый tool call...")
         aws_event_parser.feed(b'{"name":"func","toolUseId":"call_1"}')
-        
+
         print("Действие: Получение tool calls...")
         tool_calls = aws_event_parser.get_tool_calls()
-        
+
         print(f"Результат: {tool_calls}")
         assert len(tool_calls) == 1
         assert aws_event_parser.current_tool_call is None
@@ -647,7 +676,7 @@ class TestAwsEventStreamParserToolCalls:
 
 class TestAwsEventStreamParserReset:
     """Тесты метода reset."""
-    
+
     def test_reset_clears_state(self, aws_event_parser):
         """
         Что он делает: Проверяет сброс состояния парсера.
@@ -656,10 +685,10 @@ class TestAwsEventStreamParserReset:
         print("Настройка: Заполнение парсера данными...")
         aws_event_parser.feed(b'{"content":"test"}')
         aws_event_parser.feed(b'{"name":"func","toolUseId":"call_1"}')
-        
+
         print("Действие: Сброс парсера...")
         aws_event_parser.reset()
-        
+
         print("Проверка: Все данные очищены...")
         assert aws_event_parser.buffer == ""
         assert aws_event_parser.last_content is None
@@ -669,7 +698,7 @@ class TestAwsEventStreamParserReset:
 
 class TestAwsEventStreamParserFinalizeToolCall:
     """Тесты метода _finalize_tool_call для обработки разных типов input."""
-    
+
     def test_finalize_with_string_arguments(self, aws_event_parser):
         """
         Что он делает: Проверяет финализацию tool call со строковыми аргументами.
@@ -679,19 +708,19 @@ class TestAwsEventStreamParserFinalizeToolCall:
         aws_event_parser.current_tool_call = {
             "id": "call_1",
             "type": "function",
-            "function": {
-                "name": "test_func",
-                "arguments": '{"key": "value"}'
-            }
+            "function": {"name": "test_func", "arguments": '{"key": "value"}'},
         }
-        
+
         print("Действие: Финализация tool call...")
         aws_event_parser._finalize_tool_call()
-        
+
         print(f"Результат: {aws_event_parser.tool_calls}")
         assert len(aws_event_parser.tool_calls) == 1
-        assert aws_event_parser.tool_calls[0]["function"]["arguments"] == '{"key": "value"}'
-    
+        assert (
+            aws_event_parser.tool_calls[0]["function"]["arguments"]
+            == '{"key": "value"}'
+        )
+
     def test_finalize_with_dict_arguments(self, aws_event_parser):
         """
         Что он делает: Проверяет финализацию tool call с dict аргументами.
@@ -703,22 +732,22 @@ class TestAwsEventStreamParserFinalizeToolCall:
             "type": "function",
             "function": {
                 "name": "test_func",
-                "arguments": {"location": "Moscow", "units": "celsius"}
-            }
+                "arguments": {"location": "Moscow", "units": "celsius"},
+            },
         }
-        
+
         print("Действие: Финализация tool call...")
         aws_event_parser._finalize_tool_call()
-        
+
         print(f"Результат: {aws_event_parser.tool_calls}")
         assert len(aws_event_parser.tool_calls) == 1
-        
+
         args = aws_event_parser.tool_calls[0]["function"]["arguments"]
         print(f"Аргументы: {args}")
         assert isinstance(args, str)
         assert "Moscow" in args
         assert "celsius" in args
-    
+
     def test_finalize_with_empty_string_arguments(self, aws_event_parser):
         """
         Что он делает: Проверяет финализацию tool call с пустой строкой аргументов.
@@ -728,19 +757,16 @@ class TestAwsEventStreamParserFinalizeToolCall:
         aws_event_parser.current_tool_call = {
             "id": "call_3",
             "type": "function",
-            "function": {
-                "name": "test_func",
-                "arguments": ""
-            }
+            "function": {"name": "test_func", "arguments": ""},
         }
-        
+
         print("Действие: Финализация tool call...")
         aws_event_parser._finalize_tool_call()
-        
+
         print(f"Результат: {aws_event_parser.tool_calls}")
         assert len(aws_event_parser.tool_calls) == 1
         assert aws_event_parser.tool_calls[0]["function"]["arguments"] == "{}"
-    
+
     def test_finalize_with_whitespace_only_arguments(self, aws_event_parser):
         """
         Что он делает: Проверяет финализацию tool call с пробельными аргументами.
@@ -750,19 +776,16 @@ class TestAwsEventStreamParserFinalizeToolCall:
         aws_event_parser.current_tool_call = {
             "id": "call_4",
             "type": "function",
-            "function": {
-                "name": "test_func",
-                "arguments": "   "
-            }
+            "function": {"name": "test_func", "arguments": "   "},
         }
-        
+
         print("Действие: Финализация tool call...")
         aws_event_parser._finalize_tool_call()
-        
+
         print(f"Результат: {aws_event_parser.tool_calls}")
         assert len(aws_event_parser.tool_calls) == 1
         assert aws_event_parser.tool_calls[0]["function"]["arguments"] == "{}"
-    
+
     def test_finalize_with_invalid_json_arguments(self, aws_event_parser):
         """
         Что он делает: Проверяет финализацию tool call с невалидным JSON.
@@ -772,19 +795,16 @@ class TestAwsEventStreamParserFinalizeToolCall:
         aws_event_parser.current_tool_call = {
             "id": "call_5",
             "type": "function",
-            "function": {
-                "name": "test_func",
-                "arguments": "not valid json {"
-            }
+            "function": {"name": "test_func", "arguments": "not valid json {"},
         }
-        
+
         print("Действие: Финализация tool call...")
         aws_event_parser._finalize_tool_call()
-        
+
         print(f"Результат: {aws_event_parser.tool_calls}")
         assert len(aws_event_parser.tool_calls) == 1
         assert aws_event_parser.tool_calls[0]["function"]["arguments"] == "{}"
-    
+
     def test_finalize_with_none_current_tool_call(self, aws_event_parser):
         """
         Что он делает: Проверяет финализацию когда current_tool_call is None.
@@ -792,13 +812,13 @@ class TestAwsEventStreamParserFinalizeToolCall:
         """
         print("Настройка: current_tool_call = None...")
         aws_event_parser.current_tool_call = None
-        
+
         print("Действие: Финализация tool call...")
         aws_event_parser._finalize_tool_call()
-        
+
         print(f"Результат: {aws_event_parser.tool_calls}")
         assert len(aws_event_parser.tool_calls) == 0
-    
+
     def test_finalize_clears_current_tool_call(self, aws_event_parser):
         """
         Что он делает: Проверяет, что финализация очищает current_tool_call.
@@ -808,22 +828,21 @@ class TestAwsEventStreamParserFinalizeToolCall:
         aws_event_parser.current_tool_call = {
             "id": "call_6",
             "type": "function",
-            "function": {
-                "name": "test_func",
-                "arguments": "{}"
-            }
+            "function": {"name": "test_func", "arguments": "{}"},
         }
-        
+
         print("Действие: Финализация tool call...")
         aws_event_parser._finalize_tool_call()
-        
-        print(f"current_tool_call после финализации: {aws_event_parser.current_tool_call}")
+
+        print(
+            f"current_tool_call после финализации: {aws_event_parser.current_tool_call}"
+        )
         assert aws_event_parser.current_tool_call is None
 
 
 class TestAwsEventStreamParserEdgeCases:
     """Тесты граничных случаев."""
-    
+
     def test_handles_followup_prompt(self, aws_event_parser):
         """
         Что он делает: Проверяет игнорирование followupPrompt.
@@ -831,13 +850,13 @@ class TestAwsEventStreamParserEdgeCases:
         """
         print("Настройка: Chunk с followupPrompt...")
         chunk = b'{"content":"text","followupPrompt":"suggestion"}'
-        
+
         print("Действие: Парсинг chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Результат: {events}")
         assert len(events) == 0  # followupPrompt игнорируется
-    
+
     def test_handles_mixed_events(self, aws_event_parser):
         """
         Что он делает: Проверяет парсинг смешанных событий.
@@ -845,16 +864,16 @@ class TestAwsEventStreamParserEdgeCases:
         """
         print("Настройка: Chunk со смешанными событиями...")
         chunk = b'{"content":"Hello"}{"usage":1.0}{"contextUsagePercentage":50}'
-        
+
         print("Действие: Парсинг chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Результат: {events}")
         assert len(events) == 3
         assert events[0]["type"] == "content"
         assert events[1]["type"] == "usage"
         assert events[2]["type"] == "context_usage"
-    
+
     def test_handles_garbage_between_events(self, aws_event_parser):
         """
         Что он делает: Проверяет обработку мусора между событиями.
@@ -862,22 +881,22 @@ class TestAwsEventStreamParserEdgeCases:
         """
         print("Настройка: Chunk с мусором между JSON...")
         chunk = b'garbage{"content":"valid"}more garbage{"usage":1}'
-        
+
         print("Действие: Парсинг chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Результат: {events}")
         assert len(events) == 2
-    
+
     def test_handles_empty_chunk(self, aws_event_parser):
         """
         Что он делает: Проверяет обработку пустого chunk.
         Цель: Убедиться, что пустой chunk не вызывает ошибок.
         """
         print("Настройка: Пустой chunk...")
-        
+
         print("Действие: Парсинг пустого chunk...")
-        events = aws_event_parser.feed(b'')
-        
+        events = aws_event_parser.feed(b"")
+
         print(f"Сравниваем результат: Ожидалось [], Получено {events}")
         assert events == []

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 
 """
@@ -11,12 +10,9 @@ For OpenAI API tests, see test_routes_openai.py.
 """
 
 import pytest
-from unittest.mock import AsyncMock, Mock, patch, MagicMock
-from datetime import datetime, timezone
-import json
+from unittest.mock import patch, MagicMock
 
 from fastapi import HTTPException
-from fastapi.testclient import TestClient
 
 from kiro.routes_anthropic import verify_anthropic_api_key, router
 from kiro.config import PROXY_API_KEY
@@ -26,9 +22,10 @@ from kiro.config import PROXY_API_KEY
 # Tests for verify_anthropic_api_key function
 # =============================================================================
 
+
 class TestVerifyAnthropicApiKey:
     """Tests for the verify_anthropic_api_key authentication function."""
-    
+
     @pytest.mark.asyncio
     async def test_valid_x_api_key_returns_true(self):
         """
@@ -36,13 +33,15 @@ class TestVerifyAnthropicApiKey:
         Purpose: Ensure Anthropic native authentication works.
         """
         print("Setup: Creating valid x-api-key...")
-        
+
         print("Action: Calling verify_anthropic_api_key...")
-        result = await verify_anthropic_api_key(x_api_key=PROXY_API_KEY, authorization=None)
-        
+        result = await verify_anthropic_api_key(
+            x_api_key=PROXY_API_KEY, authorization=None
+        )
+
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     @pytest.mark.asyncio
     async def test_valid_bearer_token_returns_true(self):
         """
@@ -51,13 +50,15 @@ class TestVerifyAnthropicApiKey:
         """
         print("Setup: Creating valid Bearer token...")
         valid_auth = f"Bearer {PROXY_API_KEY}"
-        
+
         print("Action: Calling verify_anthropic_api_key...")
-        result = await verify_anthropic_api_key(x_api_key=None, authorization=valid_auth)
-        
+        result = await verify_anthropic_api_key(
+            x_api_key=None, authorization=valid_auth
+        )
+
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     @pytest.mark.asyncio
     async def test_x_api_key_takes_precedence(self):
         """
@@ -65,16 +66,15 @@ class TestVerifyAnthropicApiKey:
         Purpose: Ensure Anthropic native auth has priority.
         """
         print("Setup: Both headers provided...")
-        
+
         print("Action: Calling verify_anthropic_api_key with both headers...")
         result = await verify_anthropic_api_key(
-            x_api_key=PROXY_API_KEY,
-            authorization="Bearer wrong_key"
+            x_api_key=PROXY_API_KEY, authorization="Bearer wrong_key"
         )
-        
+
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     @pytest.mark.asyncio
     async def test_invalid_x_api_key_raises_401(self):
         """
@@ -82,14 +82,14 @@ class TestVerifyAnthropicApiKey:
         Purpose: Ensure unauthorized access is blocked.
         """
         print("Setup: Creating invalid x-api-key...")
-        
+
         print("Action: Calling verify_anthropic_api_key with invalid key...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_anthropic_api_key(x_api_key="wrong_key", authorization=None)
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
-    
+
     @pytest.mark.asyncio
     async def test_invalid_bearer_token_raises_401(self):
         """
@@ -97,14 +97,16 @@ class TestVerifyAnthropicApiKey:
         Purpose: Ensure unauthorized access is blocked.
         """
         print("Setup: Creating invalid Bearer token...")
-        
+
         print("Action: Calling verify_anthropic_api_key with invalid token...")
         with pytest.raises(HTTPException) as exc_info:
-            await verify_anthropic_api_key(x_api_key=None, authorization="Bearer wrong_key")
-        
-        print(f"Checking: HTTPException with status 401...")
+            await verify_anthropic_api_key(
+                x_api_key=None, authorization="Bearer wrong_key"
+            )
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
-    
+
     @pytest.mark.asyncio
     async def test_missing_both_headers_raises_401(self):
         """
@@ -112,14 +114,14 @@ class TestVerifyAnthropicApiKey:
         Purpose: Ensure authentication is required.
         """
         print("Setup: No authentication headers...")
-        
+
         print("Action: Calling verify_anthropic_api_key with no headers...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_anthropic_api_key(x_api_key=None, authorization=None)
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
-    
+
     @pytest.mark.asyncio
     async def test_empty_x_api_key_raises_401(self):
         """
@@ -127,14 +129,14 @@ class TestVerifyAnthropicApiKey:
         Purpose: Ensure empty credentials are blocked.
         """
         print("Setup: Empty x-api-key...")
-        
+
         print("Action: Calling verify_anthropic_api_key with empty key...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_anthropic_api_key(x_api_key="", authorization=None)
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
-    
+
     @pytest.mark.asyncio
     async def test_error_response_format_is_anthropic_style(self):
         """
@@ -142,12 +144,12 @@ class TestVerifyAnthropicApiKey:
         Purpose: Ensure error format matches Anthropic API.
         """
         print("Setup: Invalid credentials...")
-        
+
         print("Action: Calling verify_anthropic_api_key...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_anthropic_api_key(x_api_key="wrong", authorization=None)
-        
-        print(f"Checking: Error format...")
+
+        print("Checking: Error format...")
         detail = exc_info.value.detail
         assert "type" in detail
         assert "error" in detail
@@ -158,9 +160,10 @@ class TestVerifyAnthropicApiKey:
 # Tests for /v1/messages endpoint authentication
 # =============================================================================
 
+
 class TestMessagesAuthentication:
     """Tests for authentication on /v1/messages endpoint."""
-    
+
     def test_messages_requires_authentication(self, test_client):
         """
         What it does: Verifies messages endpoint requires authentication.
@@ -172,13 +175,13 @@ class TestMessagesAuthentication:
             json={
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 401
-    
+
     def test_messages_accepts_x_api_key(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies messages endpoint accepts x-api-key header.
@@ -191,14 +194,14 @@ class TestMessagesAuthentication:
             json={
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass auth (not 401)
         assert response.status_code != 401
-    
+
     def test_messages_accepts_bearer_token(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies messages endpoint accepts Bearer token.
@@ -211,15 +214,17 @@ class TestMessagesAuthentication:
             json={
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass auth (not 401)
         assert response.status_code != 401
-    
-    def test_messages_rejects_invalid_x_api_key(self, test_client, invalid_proxy_api_key):
+
+    def test_messages_rejects_invalid_x_api_key(
+        self, test_client, invalid_proxy_api_key
+    ):
         """
         What it does: Verifies messages endpoint rejects invalid x-api-key.
         Purpose: Ensure authentication is enforced.
@@ -231,10 +236,10 @@ class TestMessagesAuthentication:
             json={
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 401
 
@@ -243,9 +248,10 @@ class TestMessagesAuthentication:
 # Tests for /v1/messages endpoint validation
 # =============================================================================
 
+
 class TestMessagesValidation:
     """Tests for request validation on /v1/messages endpoint."""
-    
+
     def test_validates_missing_model(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies missing model field is rejected.
@@ -257,13 +263,13 @@ class TestMessagesValidation:
             headers={"x-api-key": valid_proxy_api_key},
             json={
                 "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_missing_max_tokens(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies missing max_tokens field is rejected.
@@ -275,13 +281,13 @@ class TestMessagesValidation:
             headers={"x-api-key": valid_proxy_api_key},
             json={
                 "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_missing_messages(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies missing messages field is rejected.
@@ -291,15 +297,12 @@ class TestMessagesValidation:
         response = test_client.post(
             "/v1/messages",
             headers={"x-api-key": valid_proxy_api_key},
-            json={
-                "model": "claude-sonnet-4-5",
-                "max_tokens": 1024
-            }
+            json={"model": "claude-sonnet-4-5", "max_tokens": 1024},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_empty_messages_array(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies empty messages array is rejected.
@@ -309,16 +312,12 @@ class TestMessagesValidation:
         response = test_client.post(
             "/v1/messages",
             headers={"x-api-key": valid_proxy_api_key},
-            json={
-                "model": "claude-sonnet-4-5",
-                "max_tokens": 1024,
-                "messages": []
-            }
+            json={"model": "claude-sonnet-4-5", "max_tokens": 1024, "messages": []},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_invalid_json(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies invalid JSON is rejected.
@@ -329,14 +328,14 @@ class TestMessagesValidation:
             "/v1/messages",
             headers={
                 "x-api-key": valid_proxy_api_key,
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
             },
-            content=b"not valid json {{{}"
+            content=b"not valid json {{{}",
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_invalid_role(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies invalid message role is rejected.
@@ -349,14 +348,14 @@ class TestMessagesValidation:
             json={
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
-                "messages": [{"role": "invalid_role", "content": "Hello"}]
-            }
+                "messages": [{"role": "invalid_role", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Anthropic model strictly validates role - only 'user' or 'assistant' allowed
         assert response.status_code == 422
-    
+
     def test_accepts_valid_request_format(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies valid request format passes validation.
@@ -369,10 +368,10 @@ class TestMessagesValidation:
             json={
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation (not 422)
         assert response.status_code != 422
@@ -382,9 +381,10 @@ class TestMessagesValidation:
 # Tests for /v1/messages system prompt
 # =============================================================================
 
+
 class TestMessagesSystemPrompt:
     """Tests for system prompt handling on /v1/messages endpoint."""
-    
+
     def test_accepts_system_as_separate_field(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies system prompt as separate field is accepted.
@@ -398,14 +398,14 @@ class TestMessagesSystemPrompt:
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
                 "system": "You are a helpful assistant.",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation
         assert response.status_code != 422
-    
+
     def test_accepts_empty_system_prompt(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies empty system prompt is accepted.
@@ -419,14 +419,14 @@ class TestMessagesSystemPrompt:
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
                 "system": "",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation
         assert response.status_code != 422
-    
+
     def test_accepts_no_system_prompt(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies request without system prompt is accepted.
@@ -439,10 +439,10 @@ class TestMessagesSystemPrompt:
             json={
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation
         assert response.status_code != 422
@@ -452,9 +452,10 @@ class TestMessagesSystemPrompt:
 # Tests for /v1/messages content blocks
 # =============================================================================
 
+
 class TestMessagesContentBlocks:
     """Tests for content block handling on /v1/messages endpoint."""
-    
+
     def test_accepts_string_content(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies string content is accepted.
@@ -467,13 +468,13 @@ class TestMessagesContentBlocks:
             json={
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_content_block_array(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies content block array is accepted.
@@ -487,19 +488,14 @@ class TestMessagesContentBlocks:
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
                 "messages": [
-                    {
-                        "role": "user",
-                        "content": [
-                            {"type": "text", "text": "Hello"}
-                        ]
-                    }
-                ]
-            }
+                    {"role": "user", "content": [{"type": "text", "text": "Hello"}]}
+                ],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_multiple_content_blocks(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies multiple content blocks are accepted.
@@ -517,13 +513,13 @@ class TestMessagesContentBlocks:
                         "role": "user",
                         "content": [
                             {"type": "text", "text": "First part"},
-                            {"type": "text", "text": "Second part"}
-                        ]
+                            {"type": "text", "text": "Second part"},
+                        ],
                     }
-                ]
-            }
+                ],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
@@ -532,9 +528,10 @@ class TestMessagesContentBlocks:
 # Tests for /v1/messages tool use
 # =============================================================================
 
+
 class TestMessagesToolUse:
     """Tests for tool use on /v1/messages endpoint."""
-    
+
     def test_accepts_tool_definition(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies tool definition is accepted.
@@ -554,19 +551,17 @@ class TestMessagesToolUse:
                         "description": "Get weather for a location",
                         "input_schema": {
                             "type": "object",
-                            "properties": {
-                                "location": {"type": "string"}
-                            },
-                            "required": ["location"]
-                        }
+                            "properties": {"location": {"type": "string"}},
+                            "required": ["location"],
+                        },
                     }
-                ]
-            }
+                ],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_multiple_tools(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies multiple tools are accepted.
@@ -584,20 +579,20 @@ class TestMessagesToolUse:
                     {
                         "name": "get_weather",
                         "description": "Get weather",
-                        "input_schema": {"type": "object", "properties": {}}
+                        "input_schema": {"type": "object", "properties": {}},
                     },
                     {
                         "name": "get_time",
                         "description": "Get time",
-                        "input_schema": {"type": "object", "properties": {}}
-                    }
-                ]
-            }
+                        "input_schema": {"type": "object", "properties": {}},
+                    },
+                ],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_tool_result_message(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies tool result message is accepted.
@@ -619,9 +614,9 @@ class TestMessagesToolUse:
                                 "type": "tool_use",
                                 "id": "call_123",
                                 "name": "get_weather",
-                                "input": {"location": "Moscow"}
+                                "input": {"location": "Moscow"},
                             }
-                        ]
+                        ],
                     },
                     {
                         "role": "user",
@@ -629,14 +624,14 @@ class TestMessagesToolUse:
                             {
                                 "type": "tool_result",
                                 "tool_use_id": "call_123",
-                                "content": "Sunny, 25°C"
+                                "content": "Sunny, 25°C",
                             }
-                        ]
-                    }
-                ]
-            }
+                        ],
+                    },
+                ],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
@@ -645,9 +640,10 @@ class TestMessagesToolUse:
 # Tests for /v1/messages optional parameters
 # =============================================================================
 
+
 class TestMessagesOptionalParams:
     """Tests for optional parameters on /v1/messages endpoint."""
-    
+
     def test_accepts_temperature_parameter(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies temperature parameter is accepted.
@@ -661,13 +657,13 @@ class TestMessagesOptionalParams:
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
                 "messages": [{"role": "user", "content": "Hello"}],
-                "temperature": 0.7
-            }
+                "temperature": 0.7,
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_top_p_parameter(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies top_p parameter is accepted.
@@ -681,13 +677,13 @@ class TestMessagesOptionalParams:
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
                 "messages": [{"role": "user", "content": "Hello"}],
-                "top_p": 0.9
-            }
+                "top_p": 0.9,
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_top_k_parameter(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies top_k parameter is accepted.
@@ -701,31 +697,36 @@ class TestMessagesOptionalParams:
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
                 "messages": [{"role": "user", "content": "Hello"}],
-                "top_k": 40
-            }
+                "top_k": 40,
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_stream_true(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies stream=true is accepted.
         Purpose: Ensure streaming mode is supported.
         """
         print("Action: POST /v1/messages with stream=true...")
-        
+
         # Mock the streaming function to avoid real HTTP requests
         async def mock_stream(*args, **kwargs):
             yield 'event: message_start\ndata: {"type":"message_start"}\n\n'
             yield 'event: message_stop\ndata: {"type":"message_stop"}\n\n'
-        
+
         # Create mock response for HTTP client
         mock_response = MagicMock()
         mock_response.status_code = 200
-        
-        with patch('kiro.routes_anthropic.stream_kiro_to_anthropic', mock_stream), \
-             patch('kiro.http_client.KiroHttpClient.request_with_retry', return_value=mock_response):
+
+        with (
+            patch("kiro.routes_anthropic.stream_kiro_to_anthropic", mock_stream),
+            patch(
+                "kiro.http_client.KiroHttpClient.request_with_retry",
+                return_value=mock_response,
+            ),
+        ):
             response = test_client.post(
                 "/v1/messages",
                 headers={"x-api-key": valid_proxy_api_key},
@@ -733,13 +734,13 @@ class TestMessagesOptionalParams:
                     "model": "claude-sonnet-4-5",
                     "max_tokens": 1024,
                     "messages": [{"role": "user", "content": "Hello"}],
-                    "stream": True
-                }
+                    "stream": True,
+                },
             )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_stop_sequences(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies stop_sequences parameter is accepted.
@@ -753,13 +754,13 @@ class TestMessagesOptionalParams:
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
                 "messages": [{"role": "user", "content": "Hello"}],
-                "stop_sequences": ["END", "STOP"]
-            }
+                "stop_sequences": ["END", "STOP"],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_metadata(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies metadata parameter is accepted.
@@ -773,10 +774,10 @@ class TestMessagesOptionalParams:
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
                 "messages": [{"role": "user", "content": "Hello"}],
-                "metadata": {"user_id": "test_user"}
-            }
+                "metadata": {"user_id": "test_user"},
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
@@ -785,9 +786,10 @@ class TestMessagesOptionalParams:
 # Tests for /v1/messages anthropic-version header
 # =============================================================================
 
+
 class TestMessagesAnthropicVersion:
     """Tests for anthropic-version header handling."""
-    
+
     def test_accepts_anthropic_version_header(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies anthropic-version header is accepted.
@@ -798,20 +800,22 @@ class TestMessagesAnthropicVersion:
             "/v1/messages",
             headers={
                 "x-api-key": valid_proxy_api_key,
-                "anthropic-version": "2023-06-01"
+                "anthropic-version": "2023-06-01",
             },
             json={
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation
         assert response.status_code != 422
-    
-    def test_works_without_anthropic_version_header(self, test_client, valid_proxy_api_key):
+
+    def test_works_without_anthropic_version_header(
+        self, test_client, valid_proxy_api_key
+    ):
         """
         What it does: Verifies request works without anthropic-version header.
         Purpose: Ensure header is optional.
@@ -823,10 +827,10 @@ class TestMessagesAnthropicVersion:
             json={
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation
         assert response.status_code != 422
@@ -836,9 +840,10 @@ class TestMessagesAnthropicVersion:
 # Tests for router integration
 # =============================================================================
 
+
 class TestAnthropicRouterIntegration:
     """Tests for Anthropic router configuration and integration."""
-    
+
     def test_router_has_messages_endpoint(self):
         """
         What it does: Verifies messages endpoint is registered.
@@ -846,10 +851,10 @@ class TestAnthropicRouterIntegration:
         """
         print("Checking: Router endpoints...")
         routes = [route.path for route in router.routes]
-        
+
         print(f"Found routes: {routes}")
         assert "/v1/messages" in routes
-    
+
     def test_messages_endpoint_uses_post_method(self):
         """
         What it does: Verifies messages endpoint uses POST method.
@@ -862,7 +867,7 @@ class TestAnthropicRouterIntegration:
                 assert "POST" in route.methods
                 return
         pytest.fail("Messages endpoint not found")
-    
+
     def test_router_has_anthropic_tag(self):
         """
         What it does: Verifies router has Anthropic API tag.
@@ -877,9 +882,10 @@ class TestAnthropicRouterIntegration:
 # Tests for conversation history
 # =============================================================================
 
+
 class TestMessagesConversationHistory:
     """Tests for conversation history handling on /v1/messages endpoint."""
-    
+
     def test_accepts_multi_turn_conversation(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies multi-turn conversation is accepted.
@@ -895,14 +901,14 @@ class TestMessagesConversationHistory:
                 "messages": [
                     {"role": "user", "content": "Hello"},
                     {"role": "assistant", "content": "Hi there!"},
-                    {"role": "user", "content": "How are you?"}
-                ]
-            }
+                    {"role": "user", "content": "How are you?"},
+                ],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_long_conversation(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies long conversation is accepted.
@@ -914,17 +920,17 @@ class TestMessagesConversationHistory:
             messages.append({"role": "user", "content": f"Message {i}"})
             messages.append({"role": "assistant", "content": f"Response {i}"})
         messages.append({"role": "user", "content": "Final question"})
-        
+
         response = test_client.post(
             "/v1/messages",
             headers={"x-api-key": valid_proxy_api_key},
             json={
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
-                "messages": messages
-            }
+                "messages": messages,
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
@@ -933,9 +939,10 @@ class TestMessagesConversationHistory:
 # Tests for error response format
 # =============================================================================
 
+
 class TestMessagesErrorFormat:
     """Tests for error response format on /v1/messages endpoint."""
-    
+
     def test_validation_error_format(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies validation error response format.
@@ -948,13 +955,13 @@ class TestMessagesErrorFormat:
             json={
                 "model": "claude-sonnet-4-5"
                 # Missing required fields
-            }
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         print(f"Response: {response.json()}")
         assert response.status_code == 422
-    
+
     def test_auth_error_format_is_anthropic_style(self, test_client):
         """
         What it does: Verifies auth error follows Anthropic format.
@@ -966,14 +973,14 @@ class TestMessagesErrorFormat:
             json={
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         print(f"Response: {response.json()}")
         assert response.status_code == 401
-        
+
         # Check Anthropic error format
         data = response.json()
         assert "detail" in data

--- a/tests/unit/test_routes_openai.py
+++ b/tests/unit/test_routes_openai.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 
 """
@@ -14,12 +13,8 @@ For Anthropic API tests, see test_routes_anthropic.py.
 """
 
 import pytest
-from unittest.mock import AsyncMock, Mock, patch, MagicMock
-from datetime import datetime, timezone
-import json
 
 from fastapi import HTTPException
-from fastapi.testclient import TestClient
 
 from kiro.routes_openai import verify_api_key, router
 from kiro.config import PROXY_API_KEY, APP_VERSION
@@ -29,9 +24,10 @@ from kiro.config import PROXY_API_KEY, APP_VERSION
 # Tests for verify_api_key function
 # =============================================================================
 
+
 class TestVerifyApiKey:
     """Tests for the verify_api_key authentication function."""
-    
+
     @pytest.mark.asyncio
     async def test_valid_bearer_token_returns_true(self):
         """
@@ -40,13 +36,13 @@ class TestVerifyApiKey:
         """
         print("Setup: Creating valid Bearer token...")
         valid_header = f"Bearer {PROXY_API_KEY}"
-        
+
         print("Action: Calling verify_api_key...")
         result = await verify_api_key(valid_header)
-        
+
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     @pytest.mark.asyncio
     async def test_invalid_api_key_raises_401(self):
         """
@@ -55,15 +51,15 @@ class TestVerifyApiKey:
         """
         print("Setup: Creating invalid Bearer token...")
         invalid_header = "Bearer wrong_key_12345"
-        
+
         print("Action: Calling verify_api_key with invalid key...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_api_key(invalid_header)
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
         assert "Invalid or missing API Key" in exc_info.value.detail
-    
+
     @pytest.mark.asyncio
     async def test_missing_api_key_raises_401(self):
         """
@@ -71,14 +67,14 @@ class TestVerifyApiKey:
         Purpose: Ensure requests without authentication are blocked.
         """
         print("Setup: No API key provided...")
-        
+
         print("Action: Calling verify_api_key with None...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_api_key(None)
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
-    
+
     @pytest.mark.asyncio
     async def test_empty_api_key_raises_401(self):
         """
@@ -86,14 +82,14 @@ class TestVerifyApiKey:
         Purpose: Ensure empty credentials are blocked.
         """
         print("Setup: Empty API key...")
-        
+
         print("Action: Calling verify_api_key with empty string...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_api_key("")
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
-    
+
     @pytest.mark.asyncio
     async def test_key_without_bearer_prefix_raises_401(self):
         """
@@ -102,14 +98,14 @@ class TestVerifyApiKey:
         """
         print("Setup: API key without Bearer prefix...")
         wrong_format = PROXY_API_KEY  # Without "Bearer "
-        
+
         print("Action: Calling verify_api_key...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_api_key(wrong_format)
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
-    
+
     @pytest.mark.asyncio
     async def test_bearer_with_extra_spaces_raises_401(self):
         """
@@ -118,14 +114,14 @@ class TestVerifyApiKey:
         """
         print("Setup: Bearer token with extra spaces...")
         malformed = f"Bearer  {PROXY_API_KEY}"  # Double space
-        
+
         print("Action: Calling verify_api_key...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_api_key(malformed)
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
-    
+
     @pytest.mark.asyncio
     async def test_lowercase_bearer_raises_401(self):
         """
@@ -134,12 +130,12 @@ class TestVerifyApiKey:
         """
         print("Setup: Lowercase bearer prefix...")
         lowercase = f"bearer {PROXY_API_KEY}"
-        
+
         print("Action: Calling verify_api_key...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_api_key(lowercase)
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
 
 
@@ -147,9 +143,10 @@ class TestVerifyApiKey:
 # Tests for root endpoint (/)
 # =============================================================================
 
+
 class TestRootEndpoint:
     """Tests for the GET / endpoint."""
-    
+
     def test_root_returns_status_ok(self, test_client):
         """
         What it does: Verifies root endpoint returns ok status.
@@ -157,11 +154,11 @@ class TestRootEndpoint:
         """
         print("Action: GET /...")
         response = test_client.get("/")
-        
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
         assert response.json()["status"] == "ok"
-    
+
     def test_root_returns_gateway_message(self, test_client):
         """
         What it does: Verifies root endpoint returns gateway message.
@@ -169,11 +166,11 @@ class TestRootEndpoint:
         """
         print("Action: GET /...")
         response = test_client.get("/")
-        
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
         assert "Kiro Gateway" in response.json()["message"]
-    
+
     def test_root_returns_version(self, test_client):
         """
         What it does: Verifies root endpoint returns application version.
@@ -181,12 +178,12 @@ class TestRootEndpoint:
         """
         print("Action: GET /...")
         response = test_client.get("/")
-        
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
         assert "version" in response.json()
         assert response.json()["version"] == APP_VERSION
-    
+
     def test_root_does_not_require_auth(self, test_client):
         """
         What it does: Verifies root endpoint is accessible without authentication.
@@ -194,7 +191,7 @@ class TestRootEndpoint:
         """
         print("Action: GET / without auth headers...")
         response = test_client.get("/")
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 200
 
@@ -203,9 +200,10 @@ class TestRootEndpoint:
 # Tests for health endpoint (/health)
 # =============================================================================
 
+
 class TestHealthEndpoint:
     """Tests for the GET /health endpoint."""
-    
+
     def test_health_returns_healthy_status(self, test_client):
         """
         What it does: Verifies health endpoint returns healthy status.
@@ -213,11 +211,11 @@ class TestHealthEndpoint:
         """
         print("Action: GET /health...")
         response = test_client.get("/health")
-        
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
         assert response.json()["status"] == "healthy"
-    
+
     def test_health_returns_timestamp(self, test_client):
         """
         What it does: Verifies health endpoint returns timestamp.
@@ -225,14 +223,14 @@ class TestHealthEndpoint:
         """
         print("Action: GET /health...")
         response = test_client.get("/health")
-        
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
         assert "timestamp" in response.json()
         # Verify timestamp is ISO format
         timestamp = response.json()["timestamp"]
         assert "T" in timestamp  # ISO format contains T
-    
+
     def test_health_returns_version(self, test_client):
         """
         What it does: Verifies health endpoint returns version.
@@ -240,11 +238,11 @@ class TestHealthEndpoint:
         """
         print("Action: GET /health...")
         response = test_client.get("/health")
-        
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
         assert response.json()["version"] == APP_VERSION
-    
+
     def test_health_does_not_require_auth(self, test_client):
         """
         What it does: Verifies health endpoint is accessible without authentication.
@@ -252,7 +250,7 @@ class TestHealthEndpoint:
         """
         print("Action: GET /health without auth headers...")
         response = test_client.get("/health")
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 200
 
@@ -261,9 +259,10 @@ class TestHealthEndpoint:
 # Tests for models endpoint (/v1/models)
 # =============================================================================
 
+
 class TestModelsEndpoint:
     """Tests for the GET /v1/models endpoint."""
-    
+
     def test_models_requires_authentication(self, test_client):
         """
         What it does: Verifies models endpoint requires authentication.
@@ -271,10 +270,10 @@ class TestModelsEndpoint:
         """
         print("Action: GET /v1/models without auth...")
         response = test_client.get("/v1/models")
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 401
-    
+
     def test_models_rejects_invalid_key(self, test_client, invalid_proxy_api_key):
         """
         What it does: Verifies models endpoint rejects invalid API key.
@@ -282,13 +281,12 @@ class TestModelsEndpoint:
         """
         print("Action: GET /v1/models with invalid key...")
         response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {invalid_proxy_api_key}"}
+            "/v1/models", headers={"Authorization": f"Bearer {invalid_proxy_api_key}"}
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 401
-    
+
     def test_models_returns_list_object(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies models endpoint returns list object type.
@@ -296,14 +294,13 @@ class TestModelsEndpoint:
         """
         print("Action: GET /v1/models with valid auth...")
         response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
+            "/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
         )
-        
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
         assert response.json()["object"] == "list"
-    
+
     def test_models_returns_data_array(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies models endpoint returns data array.
@@ -311,15 +308,14 @@ class TestModelsEndpoint:
         """
         print("Action: GET /v1/models with valid auth...")
         response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
+            "/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
         )
-        
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
         assert "data" in response.json()
         assert isinstance(response.json()["data"], list)
-    
+
     def test_models_contains_available_models(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies all configured models are returned.
@@ -327,20 +323,19 @@ class TestModelsEndpoint:
         """
         print("Action: GET /v1/models with valid auth...")
         response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
+            "/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
         )
-        
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
-        
+
         model_ids = [m["id"] for m in response.json()["data"]]
         print(f"Model IDs: {model_ids}")
-        
+
         # At minimum, hidden models should be present
         # (even if Kiro API cache is empty)
         assert len(model_ids) >= 1, "Expected at least one model (hidden models)"
-    
+
     def test_models_format_is_openai_compatible(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies model objects have OpenAI-compatible format.
@@ -348,20 +343,19 @@ class TestModelsEndpoint:
         """
         print("Action: GET /v1/models with valid auth...")
         response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
+            "/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
         )
-        
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
-        
+
         for model in response.json()["data"]:
             print(f"Checking model format: {model}")
             assert "id" in model, "Model missing 'id' field"
             assert "object" in model, "Model missing 'object' field"
             assert model["object"] == "model", "Model object type should be 'model'"
             assert "owned_by" in model, "Model missing 'owned_by' field"
-    
+
     def test_models_owned_by_anthropic(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies models are owned by Anthropic.
@@ -369,13 +363,12 @@ class TestModelsEndpoint:
         """
         print("Action: GET /v1/models with valid auth...")
         response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
+            "/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
         )
-        
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
-        
+
         for model in response.json()["data"]:
             assert model["owned_by"] == "anthropic"
 
@@ -384,9 +377,10 @@ class TestModelsEndpoint:
 # Tests for chat completions endpoint (/v1/chat/completions)
 # =============================================================================
 
+
 class TestChatCompletionsAuthentication:
     """Tests for authentication on /v1/chat/completions endpoint."""
-    
+
     def test_chat_completions_requires_authentication(self, test_client):
         """
         What it does: Verifies chat completions requires authentication.
@@ -397,14 +391,16 @@ class TestChatCompletionsAuthentication:
             "/v1/chat/completions",
             json={
                 "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 401
-    
-    def test_chat_completions_rejects_invalid_key(self, test_client, invalid_proxy_api_key):
+
+    def test_chat_completions_rejects_invalid_key(
+        self, test_client, invalid_proxy_api_key
+    ):
         """
         What it does: Verifies chat completions rejects invalid API key.
         Purpose: Ensure authentication is enforced.
@@ -415,17 +411,17 @@ class TestChatCompletionsAuthentication:
             headers={"Authorization": f"Bearer {invalid_proxy_api_key}"},
             json={
                 "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 401
 
 
 class TestChatCompletionsValidation:
     """Tests for request validation on /v1/chat/completions endpoint."""
-    
+
     def test_validates_empty_messages_array(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies empty messages array is rejected.
@@ -435,15 +431,12 @@ class TestChatCompletionsValidation:
         response = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": []
-            }
+            json={"model": "claude-sonnet-4-5", "messages": []},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_missing_model(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies missing model field is rejected.
@@ -453,14 +446,12 @@ class TestChatCompletionsValidation:
         response = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"messages": [{"role": "user", "content": "Hello"}]},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_missing_messages(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies missing messages field is rejected.
@@ -470,14 +461,12 @@ class TestChatCompletionsValidation:
         response = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={
-                "model": "claude-sonnet-4-5"
-            }
+            json={"model": "claude-sonnet-4-5"},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_invalid_json(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies invalid JSON is rejected.
@@ -488,14 +477,14 @@ class TestChatCompletionsValidation:
             "/v1/chat/completions",
             headers={
                 "Authorization": f"Bearer {valid_proxy_api_key}",
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
             },
-            content=b"not valid json {{{}"
+            content=b"not valid json {{{}",
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_invalid_role(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies invalid message role passes Pydantic validation.
@@ -509,15 +498,15 @@ class TestChatCompletionsValidation:
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
             json={
                 "model": "claude-sonnet-4-5",
-                "messages": [{"role": "invalid_role", "content": "Hello"}]
-            }
+                "messages": [{"role": "invalid_role", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Pydantic model accepts any string as role, so validation passes (not 422)
         # The request may fail later during processing (500) due to network blocking
         assert response.status_code != 422
-    
+
     def test_accepts_valid_request_format(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies valid request format passes validation.
@@ -530,15 +519,15 @@ class TestChatCompletionsValidation:
             json={
                 "model": "claude-sonnet-4-5",
                 "messages": [{"role": "user", "content": "Hello"}],
-                "stream": False
-            }
+                "stream": False,
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation (not 422)
         # May fail on HTTP call due to network blocking, but that's expected
         assert response.status_code != 422
-    
+
     def test_accepts_message_without_content(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies message without content is accepted.
@@ -550,10 +539,10 @@ class TestChatCompletionsValidation:
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
             json={
                 "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user"}]  # No content
-            }
+                "messages": [{"role": "user"}],  # No content
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation (content is optional)
         assert response.status_code != 422 or "content" not in str(response.json())
@@ -561,8 +550,10 @@ class TestChatCompletionsValidation:
 
 class TestChatCompletionsWithTools:
     """Tests for tool calling on /v1/chat/completions endpoint."""
-    
-    def test_accepts_valid_tool_definition(self, test_client, valid_proxy_api_key, sample_tool_definition):
+
+    def test_accepts_valid_tool_definition(
+        self, test_client, valid_proxy_api_key, sample_tool_definition
+    ):
         """
         What it does: Verifies valid tool definition is accepted.
         Purpose: Ensure tool calling format is supported.
@@ -574,14 +565,14 @@ class TestChatCompletionsWithTools:
             json={
                 "model": "claude-sonnet-4-5",
                 "messages": [{"role": "user", "content": "What's the weather?"}],
-                "tools": [sample_tool_definition]
-            }
+                "tools": [sample_tool_definition],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation
         assert response.status_code != 422
-    
+
     def test_accepts_multiple_tools(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies multiple tools are accepted.
@@ -594,36 +585,36 @@ class TestChatCompletionsWithTools:
                 "function": {
                     "name": "get_weather",
                     "description": "Get weather",
-                    "parameters": {"type": "object", "properties": {}}
-                }
+                    "parameters": {"type": "object", "properties": {}},
+                },
             },
             {
                 "type": "function",
                 "function": {
                     "name": "get_time",
                     "description": "Get time",
-                    "parameters": {"type": "object", "properties": {}}
-                }
-            }
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
         ]
-        
+
         response = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
             json={
                 "model": "claude-sonnet-4-5",
                 "messages": [{"role": "user", "content": "Hello"}],
-                "tools": tools
-            }
+                "tools": tools,
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
 
 class TestChatCompletionsOptionalParams:
     """Tests for optional parameters on /v1/chat/completions endpoint."""
-    
+
     def test_accepts_temperature_parameter(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies temperature parameter is accepted.
@@ -636,13 +627,13 @@ class TestChatCompletionsOptionalParams:
             json={
                 "model": "claude-sonnet-4-5",
                 "messages": [{"role": "user", "content": "Hello"}],
-                "temperature": 0.7
-            }
+                "temperature": 0.7,
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_max_tokens_parameter(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies max_tokens parameter is accepted.
@@ -655,13 +646,13 @@ class TestChatCompletionsOptionalParams:
             json={
                 "model": "claude-sonnet-4-5",
                 "messages": [{"role": "user", "content": "Hello"}],
-                "max_tokens": 100
-            }
+                "max_tokens": 100,
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_stream_true(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies stream=true is accepted.
@@ -674,13 +665,13 @@ class TestChatCompletionsOptionalParams:
             json={
                 "model": "claude-sonnet-4-5",
                 "messages": [{"role": "user", "content": "Hello"}],
-                "stream": True
-            }
+                "stream": True,
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_top_p_parameter(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies top_p parameter is accepted.
@@ -693,17 +684,17 @@ class TestChatCompletionsOptionalParams:
             json={
                 "model": "claude-sonnet-4-5",
                 "messages": [{"role": "user", "content": "Hello"}],
-                "top_p": 0.9
-            }
+                "top_p": 0.9,
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
 
 class TestChatCompletionsMessageTypes:
     """Tests for different message types on /v1/chat/completions endpoint."""
-    
+
     def test_accepts_system_message(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies system message is accepted.
@@ -717,14 +708,14 @@ class TestChatCompletionsMessageTypes:
                 "model": "claude-sonnet-4-5",
                 "messages": [
                     {"role": "system", "content": "You are helpful."},
-                    {"role": "user", "content": "Hello"}
-                ]
-            }
+                    {"role": "user", "content": "Hello"},
+                ],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_assistant_message(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies assistant message is accepted.
@@ -739,14 +730,14 @@ class TestChatCompletionsMessageTypes:
                 "messages": [
                     {"role": "user", "content": "Hello"},
                     {"role": "assistant", "content": "Hi there!"},
-                    {"role": "user", "content": "How are you?"}
-                ]
-            }
+                    {"role": "user", "content": "How are you?"},
+                ],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_multipart_content(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies multipart content array is accepted.
@@ -763,13 +754,13 @@ class TestChatCompletionsMessageTypes:
                         "role": "user",
                         "content": [
                             {"type": "text", "text": "Hello"},
-                            {"type": "text", "text": "World"}
-                        ]
+                            {"type": "text", "text": "World"},
+                        ],
                     }
-                ]
-            }
+                ],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
@@ -778,9 +769,10 @@ class TestChatCompletionsMessageTypes:
 # Tests for router integration
 # =============================================================================
 
+
 class TestRouterIntegration:
     """Tests for router configuration and integration."""
-    
+
     def test_router_has_root_endpoint(self):
         """
         What it does: Verifies root endpoint is registered.
@@ -788,10 +780,10 @@ class TestRouterIntegration:
         """
         print("Checking: Router endpoints...")
         routes = [route.path for route in router.routes]
-        
+
         print(f"Found routes: {routes}")
         assert "/" in routes
-    
+
     def test_router_has_health_endpoint(self):
         """
         What it does: Verifies health endpoint is registered.
@@ -799,10 +791,10 @@ class TestRouterIntegration:
         """
         print("Checking: Router endpoints...")
         routes = [route.path for route in router.routes]
-        
+
         print(f"Found routes: {routes}")
         assert "/health" in routes
-    
+
     def test_router_has_models_endpoint(self):
         """
         What it does: Verifies models endpoint is registered.
@@ -810,10 +802,10 @@ class TestRouterIntegration:
         """
         print("Checking: Router endpoints...")
         routes = [route.path for route in router.routes]
-        
+
         print(f"Found routes: {routes}")
         assert "/v1/models" in routes
-    
+
     def test_router_has_chat_completions_endpoint(self):
         """
         What it does: Verifies chat completions endpoint is registered.
@@ -821,10 +813,10 @@ class TestRouterIntegration:
         """
         print("Checking: Router endpoints...")
         routes = [route.path for route in router.routes]
-        
+
         print(f"Found routes: {routes}")
         assert "/v1/chat/completions" in routes
-    
+
     def test_root_endpoint_uses_get_method(self):
         """
         What it does: Verifies root endpoint uses GET method.
@@ -837,7 +829,7 @@ class TestRouterIntegration:
                 assert "GET" in route.methods
                 return
         pytest.fail("Root endpoint not found")
-    
+
     def test_health_endpoint_uses_get_method(self):
         """
         What it does: Verifies health endpoint uses GET method.
@@ -850,7 +842,7 @@ class TestRouterIntegration:
                 assert "GET" in route.methods
                 return
         pytest.fail("Health endpoint not found")
-    
+
     def test_models_endpoint_uses_get_method(self):
         """
         What it does: Verifies models endpoint uses GET method.
@@ -863,7 +855,7 @@ class TestRouterIntegration:
                 assert "GET" in route.methods
                 return
         pytest.fail("Models endpoint not found")
-    
+
     def test_chat_completions_endpoint_uses_post_method(self):
         """
         What it does: Verifies chat completions endpoint uses POST method.

--- a/tests/unit/test_streaming_anthropic.py
+++ b/tests/unit/test_streaming_anthropic.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 
 """
@@ -13,7 +12,6 @@ Tests for:
 
 import pytest
 import json
-import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from kiro.streaming_anthropic import (
@@ -30,6 +28,7 @@ from kiro.streaming_core import KiroEvent, StreamResult
 # ==================================================================================================
 # Fixtures
 # ==================================================================================================
+
 
 @pytest.fixture
 def mock_model_cache():
@@ -59,9 +58,10 @@ def mock_response():
 # Tests for generate_message_id()
 # ==================================================================================================
 
+
 class TestGenerateMessageId:
     """Tests for generate_message_id() function."""
-    
+
     def test_generates_message_id_with_prefix(self):
         """
         What it does: Generates message ID with 'msg_' prefix.
@@ -69,11 +69,11 @@ class TestGenerateMessageId:
         """
         print("Action: Generating message ID...")
         message_id = generate_message_id()
-        
+
         print(f"Generated ID: {message_id}")
         assert message_id.startswith("msg_")
         print("✓ Message ID has correct prefix")
-    
+
     def test_generates_unique_ids(self):
         """
         What it does: Generates unique message IDs.
@@ -81,14 +81,14 @@ class TestGenerateMessageId:
         """
         print("Action: Generating multiple message IDs...")
         ids = [generate_message_id() for _ in range(100)]
-        
+
         print(f"Generated {len(ids)} IDs")
         unique_ids = set(ids)
         print(f"Unique IDs: {len(unique_ids)}")
-        
+
         assert len(unique_ids) == 100
         print("✓ All message IDs are unique")
-    
+
     def test_message_id_has_correct_length(self):
         """
         What it does: Verifies message ID length.
@@ -96,7 +96,7 @@ class TestGenerateMessageId:
         """
         print("Action: Generating message ID...")
         message_id = generate_message_id()
-        
+
         # Format: msg_ + 24 hex chars
         print(f"Generated ID: {message_id}, length: {len(message_id)}")
         assert len(message_id) == 4 + 24  # "msg_" + 24 chars
@@ -107,9 +107,10 @@ class TestGenerateMessageId:
 # Tests for format_sse_event()
 # ==================================================================================================
 
+
 class TestFormatSseEvent:
     """Tests for format_sse_event() function."""
-    
+
     def test_formats_message_start_event(self):
         """
         What it does: Formats message_start event.
@@ -118,21 +119,17 @@ class TestFormatSseEvent:
         print("Action: Formatting message_start event...")
         data = {
             "type": "message_start",
-            "message": {
-                "id": "msg_123",
-                "type": "message",
-                "role": "assistant"
-            }
+            "message": {"id": "msg_123", "type": "message", "role": "assistant"},
         }
-        
+
         result = format_sse_event("message_start", data)
-        
+
         print(f"Formatted event:\n{result}")
         assert result.startswith("event: message_start\n")
         assert "data: " in result
         assert result.endswith("\n\n")
         print("✓ Event formatted correctly")
-    
+
     def test_formats_content_block_delta_event(self):
         """
         What it does: Formats content_block_delta event.
@@ -142,19 +139,16 @@ class TestFormatSseEvent:
         data = {
             "type": "content_block_delta",
             "index": 0,
-            "delta": {
-                "type": "text_delta",
-                "text": "Hello"
-            }
+            "delta": {"type": "text_delta", "text": "Hello"},
         }
-        
+
         result = format_sse_event("content_block_delta", data)
-        
+
         print(f"Formatted event:\n{result}")
         assert "event: content_block_delta\n" in result
         assert '"text": "Hello"' in result
         print("✓ Delta event formatted correctly")
-    
+
     def test_formats_message_stop_event(self):
         """
         What it does: Formats message_stop event.
@@ -162,31 +156,28 @@ class TestFormatSseEvent:
         """
         print("Action: Formatting message_stop event...")
         data = {"type": "message_stop"}
-        
+
         result = format_sse_event("message_stop", data)
-        
+
         print(f"Formatted event:\n{result}")
         assert "event: message_stop\n" in result
         print("✓ Stop event formatted correctly")
-    
+
     def test_handles_unicode_content(self):
         """
         What it does: Handles Unicode content in events.
         Goal: Verify non-ASCII characters are preserved.
         """
         print("Action: Formatting event with Unicode...")
-        data = {
-            "type": "content_block_delta",
-            "delta": {"text": "Привет мир! 🌍"}
-        }
-        
+        data = {"type": "content_block_delta", "delta": {"text": "Привет мир! 🌍"}}
+
         result = format_sse_event("content_block_delta", data)
-        
+
         print(f"Formatted event:\n{result}")
         assert "Привет мир!" in result
         assert "🌍" in result
         print("✓ Unicode content preserved")
-    
+
     def test_json_data_is_valid(self):
         """
         What it does: Verifies JSON data is valid.
@@ -196,19 +187,19 @@ class TestFormatSseEvent:
         data = {
             "type": "message_delta",
             "delta": {"stop_reason": "end_turn"},
-            "usage": {"output_tokens": 100}
+            "usage": {"output_tokens": 100},
         }
-        
+
         result = format_sse_event("message_delta", data)
-        
+
         # Extract JSON from result
         lines = result.strip().split("\n")
-        data_line = [l for l in lines if l.startswith("data: ")][0]
+        data_line = [line for line in lines if line.startswith("data: ")][0]
         json_str = data_line[6:]  # Remove "data: " prefix
-        
+
         print(f"JSON string: {json_str}")
         parsed = json.loads(json_str)
-        
+
         assert parsed["type"] == "message_delta"
         assert parsed["delta"]["stop_reason"] == "end_turn"
         print("✓ JSON data is valid and parseable")
@@ -218,308 +209,396 @@ class TestFormatSseEvent:
 # Tests for stream_kiro_to_anthropic()
 # ==================================================================================================
 
+
 class TestStreamKiroToAnthropic:
     """Tests for stream_kiro_to_anthropic() generator."""
-    
+
     @pytest.mark.asyncio
-    async def test_yields_message_start_event(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_yields_message_start_event(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Yields message_start event at beginning.
         Goal: Verify Anthropic streaming protocol.
         """
         print("Setup: Mock empty stream...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             return
             yield  # Make it a generator
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
             async for event in stream_kiro_to_anthropic(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             ):
                 events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # First event should be message_start
         assert len(events) > 0
         assert "event: message_start" in events[0]
         print("✓ message_start event yielded first")
-    
+
     @pytest.mark.asyncio
-    async def test_yields_content_block_start_on_first_content(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_yields_content_block_start_on_first_content(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Yields content_block_start before first content.
         Goal: Verify content block lifecycle.
         """
         print("Setup: Mock stream with content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
+            with patch(
+                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for event in stream_kiro_to_anthropic(
-                    mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Should have content_block_start
         content_block_start_found = any("content_block_start" in e for e in events)
         assert content_block_start_found
         print("✓ content_block_start event yielded")
-    
+
     @pytest.mark.asyncio
-    async def test_yields_content_block_delta_for_content(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_yields_content_block_delta_for_content(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Yields content_block_delta for content events.
         Goal: Verify content streaming.
         """
         print("Setup: Mock stream with content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             yield KiroEvent(type="content", content=" World")
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
+            with patch(
+                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for event in stream_kiro_to_anthropic(
-                    mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Should have content_block_delta events
         delta_events = [e for e in events if "content_block_delta" in e]
         print(f"Delta events: {len(delta_events)}")
-        
+
         assert len(delta_events) >= 2
         assert "Hello" in delta_events[0]
         assert "World" in delta_events[1]
         print("✓ content_block_delta events yielded for content")
-    
+
     @pytest.mark.asyncio
-    async def test_yields_tool_use_block_for_tool_calls(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_yields_tool_use_block_for_tool_calls(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Yields tool_use block for tool calls.
         Goal: Verify tool use streaming.
         """
         print("Setup: Mock stream with tool call...")
-        
+
         tool_use_data = {
             "id": "toolu_123",
-            "function": {
-                "name": "get_weather",
-                "arguments": '{"city": "Moscow"}'
-            }
+            "function": {"name": "get_weather", "arguments": '{"city": "Moscow"}'},
         }
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Let me check")
             yield KiroEvent(type="tool_use", tool_use=tool_use_data)
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
+            with patch(
+                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for event in stream_kiro_to_anthropic(
-                    mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Should have tool_use content block
-        tool_use_events = [e for e in events if "tool_use" in e and "content_block_start" in e]
+        tool_use_events = [
+            e for e in events if "tool_use" in e and "content_block_start" in e
+        ]
         print(f"Tool use events: {len(tool_use_events)}")
-        
+
         assert len(tool_use_events) >= 1
         assert "get_weather" in tool_use_events[0]
         print("✓ tool_use block yielded for tool calls")
-    
+
     @pytest.mark.asyncio
-    async def test_yields_message_delta_with_stop_reason(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_yields_message_delta_with_stop_reason(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Yields message_delta with stop_reason.
         Goal: Verify message completion.
         """
         print("Setup: Mock stream with content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
+            with patch(
+                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for event in stream_kiro_to_anthropic(
-                    mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Should have message_delta with stop_reason
         message_delta_events = [e for e in events if "message_delta" in e]
         assert len(message_delta_events) >= 1
         assert "end_turn" in message_delta_events[0]
         print("✓ message_delta with stop_reason yielded")
-    
+
     @pytest.mark.asyncio
-    async def test_yields_message_stop_at_end(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_yields_message_stop_at_end(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Yields message_stop at end.
         Goal: Verify stream termination.
         """
         print("Setup: Mock stream with content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
+            with patch(
+                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for event in stream_kiro_to_anthropic(
-                    mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Last event should be message_stop
         assert "message_stop" in events[-1]
         print("✓ message_stop yielded at end")
-    
+
     @pytest.mark.asyncio
-    async def test_stop_reason_is_tool_use_when_tools_present(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_stop_reason_is_tool_use_when_tools_present(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Sets stop_reason to tool_use when tools are present.
         Goal: Verify correct stop reason for tool calls.
         """
         print("Setup: Mock stream with tool call...")
-        
+
         tool_use_data = {
             "id": "toolu_123",
-            "function": {"name": "func1", "arguments": "{}"}
+            "function": {"name": "func1", "arguments": "{}"},
         }
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="tool_use", tool_use=tool_use_data)
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
+            with patch(
+                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for event in stream_kiro_to_anthropic(
-                    mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # message_delta should have stop_reason: tool_use
         message_delta_events = [e for e in events if "message_delta" in e]
         assert len(message_delta_events) >= 1
         assert "tool_use" in message_delta_events[0]
         print("✓ stop_reason is tool_use when tools present")
-    
+
     @pytest.mark.asyncio
-    async def test_handles_bracket_tool_calls(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_handles_bracket_tool_calls(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Handles bracket-style tool calls in content.
         Goal: Verify bracket tool call detection.
         """
         print("Setup: Mock stream with bracket tool calls...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="[tool_call: func1]")
-        
+
         bracket_tool_calls = [
             {"id": "call_1", "function": {"name": "func1", "arguments": "{}"}}
         ]
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=bracket_tool_calls):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
+            with patch(
+                "kiro.streaming_anthropic.parse_bracket_tool_calls",
+                return_value=bracket_tool_calls,
+            ):
                 async for event in stream_kiro_to_anthropic(
-                    mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Should have tool_use block from bracket tool calls
-        tool_use_events = [e for e in events if "tool_use" in e and "content_block_start" in e]
+        tool_use_events = [
+            e for e in events if "tool_use" in e and "content_block_start" in e
+        ]
         assert len(tool_use_events) >= 1
         print("✓ Bracket tool calls handled correctly")
-    
+
     @pytest.mark.asyncio
-    async def test_closes_response_on_completion(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_closes_response_on_completion(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Closes response on completion.
         Goal: Verify resource cleanup.
         """
         print("Setup: Mock stream...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Streaming to Anthropic format...")
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
+            with patch(
+                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for event in stream_kiro_to_anthropic(
-                    mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     pass
-        
+
         print("Check: response.aclose() should be called...")
         mock_response.aclose.assert_called()
         print("✓ Response closed on completion")
-    
+
     @pytest.mark.asyncio
-    async def test_closes_response_on_error(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_closes_response_on_error(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Closes response on error.
         Goal: Verify resource cleanup on error.
         """
         print("Setup: Mock stream that raises error...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             raise RuntimeError("Test error")
-        
+
         print("Action: Streaming to Anthropic format with error...")
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
+            with patch(
+                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
+            ):
                 try:
                     async for event in stream_kiro_to_anthropic(
-                        mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                        mock_response,
+                        "claude-sonnet-4",
+                        mock_model_cache,
+                        mock_auth_manager,
                     ):
                         pass
                 except RuntimeError:
                     pass
-        
+
         print("Check: response.aclose() should be called...")
         mock_response.aclose.assert_called()
         print("✓ Response closed on error")
@@ -529,49 +608,57 @@ class TestStreamKiroToAnthropic:
 # Tests for collect_anthropic_response()
 # ==================================================================================================
 
+
 class TestCollectAnthropicResponse:
     """Tests for collect_anthropic_response() function."""
-    
+
     @pytest.mark.asyncio
-    async def test_collects_text_content(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_collects_text_content(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Collects text content into response.
         Goal: Verify content collection.
         """
         print("Setup: Mock stream result with content...")
-        
+
         mock_result = StreamResult(
             content="Hello, world!",
             thinking_content="",
             tool_calls=[],
             usage=None,
-            context_usage_percentage=None
+            context_usage_percentage=None,
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch(
+            "kiro.streaming_anthropic.collect_stream_to_result",
+            return_value=mock_result,
+        ):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"Result: {result}")
-        
+
         assert result["type"] == "message"
         assert result["role"] == "assistant"
         assert len(result["content"]) == 1
         assert result["content"][0]["type"] == "text"
         assert result["content"][0]["text"] == "Hello, world!"
         print("✓ Text content collected correctly")
-    
+
     @pytest.mark.asyncio
-    async def test_collects_tool_use_content(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_collects_tool_use_content(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Collects tool use into response.
         Goal: Verify tool use collection.
         """
         print("Setup: Mock stream result with tool calls...")
-        
+
         mock_result = StreamResult(
             content="Let me check",
             thinking_content="",
@@ -580,182 +667,219 @@ class TestCollectAnthropicResponse:
                     "id": "toolu_123",
                     "function": {
                         "name": "get_weather",
-                        "arguments": '{"city": "Moscow"}'
-                    }
+                        "arguments": '{"city": "Moscow"}',
+                    },
                 }
             ],
             usage=None,
-            context_usage_percentage=None
+            context_usage_percentage=None,
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch(
+            "kiro.streaming_anthropic.collect_stream_to_result",
+            return_value=mock_result,
+        ):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"Result: {result}")
-        
+
         # Should have text and tool_use blocks
         assert len(result["content"]) == 2
-        
+
         text_block = result["content"][0]
         assert text_block["type"] == "text"
-        
+
         tool_block = result["content"][1]
         assert tool_block["type"] == "tool_use"
         assert tool_block["name"] == "get_weather"
         assert tool_block["input"] == {"city": "Moscow"}
         print("✓ Tool use content collected correctly")
-    
+
     @pytest.mark.asyncio
-    async def test_sets_stop_reason_end_turn(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_sets_stop_reason_end_turn(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Sets stop_reason to end_turn for normal completion.
         Goal: Verify stop reason.
         """
         print("Setup: Mock stream result without tool calls...")
-        
+
         mock_result = StreamResult(
             content="Hello",
             thinking_content="",
             tool_calls=[],
             usage=None,
-            context_usage_percentage=None
+            context_usage_percentage=None,
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch(
+            "kiro.streaming_anthropic.collect_stream_to_result",
+            return_value=mock_result,
+        ):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"stop_reason: {result['stop_reason']}")
         assert result["stop_reason"] == "end_turn"
         print("✓ stop_reason is end_turn")
-    
+
     @pytest.mark.asyncio
-    async def test_sets_stop_reason_tool_use(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_sets_stop_reason_tool_use(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Sets stop_reason to tool_use when tools present.
         Goal: Verify stop reason for tool calls.
         """
         print("Setup: Mock stream result with tool calls...")
-        
+
         mock_result = StreamResult(
             content="",
             thinking_content="",
-            tool_calls=[{"id": "call_1", "function": {"name": "func1", "arguments": "{}"}}],
+            tool_calls=[
+                {"id": "call_1", "function": {"name": "func1", "arguments": "{}"}}
+            ],
             usage=None,
-            context_usage_percentage=None
+            context_usage_percentage=None,
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch(
+            "kiro.streaming_anthropic.collect_stream_to_result",
+            return_value=mock_result,
+        ):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"stop_reason: {result['stop_reason']}")
         assert result["stop_reason"] == "tool_use"
         print("✓ stop_reason is tool_use")
-    
+
     @pytest.mark.asyncio
-    async def test_includes_usage_info(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_includes_usage_info(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Includes usage information in response.
         Goal: Verify usage is included.
         """
         print("Setup: Mock stream result...")
-        
+
         mock_result = StreamResult(
             content="Hello, world!",
             thinking_content="",
             tool_calls=[],
             usage=None,
-            context_usage_percentage=None
+            context_usage_percentage=None,
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
-            with patch('kiro.streaming_anthropic.count_message_tokens', return_value=10):
-                with patch('kiro.streaming_anthropic.count_tokens', return_value=5):
+
+        with patch(
+            "kiro.streaming_anthropic.collect_stream_to_result",
+            return_value=mock_result,
+        ):
+            with patch(
+                "kiro.streaming_anthropic.count_message_tokens", return_value=10
+            ):
+                with patch("kiro.streaming_anthropic.count_tokens", return_value=5):
                     result = await collect_anthropic_response(
-                        mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager,
-                        request_messages=[{"role": "user", "content": "Hi"}]
+                        mock_response,
+                        "claude-sonnet-4",
+                        mock_model_cache,
+                        mock_auth_manager,
+                        request_messages=[{"role": "user", "content": "Hi"}],
                     )
-        
+
         print(f"Usage: {result['usage']}")
         assert "input_tokens" in result["usage"]
         assert "output_tokens" in result["usage"]
         print("✓ Usage info included")
-    
+
     @pytest.mark.asyncio
-    async def test_generates_message_id(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_generates_message_id(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Generates message ID for response.
         Goal: Verify message ID is present.
         """
         print("Setup: Mock stream result...")
-        
+
         mock_result = StreamResult(
             content="Hello",
             thinking_content="",
             tool_calls=[],
             usage=None,
-            context_usage_percentage=None
+            context_usage_percentage=None,
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch(
+            "kiro.streaming_anthropic.collect_stream_to_result",
+            return_value=mock_result,
+        ):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"Message ID: {result['id']}")
         assert result["id"].startswith("msg_")
         print("✓ Message ID generated")
-    
+
     @pytest.mark.asyncio
-    async def test_includes_model_name(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_includes_model_name(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Includes model name in response.
         Goal: Verify model is included.
         """
         print("Setup: Mock stream result...")
-        
+
         mock_result = StreamResult(
             content="Hello",
             thinking_content="",
             tool_calls=[],
             usage=None,
-            context_usage_percentage=None
+            context_usage_percentage=None,
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch(
+            "kiro.streaming_anthropic.collect_stream_to_result",
+            return_value=mock_result,
+        ):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"Model: {result['model']}")
         assert result["model"] == "claude-sonnet-4"
         print("✓ Model name included")
-    
+
     @pytest.mark.asyncio
-    async def test_parses_tool_arguments_from_string(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_parses_tool_arguments_from_string(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Parses tool arguments from JSON string.
         Goal: Verify arguments are parsed to dict.
         """
         print("Setup: Mock stream result with string arguments...")
-        
+
         mock_result = StreamResult(
             content="",
             thinking_content="",
@@ -764,38 +888,43 @@ class TestCollectAnthropicResponse:
                     "id": "call_1",
                     "function": {
                         "name": "func1",
-                        "arguments": '{"key": "value"}'  # String, not dict
-                    }
+                        "arguments": '{"key": "value"}',  # String, not dict
+                    },
                 }
             ],
             usage=None,
-            context_usage_percentage=None
+            context_usage_percentage=None,
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch(
+            "kiro.streaming_anthropic.collect_stream_to_result",
+            return_value=mock_result,
+        ):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"Result: {result}")
-        
+
         # Tool input should be parsed to dict
         tool_block = result["content"][0]  # Only tool_use since content is empty
         assert tool_block["type"] == "tool_use"
         assert tool_block["input"] == {"key": "value"}
         assert isinstance(tool_block["input"], dict)
         print("✓ Tool arguments parsed from string to dict")
-    
+
     @pytest.mark.asyncio
-    async def test_handles_invalid_json_arguments(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_handles_invalid_json_arguments(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Handles invalid JSON in tool arguments.
         Goal: Verify graceful handling of invalid JSON.
         """
         print("Setup: Mock stream result with invalid JSON arguments...")
-        
+
         mock_result = StreamResult(
             content="",
             thinking_content="",
@@ -804,54 +933,62 @@ class TestCollectAnthropicResponse:
                     "id": "call_1",
                     "function": {
                         "name": "func1",
-                        "arguments": "not valid json"  # Invalid JSON
-                    }
+                        "arguments": "not valid json",  # Invalid JSON
+                    },
                 }
             ],
             usage=None,
-            context_usage_percentage=None
+            context_usage_percentage=None,
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch(
+            "kiro.streaming_anthropic.collect_stream_to_result",
+            return_value=mock_result,
+        ):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"Result: {result}")
-        
+
         # Should handle gracefully with empty dict
         tool_block = result["content"][0]
         assert tool_block["type"] == "tool_use"
         assert tool_block["input"] == {}
         print("✓ Invalid JSON arguments handled gracefully")
-    
+
     @pytest.mark.asyncio
-    async def test_handles_empty_content(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_handles_empty_content(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Handles empty content in response.
         Goal: Verify empty content is handled.
         """
         print("Setup: Mock stream result with empty content...")
-        
+
         mock_result = StreamResult(
             content="",
             thinking_content="",
             tool_calls=[],
             usage=None,
-            context_usage_percentage=None
+            context_usage_percentage=None,
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch(
+            "kiro.streaming_anthropic.collect_stream_to_result",
+            return_value=mock_result,
+        ):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"Result: {result}")
-        
+
         # Content should be empty list
         assert result["content"] == []
         print("✓ Empty content handled correctly")
@@ -861,114 +998,147 @@ class TestCollectAnthropicResponse:
 # Tests for error handling
 # ==================================================================================================
 
+
 class TestStreamingAnthropicErrorHandling:
     """Tests for error handling in streaming_anthropic."""
-    
+
     @pytest.mark.asyncio
-    async def test_propagates_first_token_timeout_error(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_propagates_first_token_timeout_error(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Propagates FirstTokenTimeoutError.
         Goal: Verify timeout error is not caught internally.
         """
         from kiro.streaming_core import FirstTokenTimeoutError
-        
+
         print("Setup: Mock stream that raises timeout...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         print("Action: Streaming to Anthropic format with timeout...")
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
             with pytest.raises(FirstTokenTimeoutError):
                 async for event in stream_kiro_to_anthropic(
-                    mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     pass
-        
+
         print("✓ FirstTokenTimeoutError propagated correctly")
-    
+
     @pytest.mark.asyncio
-    async def test_propagates_generator_exit(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_propagates_generator_exit(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Propagates GeneratorExit.
         Goal: Verify client disconnect is handled.
         """
         print("Setup: Mock stream that raises GeneratorExit...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             raise GeneratorExit()
-        
+
         print("Action: Streaming to Anthropic format with GeneratorExit...")
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
+            with patch(
+                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
+            ):
                 with pytest.raises(GeneratorExit):
                     async for event in stream_kiro_to_anthropic(
-                        mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                        mock_response,
+                        "claude-sonnet-4",
+                        mock_model_cache,
+                        mock_auth_manager,
                     ):
                         pass
-        
+
         print("✓ GeneratorExit propagated correctly")
-    
+
     @pytest.mark.asyncio
-    async def test_yields_error_event_on_exception(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_yields_error_event_on_exception(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Yields error event on exception.
         Goal: Verify error event is sent to client.
         """
         print("Setup: Mock stream that raises RuntimeError...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             raise RuntimeError("Test error")
-        
+
         print("Action: Streaming to Anthropic format with error...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
+            with patch(
+                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
+            ):
                 try:
                     async for event in stream_kiro_to_anthropic(
-                        mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                        mock_response,
+                        "claude-sonnet-4",
+                        mock_model_cache,
+                        mock_auth_manager,
                     ):
                         events.append(event)
                 except RuntimeError:
                     pass
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Should have error event
         error_events = [e for e in events if "event: error" in e]
         assert len(error_events) >= 1
         assert "Test error" in error_events[0]
         print("✓ Error event yielded on exception")
-    
+
     @pytest.mark.asyncio
-    async def test_closes_response_in_finally(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_closes_response_in_finally(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Closes response in finally block.
         Goal: Verify resource cleanup always happens.
         """
         print("Setup: Mock stream that raises error...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             raise ValueError("Test error")
             yield  # Make it a generator
-        
+
         print("Action: Streaming to Anthropic format with error...")
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
             try:
                 async for event in stream_kiro_to_anthropic(
-                    mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     pass
             except ValueError:
                 pass
-        
+
         print("Check: response.aclose() should be called...")
         mock_response.aclose.assert_called()
         print("✓ Response closed in finally block")
@@ -978,65 +1148,87 @@ class TestStreamingAnthropicErrorHandling:
 # Tests for thinking content handling
 # ==================================================================================================
 
+
 class TestStreamingAnthropicThinkingContent:
     """Tests for thinking content handling in Anthropic streaming."""
-    
+
     @pytest.mark.asyncio
-    async def test_includes_thinking_as_text_when_configured(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_includes_thinking_as_text_when_configured(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Includes thinking content as text when configured.
         Goal: Verify thinking content handling.
         """
         print("Setup: Mock stream with thinking content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="thinking", thinking_content="Let me think...")
             yield KiroEvent(type="content", content="Here is my answer")
-        
+
         print("Action: Streaming to Anthropic format with thinking...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
-                with patch('kiro.streaming_anthropic.FAKE_REASONING_HANDLING', 'include_as_text'):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
+            with patch(
+                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
+            ):
+                with patch(
+                    "kiro.streaming_anthropic.FAKE_REASONING_HANDLING",
+                    "include_as_text",
+                ):
                     async for event in stream_kiro_to_anthropic(
-                        mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                        mock_response,
+                        "claude-sonnet-4",
+                        mock_model_cache,
+                        mock_auth_manager,
                     ):
                         events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Should have thinking content as text delta
         delta_events = [e for e in events if "content_block_delta" in e]
         thinking_found = any("Let me think" in e for e in delta_events)
         assert thinking_found
         print("✓ Thinking content included as text")
-    
+
     @pytest.mark.asyncio
-    async def test_strips_thinking_when_configured(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_strips_thinking_when_configured(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Strips thinking content when configured.
         Goal: Verify thinking content is stripped.
         """
         print("Setup: Mock stream with thinking content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="thinking", thinking_content="Let me think...")
             yield KiroEvent(type="content", content="Here is my answer")
-        
+
         print("Action: Streaming to Anthropic format with strip mode...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
-                with patch('kiro.streaming_anthropic.FAKE_REASONING_HANDLING', 'strip'):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
+            with patch(
+                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
+            ):
+                with patch("kiro.streaming_anthropic.FAKE_REASONING_HANDLING", "strip"):
                     async for event in stream_kiro_to_anthropic(
-                        mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                        mock_response,
+                        "claude-sonnet-4",
+                        mock_model_cache,
+                        mock_auth_manager,
                     ):
                         events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Should NOT have thinking content
         delta_events = [e for e in events if "content_block_delta" in e]
         thinking_found = any("Let me think" in e for e in delta_events)
@@ -1048,69 +1240,90 @@ class TestStreamingAnthropicThinkingContent:
 # Tests for context usage calculation
 # ==================================================================================================
 
+
 class TestStreamingAnthropicContextUsage:
     """Tests for context usage calculation in Anthropic streaming."""
-    
+
     @pytest.mark.asyncio
-    async def test_calculates_tokens_from_context_usage(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_calculates_tokens_from_context_usage(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Calculates tokens from context usage percentage.
         Goal: Verify token calculation.
         """
         print("Setup: Mock stream with context usage...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             yield KiroEvent(type="context_usage", context_usage_percentage=5.0)
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
+            with patch(
+                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for event in stream_kiro_to_anthropic(
-                    mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # message_delta should have usage with output_tokens
         message_delta_events = [e for e in events if "message_delta" in e]
         assert len(message_delta_events) >= 1
         assert "output_tokens" in message_delta_events[0]
         print("✓ Tokens calculated from context usage")
-    
+
     @pytest.mark.asyncio
-    async def test_uses_request_messages_for_input_tokens(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_uses_request_messages_for_input_tokens(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Uses request messages for input token count.
         Goal: Verify input tokens are counted from request.
         """
         print("Setup: Mock stream...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
-        request_messages = [
-            {"role": "user", "content": "Hi there!"}
-        ]
-        
+
+        request_messages = [{"role": "user", "content": "Hi there!"}]
+
         print("Action: Streaming to Anthropic format with request messages...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
-                with patch('kiro.streaming_anthropic.count_message_tokens', return_value=10) as mock_count:
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
+            with patch(
+                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
+            ):
+                with patch(
+                    "kiro.streaming_anthropic.count_message_tokens", return_value=10
+                ) as mock_count:
                     async for event in stream_kiro_to_anthropic(
-                        mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager,
-                        request_messages=request_messages
+                        mock_response,
+                        "claude-sonnet-4",
+                        mock_model_cache,
+                        mock_auth_manager,
+                        request_messages=request_messages,
                     ):
                         events.append(event)
-                    
+
                     # Verify count_message_tokens was called
-                    mock_count.assert_called_once_with(request_messages, apply_claude_correction=False)
-        
+                    mock_count.assert_called_once_with(
+                        request_messages, apply_claude_correction=False
+                    )
+
         print("✓ Request messages used for input token count")
 
 
@@ -1118,15 +1331,16 @@ class TestStreamingAnthropicContextUsage:
 # Tests for generate_thinking_signature()
 # ==================================================================================================
 
+
 class TestGenerateThinkingSignature:
     """
     Tests for generate_thinking_signature() function.
-    
+
     This function generates placeholder signatures for thinking content blocks.
     In real Anthropic API, this is a cryptographic signature for verification.
     Since we use fake reasoning via tag injection, we generate a placeholder.
     """
-    
+
     def test_generates_signature_with_prefix(self):
         """
         What it does: Generates signature with 'sig_' prefix.
@@ -1134,11 +1348,11 @@ class TestGenerateThinkingSignature:
         """
         print("Action: Generating thinking signature...")
         signature = generate_thinking_signature()
-        
+
         print(f"Generated signature: {signature}")
         assert signature.startswith("sig_")
         print("✓ Signature has correct prefix")
-    
+
     def test_generates_unique_signatures(self):
         """
         What it does: Generates unique signatures.
@@ -1146,14 +1360,14 @@ class TestGenerateThinkingSignature:
         """
         print("Action: Generating multiple signatures...")
         signatures = [generate_thinking_signature() for _ in range(100)]
-        
+
         print(f"Generated {len(signatures)} signatures")
         unique_signatures = set(signatures)
         print(f"Unique signatures: {len(unique_signatures)}")
-        
+
         assert len(unique_signatures) == 100
         print("✓ All signatures are unique")
-    
+
     def test_signature_has_correct_length(self):
         """
         What it does: Verifies signature length.
@@ -1161,12 +1375,12 @@ class TestGenerateThinkingSignature:
         """
         print("Action: Generating signature...")
         signature = generate_thinking_signature()
-        
+
         # Format: sig_ + 32 hex chars
         print(f"Generated signature: {signature}, length: {len(signature)}")
         assert len(signature) == 4 + 32  # "sig_" + 32 chars
         print("✓ Signature has correct length")
-    
+
     def test_signature_contains_only_valid_characters(self):
         """
         What it does: Verifies signature contains only valid hex characters.
@@ -1174,11 +1388,11 @@ class TestGenerateThinkingSignature:
         """
         print("Action: Generating signature...")
         signature = generate_thinking_signature()
-        
+
         print(f"Generated signature: {signature}")
         # Remove prefix and check remaining chars are hex
         hex_part = signature[4:]  # Remove "sig_"
-        assert all(c in '0123456789abcdef' for c in hex_part)
+        assert all(c in "0123456789abcdef" for c in hex_part)
         print("✓ Signature contains only valid hex characters")
 
 
@@ -1186,15 +1400,16 @@ class TestGenerateThinkingSignature:
 # Tests for stream_with_first_token_retry_anthropic()
 # ==================================================================================================
 
+
 class TestStreamWithFirstTokenRetryAnthropic:
     """
     Tests for stream_with_first_token_retry_anthropic() function.
-    
+
     This function wraps stream_kiro_to_anthropic with automatic retry
     on first token timeout. It uses the generic stream_with_first_token_retry
     from streaming_core.py with Anthropic-specific error formatting.
     """
-    
+
     @pytest.mark.asyncio
     async def test_yields_chunks_on_success(self, mock_model_cache, mock_auth_manager):
         """
@@ -1202,49 +1417,55 @@ class TestStreamWithFirstTokenRetryAnthropic:
         Goal: Verify normal operation without retries.
         """
         print("Setup: Mock successful request...")
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.aclose = AsyncMock()
-        
+
         async def mock_make_request():
             return mock_response
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Streaming with retry wrapper...")
         chunks = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch(
+            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
+        ):
+            with patch(
+                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for chunk in stream_with_first_token_retry_anthropic(
                     make_request=mock_make_request,
                     model="claude-sonnet-4",
                     model_cache=mock_model_cache,
                     auth_manager=mock_auth_manager,
                     max_retries=3,
-                    first_token_timeout=30
+                    first_token_timeout=30,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
         assert len(chunks) > 0
         assert any("message_start" in c for c in chunks)
         print("✓ Chunks yielded on success")
-    
+
     @pytest.mark.asyncio
-    async def test_retries_on_first_token_timeout(self, mock_model_cache, mock_auth_manager):
+    async def test_retries_on_first_token_timeout(
+        self, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Retries on first token timeout.
         Goal: Verify retry logic is triggered.
         """
         from kiro.streaming_core import FirstTokenTimeoutError
-        
+
         print("Setup: Mock request that times out then succeeds...")
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
@@ -1252,58 +1473,66 @@ class TestStreamWithFirstTokenRetryAnthropic:
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_kiro_to_anthropic(*args, **kwargs):
             nonlocal call_count
             if call_count == 1:
                 raise FirstTokenTimeoutError("Timeout on first attempt")
             yield "event: message_start\ndata: {}\n\n"
             yield "event: message_stop\ndata: {}\n\n"
-        
+
         print("Action: Streaming with retry on timeout...")
         chunks = []
-        
-        with patch('kiro.streaming_anthropic.stream_kiro_to_anthropic', mock_stream_kiro_to_anthropic):
+
+        with patch(
+            "kiro.streaming_anthropic.stream_kiro_to_anthropic",
+            mock_stream_kiro_to_anthropic,
+        ):
             async for chunk in stream_with_first_token_retry_anthropic(
                 make_request=mock_make_request,
                 model="claude-sonnet-4",
                 model_cache=mock_model_cache,
                 auth_manager=mock_auth_manager,
                 max_retries=3,
-                first_token_timeout=30
+                first_token_timeout=30,
             ):
                 chunks.append(chunk)
-        
+
         print(f"Call count: {call_count}")
         print(f"Received {len(chunks)} chunks")
-        
+
         assert call_count == 2  # First timeout, second success
         assert len(chunks) > 0
         print("✓ Retry on timeout works correctly")
-    
+
     @pytest.mark.asyncio
-    async def test_raises_anthropic_error_after_all_retries(self, mock_model_cache, mock_auth_manager):
+    async def test_raises_anthropic_error_after_all_retries(
+        self, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Raises Anthropic-formatted error after all retries exhausted.
         Goal: Verify error format matches Anthropic API.
         """
         from kiro.streaming_core import FirstTokenTimeoutError
-        
+
         print("Setup: Mock request that always times out...")
-        
+
         async def mock_make_request():
             response = AsyncMock()
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_kiro_to_anthropic(*args, **kwargs):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         print("Action: Streaming with all retries failing...")
-        
-        with patch('kiro.streaming_anthropic.stream_kiro_to_anthropic', mock_stream_kiro_to_anthropic):
+
+        with patch(
+            "kiro.streaming_anthropic.stream_kiro_to_anthropic",
+            mock_stream_kiro_to_anthropic,
+        ):
             with pytest.raises(Exception) as exc_info:
                 async for chunk in stream_with_first_token_retry_anthropic(
                     make_request=mock_make_request,
@@ -1311,36 +1540,38 @@ class TestStreamWithFirstTokenRetryAnthropic:
                     model_cache=mock_model_cache,
                     auth_manager=mock_auth_manager,
                     max_retries=2,
-                    first_token_timeout=30
+                    first_token_timeout=30,
                 ):
                     pass
-        
+
         print(f"Exception: {exc_info.value}")
-        
+
         # Error should be in Anthropic format (JSON)
         error_json = json.loads(str(exc_info.value))
         assert error_json["type"] == "error"
         assert error_json["error"]["type"] == "timeout_error"
         assert "30" in error_json["error"]["message"]
         print("✓ Anthropic-formatted error raised after all retries")
-    
+
     @pytest.mark.asyncio
-    async def test_raises_anthropic_error_on_http_error(self, mock_model_cache, mock_auth_manager):
+    async def test_raises_anthropic_error_on_http_error(
+        self, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Raises Anthropic-formatted error on HTTP error.
         Goal: Verify HTTP errors are formatted correctly.
         """
         print("Setup: Mock request that returns HTTP error...")
-        
+
         async def mock_make_request():
             response = AsyncMock()
             response.status_code = 500
             response.aread = AsyncMock(return_value=b"Internal Server Error")
             response.aclose = AsyncMock()
             return response
-        
+
         print("Action: Streaming with HTTP error...")
-        
+
         with pytest.raises(Exception) as exc_info:
             async for chunk in stream_with_first_token_retry_anthropic(
                 make_request=mock_make_request,
@@ -1348,71 +1579,78 @@ class TestStreamWithFirstTokenRetryAnthropic:
                 model_cache=mock_model_cache,
                 auth_manager=mock_auth_manager,
                 max_retries=2,
-                first_token_timeout=30
+                first_token_timeout=30,
             ):
                 pass
-        
+
         print(f"Exception: {exc_info.value}")
-        
+
         # Error should be in Anthropic format (JSON)
         error_json = json.loads(str(exc_info.value))
         assert error_json["type"] == "error"
         assert error_json["error"]["type"] == "api_error"
         assert "Upstream API error" in error_json["error"]["message"]
         print("✓ Anthropic-formatted error raised on HTTP error")
-    
+
     @pytest.mark.asyncio
-    async def test_passes_request_messages_to_stream(self, mock_model_cache, mock_auth_manager):
+    async def test_passes_request_messages_to_stream(
+        self, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Passes request_messages to underlying stream function.
         Goal: Verify token counting parameters are forwarded.
         """
         print("Setup: Mock request with messages...")
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.aclose = AsyncMock()
-        
+
         async def mock_make_request():
             return mock_response
-        
+
         captured_kwargs = {}
-        
+
         async def mock_stream_kiro_to_anthropic(*args, **kwargs):
             captured_kwargs.update(kwargs)
             yield "event: message_start\ndata: {}\n\n"
             yield "event: message_stop\ndata: {}\n\n"
-        
+
         request_messages = [{"role": "user", "content": "Hello"}]
-        
+
         print("Action: Streaming with request_messages...")
-        
-        with patch('kiro.streaming_anthropic.stream_kiro_to_anthropic', mock_stream_kiro_to_anthropic):
+
+        with patch(
+            "kiro.streaming_anthropic.stream_kiro_to_anthropic",
+            mock_stream_kiro_to_anthropic,
+        ):
             async for chunk in stream_with_first_token_retry_anthropic(
                 make_request=mock_make_request,
                 model="claude-sonnet-4",
                 model_cache=mock_model_cache,
                 auth_manager=mock_auth_manager,
-                request_messages=request_messages
+                request_messages=request_messages,
             ):
                 pass
-        
+
         print(f"Captured kwargs: {captured_kwargs}")
         assert captured_kwargs.get("request_messages") == request_messages
         print("✓ request_messages passed to stream function")
-    
+
     @pytest.mark.asyncio
-    async def test_uses_configured_max_retries(self, mock_model_cache, mock_auth_manager):
+    async def test_uses_configured_max_retries(
+        self, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Uses configured max_retries value.
         Goal: Verify max_retries parameter is respected.
         """
         from kiro.streaming_core import FirstTokenTimeoutError
-        
+
         print("Setup: Mock request that always times out...")
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
@@ -1420,14 +1658,17 @@ class TestStreamWithFirstTokenRetryAnthropic:
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_kiro_to_anthropic(*args, **kwargs):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         print("Action: Streaming with max_retries=5...")
-        
-        with patch('kiro.streaming_anthropic.stream_kiro_to_anthropic', mock_stream_kiro_to_anthropic):
+
+        with patch(
+            "kiro.streaming_anthropic.stream_kiro_to_anthropic",
+            mock_stream_kiro_to_anthropic,
+        ):
             try:
                 async for chunk in stream_with_first_token_retry_anthropic(
                     make_request=mock_make_request,
@@ -1435,12 +1676,12 @@ class TestStreamWithFirstTokenRetryAnthropic:
                     model_cache=mock_model_cache,
                     auth_manager=mock_auth_manager,
                     max_retries=5,
-                    first_token_timeout=30
+                    first_token_timeout=30,
                 ):
                     pass
             except Exception:
                 pass
-        
+
         print(f"Call count: {call_count}")
         assert call_count == 5  # Should try exactly 5 times
         print("✓ max_retries parameter respected")

--- a/tests/unit/test_streaming_core.py
+++ b/tests/unit/test_streaming_core.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 
 """
@@ -16,7 +15,6 @@ Tests for:
 import pytest
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
-from dataclasses import asdict
 
 from kiro.streaming_core import (
     KiroEvent,
@@ -33,6 +31,7 @@ from kiro.streaming_core import (
 # ==================================================================================================
 # Fixtures
 # ==================================================================================================
+
 
 @pytest.fixture
 def mock_model_cache():
@@ -64,9 +63,10 @@ def mock_parser():
 # Tests for KiroEvent dataclass
 # ==================================================================================================
 
+
 class TestKiroEvent:
     """Tests for KiroEvent dataclass."""
-    
+
     def test_creates_content_event(self):
         """
         What it does: Creates a content event with text.
@@ -74,7 +74,7 @@ class TestKiroEvent:
         """
         print("Action: Creating content event...")
         event = KiroEvent(type="content", content="Hello, world!")
-        
+
         print(f"Comparing type: Expected 'content', Got '{event.type}'")
         assert event.type == "content"
         print(f"Comparing content: Expected 'Hello, world!', Got '{event.content}'")
@@ -82,7 +82,7 @@ class TestKiroEvent:
         assert event.thinking_content is None
         assert event.tool_use is None
         print("✓ Content event created correctly")
-    
+
     def test_creates_thinking_event(self):
         """
         What it does: Creates a thinking event with reasoning content.
@@ -93,17 +93,19 @@ class TestKiroEvent:
             type="thinking",
             thinking_content="Let me think...",
             is_first_thinking_chunk=True,
-            is_last_thinking_chunk=False
+            is_last_thinking_chunk=False,
         )
-        
+
         print(f"Comparing type: Expected 'thinking', Got '{event.type}'")
         assert event.type == "thinking"
-        print(f"Comparing thinking_content: Expected 'Let me think...', Got '{event.thinking_content}'")
+        print(
+            f"Comparing thinking_content: Expected 'Let me think...', Got '{event.thinking_content}'"
+        )
         assert event.thinking_content == "Let me think..."
         assert event.is_first_thinking_chunk is True
         assert event.is_last_thinking_chunk is False
         print("✓ Thinking event created correctly")
-    
+
     def test_creates_tool_use_event(self):
         """
         What it does: Creates a tool_use event with tool data.
@@ -113,16 +115,16 @@ class TestKiroEvent:
         tool_data = {
             "id": "call_123",
             "type": "function",
-            "function": {"name": "get_weather", "arguments": '{"city": "Moscow"}'}
+            "function": {"name": "get_weather", "arguments": '{"city": "Moscow"}'},
         }
         event = KiroEvent(type="tool_use", tool_use=tool_data)
-        
+
         print(f"Comparing type: Expected 'tool_use', Got '{event.type}'")
         assert event.type == "tool_use"
         print(f"Comparing tool_use: Expected {tool_data}, Got {event.tool_use}")
         assert event.tool_use == tool_data
         print("✓ Tool use event created correctly")
-    
+
     def test_creates_usage_event(self):
         """
         What it does: Creates a usage event with metering data.
@@ -131,13 +133,13 @@ class TestKiroEvent:
         print("Action: Creating usage event...")
         usage_data = {"credits": 0.001}
         event = KiroEvent(type="usage", usage=usage_data)
-        
+
         print(f"Comparing type: Expected 'usage', Got '{event.type}'")
         assert event.type == "usage"
         print(f"Comparing usage: Expected {usage_data}, Got {event.usage}")
         assert event.usage == usage_data
         print("✓ Usage event created correctly")
-    
+
     def test_creates_context_usage_event(self):
         """
         What it does: Creates a context_usage event with percentage.
@@ -145,13 +147,15 @@ class TestKiroEvent:
         """
         print("Action: Creating context_usage event...")
         event = KiroEvent(type="context_usage", context_usage_percentage=5.5)
-        
+
         print(f"Comparing type: Expected 'context_usage', Got '{event.type}'")
         assert event.type == "context_usage"
-        print(f"Comparing context_usage_percentage: Expected 5.5, Got {event.context_usage_percentage}")
+        print(
+            f"Comparing context_usage_percentage: Expected 5.5, Got {event.context_usage_percentage}"
+        )
         assert event.context_usage_percentage == 5.5
         print("✓ Context usage event created correctly")
-    
+
     def test_default_values(self):
         """
         What it does: Verifies default values for optional fields.
@@ -159,7 +163,7 @@ class TestKiroEvent:
         """
         print("Action: Creating minimal event...")
         event = KiroEvent(type="content")
-        
+
         print("Checking default values...")
         assert event.content is None
         assert event.thinking_content is None
@@ -175,9 +179,10 @@ class TestKiroEvent:
 # Tests for StreamResult dataclass
 # ==================================================================================================
 
+
 class TestStreamResult:
     """Tests for StreamResult dataclass."""
-    
+
     def test_creates_empty_result(self):
         """
         What it does: Creates an empty StreamResult.
@@ -185,7 +190,7 @@ class TestStreamResult:
         """
         print("Action: Creating empty StreamResult...")
         result = StreamResult()
-        
+
         print("Checking default values...")
         assert result.content == ""
         assert result.thinking_content == ""
@@ -193,7 +198,7 @@ class TestStreamResult:
         assert result.usage is None
         assert result.context_usage_percentage is None
         print("✓ Empty StreamResult created correctly")
-    
+
     def test_creates_result_with_content(self):
         """
         What it does: Creates StreamResult with content.
@@ -201,11 +206,11 @@ class TestStreamResult:
         """
         print("Action: Creating StreamResult with content...")
         result = StreamResult(content="Hello, world!")
-        
+
         print(f"Comparing content: Expected 'Hello, world!', Got '{result.content}'")
         assert result.content == "Hello, world!"
         print("✓ StreamResult with content created correctly")
-    
+
     def test_creates_result_with_tool_calls(self):
         """
         What it does: Creates StreamResult with tool calls.
@@ -214,15 +219,15 @@ class TestStreamResult:
         print("Action: Creating StreamResult with tool calls...")
         tool_calls = [
             {"id": "call_1", "function": {"name": "func1"}},
-            {"id": "call_2", "function": {"name": "func2"}}
+            {"id": "call_2", "function": {"name": "func2"}},
         ]
         result = StreamResult(tool_calls=tool_calls)
-        
+
         print(f"Comparing tool_calls count: Expected 2, Got {len(result.tool_calls)}")
         assert len(result.tool_calls) == 2
         assert result.tool_calls[0]["id"] == "call_1"
         print("✓ StreamResult with tool calls created correctly")
-    
+
     def test_creates_result_with_usage(self):
         """
         What it does: Creates StreamResult with usage data.
@@ -231,11 +236,11 @@ class TestStreamResult:
         print("Action: Creating StreamResult with usage...")
         usage = {"credits": 0.002}
         result = StreamResult(usage=usage)
-        
+
         print(f"Comparing usage: Expected {usage}, Got {result.usage}")
         assert result.usage == usage
         print("✓ StreamResult with usage created correctly")
-    
+
     def test_creates_full_result(self):
         """
         What it does: Creates StreamResult with all fields.
@@ -247,9 +252,9 @@ class TestStreamResult:
             thinking_content="Thinking...",
             tool_calls=[{"id": "call_1"}],
             usage={"credits": 0.001},
-            context_usage_percentage=3.5
+            context_usage_percentage=3.5,
         )
-        
+
         print("Checking all fields...")
         assert result.content == "Response text"
         assert result.thinking_content == "Thinking..."
@@ -263,9 +268,10 @@ class TestStreamResult:
 # Tests for FirstTokenTimeoutError
 # ==================================================================================================
 
+
 class TestFirstTokenTimeoutError:
     """Tests for FirstTokenTimeoutError exception."""
-    
+
     def test_creates_exception_with_message(self):
         """
         What it does: Creates exception with custom message.
@@ -273,25 +279,27 @@ class TestFirstTokenTimeoutError:
         """
         print("Action: Creating FirstTokenTimeoutError...")
         error = FirstTokenTimeoutError("No response within 30 seconds")
-        
-        print(f"Comparing message: Expected 'No response within 30 seconds', Got '{str(error)}'")
+
+        print(
+            f"Comparing message: Expected 'No response within 30 seconds', Got '{str(error)}'"
+        )
         assert str(error) == "No response within 30 seconds"
         print("✓ Exception created correctly")
-    
+
     def test_exception_is_catchable(self):
         """
         What it does: Verifies exception can be caught.
         Goal: Ensure exception inherits from Exception.
         """
         print("Action: Raising and catching FirstTokenTimeoutError...")
-        
+
         with pytest.raises(FirstTokenTimeoutError) as exc_info:
             raise FirstTokenTimeoutError("Timeout!")
-        
+
         print(f"Caught exception: {exc_info.value}")
         assert "Timeout!" in str(exc_info.value)
         print("✓ Exception is catchable")
-    
+
     def test_exception_inherits_from_exception(self):
         """
         What it does: Verifies inheritance chain.
@@ -299,7 +307,7 @@ class TestFirstTokenTimeoutError:
         """
         print("Action: Checking inheritance...")
         error = FirstTokenTimeoutError("Test")
-        
+
         assert isinstance(error, Exception)
         print("✓ FirstTokenTimeoutError inherits from Exception")
 
@@ -308,9 +316,10 @@ class TestFirstTokenTimeoutError:
 # Tests for parse_kiro_stream()
 # ==================================================================================================
 
+
 class TestParseKiroStream:
     """Tests for parse_kiro_stream() function."""
-    
+
     @pytest.mark.asyncio
     async def test_parses_content_events(self, mock_response, mock_parser):
         """
@@ -320,31 +329,35 @@ class TestParseKiroStream:
         print("Setup: Mock parser to return content events...")
         mock_parser.feed.return_value = [
             {"type": "content", "data": "Hello"},
-            {"type": "content", "data": " World"}
+            {"type": "content", "data": " World"},
         ]
-        
+
         async def mock_aiter_bytes():
-            yield b'chunk1'
-        
+            yield b"chunk1"
+
         mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         print("Action: Parsing stream...")
         events = []
-        
-        with patch('kiro.streaming_core.AwsEventStreamParser', return_value=mock_parser):
-            with patch('kiro.streaming_core.FAKE_REASONING_ENABLED', False):
-                async for event in parse_kiro_stream(mock_response, first_token_timeout=30):
+
+        with patch(
+            "kiro.streaming_core.AwsEventStreamParser", return_value=mock_parser
+        ):
+            with patch("kiro.streaming_core.FAKE_REASONING_ENABLED", False):
+                async for event in parse_kiro_stream(
+                    mock_response, first_token_timeout=30
+                ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
         content_events = [e for e in events if e.type == "content"]
         print(f"Content events: {len(content_events)}")
-        
+
         assert len(content_events) == 2
         assert content_events[0].content == "Hello"
         assert content_events[1].content == " World"
         print("✓ Content events parsed correctly")
-    
+
     @pytest.mark.asyncio
     async def test_parses_usage_events(self, mock_response, mock_parser):
         """
@@ -352,30 +365,32 @@ class TestParseKiroStream:
         Goal: Verify usage events are yielded correctly.
         """
         print("Setup: Mock parser to return usage event...")
-        mock_parser.feed.return_value = [
-            {"type": "usage", "data": {"credits": 0.001}}
-        ]
-        
+        mock_parser.feed.return_value = [{"type": "usage", "data": {"credits": 0.001}}]
+
         async def mock_aiter_bytes():
-            yield b'chunk1'
-        
+            yield b"chunk1"
+
         mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         print("Action: Parsing stream...")
         events = []
-        
-        with patch('kiro.streaming_core.AwsEventStreamParser', return_value=mock_parser):
-            with patch('kiro.streaming_core.FAKE_REASONING_ENABLED', False):
-                async for event in parse_kiro_stream(mock_response, first_token_timeout=30):
+
+        with patch(
+            "kiro.streaming_core.AwsEventStreamParser", return_value=mock_parser
+        ):
+            with patch("kiro.streaming_core.FAKE_REASONING_ENABLED", False):
+                async for event in parse_kiro_stream(
+                    mock_response, first_token_timeout=30
+                ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
         usage_events = [e for e in events if e.type == "usage"]
-        
+
         assert len(usage_events) == 1
         assert usage_events[0].usage == {"credits": 0.001}
         print("✓ Usage events parsed correctly")
-    
+
     @pytest.mark.asyncio
     async def test_parses_context_usage_events(self, mock_response, mock_parser):
         """
@@ -383,30 +398,32 @@ class TestParseKiroStream:
         Goal: Verify context usage percentage is yielded correctly.
         """
         print("Setup: Mock parser to return context_usage event...")
-        mock_parser.feed.return_value = [
-            {"type": "context_usage", "data": 5.5}
-        ]
-        
+        mock_parser.feed.return_value = [{"type": "context_usage", "data": 5.5}]
+
         async def mock_aiter_bytes():
-            yield b'chunk1'
-        
+            yield b"chunk1"
+
         mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         print("Action: Parsing stream...")
         events = []
-        
-        with patch('kiro.streaming_core.AwsEventStreamParser', return_value=mock_parser):
-            with patch('kiro.streaming_core.FAKE_REASONING_ENABLED', False):
-                async for event in parse_kiro_stream(mock_response, first_token_timeout=30):
+
+        with patch(
+            "kiro.streaming_core.AwsEventStreamParser", return_value=mock_parser
+        ):
+            with patch("kiro.streaming_core.FAKE_REASONING_ENABLED", False):
+                async for event in parse_kiro_stream(
+                    mock_response, first_token_timeout=30
+                ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
         context_events = [e for e in events if e.type == "context_usage"]
-        
+
         assert len(context_events) == 1
         assert context_events[0].context_usage_percentage == 5.5
         print("✓ Context usage events parsed correctly")
-    
+
     @pytest.mark.asyncio
     async def test_yields_tool_calls_at_end(self, mock_response, mock_parser):
         """
@@ -418,27 +435,31 @@ class TestParseKiroStream:
         mock_parser.get_tool_calls.return_value = [
             {"id": "call_1", "function": {"name": "func1", "arguments": "{}"}}
         ]
-        
+
         async def mock_aiter_bytes():
-            yield b'chunk1'
-        
+            yield b"chunk1"
+
         mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         print("Action: Parsing stream...")
         events = []
-        
-        with patch('kiro.streaming_core.AwsEventStreamParser', return_value=mock_parser):
-            with patch('kiro.streaming_core.FAKE_REASONING_ENABLED', False):
-                async for event in parse_kiro_stream(mock_response, first_token_timeout=30):
+
+        with patch(
+            "kiro.streaming_core.AwsEventStreamParser", return_value=mock_parser
+        ):
+            with patch("kiro.streaming_core.FAKE_REASONING_ENABLED", False):
+                async for event in parse_kiro_stream(
+                    mock_response, first_token_timeout=30
+                ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
         tool_events = [e for e in events if e.type == "tool_use"]
-        
+
         assert len(tool_events) == 1
         assert tool_events[0].tool_use["id"] == "call_1"
         print("✓ Tool calls yielded correctly")
-    
+
     @pytest.mark.asyncio
     async def test_raises_timeout_on_first_token(self, mock_response):
         """
@@ -446,26 +467,30 @@ class TestParseKiroStream:
         Goal: Verify timeout handling for first token.
         """
         print("Setup: Mock response that times out...")
-        
+
         async def mock_aiter_bytes():
-            yield b'chunk'
-        
+            yield b"chunk"
+
         mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         async def mock_wait_for_timeout(*args, **kwargs):
             raise asyncio.TimeoutError()
-        
+
         print("Action: Parsing stream with timeout...")
-        
-        with patch('kiro.streaming_core.asyncio.wait_for', side_effect=mock_wait_for_timeout):
+
+        with patch(
+            "kiro.streaming_core.asyncio.wait_for", side_effect=mock_wait_for_timeout
+        ):
             with pytest.raises(FirstTokenTimeoutError) as exc_info:
-                async for event in parse_kiro_stream(mock_response, first_token_timeout=30):
+                async for event in parse_kiro_stream(
+                    mock_response, first_token_timeout=30
+                ):
                     pass
-        
+
         print(f"Caught exception: {exc_info.value}")
         assert "30" in str(exc_info.value)
         print("✓ FirstTokenTimeoutError raised on timeout")
-    
+
     @pytest.mark.asyncio
     async def test_handles_empty_response(self, mock_response):
         """
@@ -473,28 +498,30 @@ class TestParseKiroStream:
         Goal: Verify no events yielded for empty response.
         """
         print("Setup: Mock empty response...")
-        
+
         async def mock_aiter_bytes():
             return
             yield  # Make it a generator
-        
+
         mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         # Mock wait_for to raise StopAsyncIteration (empty response)
         async def mock_wait_for_empty(*args, **kwargs):
             raise StopAsyncIteration()
-        
+
         print("Action: Parsing empty stream...")
         events = []
-        
-        with patch('kiro.streaming_core.asyncio.wait_for', side_effect=mock_wait_for_empty):
+
+        with patch(
+            "kiro.streaming_core.asyncio.wait_for", side_effect=mock_wait_for_empty
+        ):
             async for event in parse_kiro_stream(mock_response, first_token_timeout=30):
                 events.append(event)
-        
+
         print(f"Received {len(events)} events")
         assert len(events) == 0
         print("✓ Empty response handled correctly")
-    
+
     @pytest.mark.asyncio
     async def test_handles_generator_exit(self, mock_response, mock_parser):
         """
@@ -502,26 +529,30 @@ class TestParseKiroStream:
         Goal: Verify client disconnect is handled.
         """
         print("Setup: Mock response that raises GeneratorExit...")
-        
+
         async def mock_aiter_bytes():
-            yield b'chunk1'
+            yield b"chunk1"
             raise GeneratorExit()
-        
+
         mock_response.aiter_bytes = mock_aiter_bytes
         mock_parser.feed.return_value = [{"type": "content", "data": "Hello"}]
-        
+
         print("Action: Parsing stream with GeneratorExit...")
         events = []
         generator_exit_raised = False
-        
-        with patch('kiro.streaming_core.AwsEventStreamParser', return_value=mock_parser):
-            with patch('kiro.streaming_core.FAKE_REASONING_ENABLED', False):
+
+        with patch(
+            "kiro.streaming_core.AwsEventStreamParser", return_value=mock_parser
+        ):
+            with patch("kiro.streaming_core.FAKE_REASONING_ENABLED", False):
                 try:
-                    async for event in parse_kiro_stream(mock_response, first_token_timeout=30):
+                    async for event in parse_kiro_stream(
+                        mock_response, first_token_timeout=30
+                    ):
                         events.append(event)
                 except GeneratorExit:
                     generator_exit_raised = True
-        
+
         print(f"GeneratorExit raised: {generator_exit_raised}")
         assert generator_exit_raised
         print("✓ GeneratorExit handled correctly")
@@ -531,9 +562,10 @@ class TestParseKiroStream:
 # Tests for _process_chunk()
 # ==================================================================================================
 
+
 class TestProcessChunk:
     """Tests for _process_chunk() helper function."""
-    
+
     @pytest.mark.asyncio
     async def test_processes_content_event(self, mock_parser):
         """
@@ -542,18 +574,18 @@ class TestProcessChunk:
         """
         print("Setup: Mock parser with content event...")
         mock_parser.feed.return_value = [{"type": "content", "data": "Hello"}]
-        
+
         print("Action: Processing chunk...")
         events = []
-        async for event in _process_chunk(mock_parser, b'chunk', None):
+        async for event in _process_chunk(mock_parser, b"chunk", None):
             events.append(event)
-        
+
         print(f"Received {len(events)} events")
         assert len(events) == 1
         assert events[0].type == "content"
         assert events[0].content == "Hello"
         print("✓ Content event processed correctly")
-    
+
     @pytest.mark.asyncio
     async def test_processes_usage_event(self, mock_parser):
         """
@@ -562,18 +594,18 @@ class TestProcessChunk:
         """
         print("Setup: Mock parser with usage event...")
         mock_parser.feed.return_value = [{"type": "usage", "data": {"credits": 0.001}}]
-        
+
         print("Action: Processing chunk...")
         events = []
-        async for event in _process_chunk(mock_parser, b'chunk', None):
+        async for event in _process_chunk(mock_parser, b"chunk", None):
             events.append(event)
-        
+
         print(f"Received {len(events)} events")
         assert len(events) == 1
         assert events[0].type == "usage"
         assert events[0].usage == {"credits": 0.001}
         print("✓ Usage event processed correctly")
-    
+
     @pytest.mark.asyncio
     async def test_processes_context_usage_event(self, mock_parser):
         """
@@ -582,18 +614,18 @@ class TestProcessChunk:
         """
         print("Setup: Mock parser with context_usage event...")
         mock_parser.feed.return_value = [{"type": "context_usage", "data": 7.5}]
-        
+
         print("Action: Processing chunk...")
         events = []
-        async for event in _process_chunk(mock_parser, b'chunk', None):
+        async for event in _process_chunk(mock_parser, b"chunk", None):
             events.append(event)
-        
+
         print(f"Received {len(events)} events")
         assert len(events) == 1
         assert events[0].type == "context_usage"
         assert events[0].context_usage_percentage == 7.5
         print("✓ Context usage event processed correctly")
-    
+
     @pytest.mark.asyncio
     async def test_processes_multiple_events(self, mock_parser):
         """
@@ -604,21 +636,21 @@ class TestProcessChunk:
         mock_parser.feed.return_value = [
             {"type": "content", "data": "Hello"},
             {"type": "content", "data": " World"},
-            {"type": "usage", "data": {"credits": 0.001}}
+            {"type": "usage", "data": {"credits": 0.001}},
         ]
-        
+
         print("Action: Processing chunk...")
         events = []
-        async for event in _process_chunk(mock_parser, b'chunk', None):
+        async for event in _process_chunk(mock_parser, b"chunk", None):
             events.append(event)
-        
+
         print(f"Received {len(events)} events")
         assert len(events) == 3
         assert events[0].type == "content"
         assert events[1].type == "content"
         assert events[2].type == "usage"
         print("✓ Multiple events processed correctly")
-    
+
     @pytest.mark.asyncio
     async def test_processes_with_thinking_parser(self, mock_parser):
         """
@@ -627,26 +659,26 @@ class TestProcessChunk:
         """
         print("Setup: Mock parser and thinking parser...")
         mock_parser.feed.return_value = [{"type": "content", "data": "Hello"}]
-        
+
         mock_thinking_parser = MagicMock()
         mock_thinking_parser.feed.return_value = MagicMock(
             thinking_content=None,
             regular_content="Hello",
             is_first_thinking_chunk=False,
-            is_last_thinking_chunk=False
+            is_last_thinking_chunk=False,
         )
-        
+
         print("Action: Processing chunk with thinking parser...")
         events = []
-        async for event in _process_chunk(mock_parser, b'chunk', mock_thinking_parser):
+        async for event in _process_chunk(mock_parser, b"chunk", mock_thinking_parser):
             events.append(event)
-        
+
         print(f"Received {len(events)} events")
         assert len(events) == 1
         assert events[0].type == "content"
         assert events[0].content == "Hello"
         print("✓ Thinking parser integration works correctly")
-    
+
     @pytest.mark.asyncio
     async def test_yields_thinking_content(self, mock_parser):
         """
@@ -654,22 +686,24 @@ class TestProcessChunk:
         Goal: Verify thinking events are created.
         """
         print("Setup: Mock parser and thinking parser with thinking content...")
-        mock_parser.feed.return_value = [{"type": "content", "data": "<thinking>Let me think</thinking>"}]
-        
+        mock_parser.feed.return_value = [
+            {"type": "content", "data": "<thinking>Let me think</thinking>"}
+        ]
+
         mock_thinking_parser = MagicMock()
         mock_thinking_parser.feed.return_value = MagicMock(
             thinking_content="Let me think",
             regular_content=None,
             is_first_thinking_chunk=True,
-            is_last_thinking_chunk=True
+            is_last_thinking_chunk=True,
         )
         mock_thinking_parser.process_for_output.return_value = "Let me think"
-        
+
         print("Action: Processing chunk with thinking content...")
         events = []
-        async for event in _process_chunk(mock_parser, b'chunk', mock_thinking_parser):
+        async for event in _process_chunk(mock_parser, b"chunk", mock_thinking_parser):
             events.append(event)
-        
+
         print(f"Received {len(events)} events")
         thinking_events = [e for e in events if e.type == "thinking"]
         assert len(thinking_events) == 1
@@ -681,9 +715,10 @@ class TestProcessChunk:
 # Tests for collect_stream_to_result()
 # ==================================================================================================
 
+
 class TestCollectStreamToResult:
     """Tests for collect_stream_to_result() function."""
-    
+
     @pytest.mark.asyncio
     async def test_collects_content(self, mock_response, mock_parser):
         """
@@ -693,26 +728,32 @@ class TestCollectStreamToResult:
         print("Setup: Mock parser with content events...")
         mock_parser.feed.return_value = [
             {"type": "content", "data": "Hello"},
-            {"type": "content", "data": " World"}
+            {"type": "content", "data": " World"},
         ]
         mock_parser.get_tool_calls.return_value = []
-        
+
         async def mock_aiter_bytes():
-            yield b'chunk1'
-        
+            yield b"chunk1"
+
         mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         print("Action: Collecting stream...")
-        
-        with patch('kiro.streaming_core.AwsEventStreamParser', return_value=mock_parser):
-            with patch('kiro.streaming_core.FAKE_REASONING_ENABLED', False):
-                with patch('kiro.streaming_core.parse_bracket_tool_calls', return_value=[]):
-                    result = await collect_stream_to_result(mock_response, first_token_timeout=30)
-        
+
+        with patch(
+            "kiro.streaming_core.AwsEventStreamParser", return_value=mock_parser
+        ):
+            with patch("kiro.streaming_core.FAKE_REASONING_ENABLED", False):
+                with patch(
+                    "kiro.streaming_core.parse_bracket_tool_calls", return_value=[]
+                ):
+                    result = await collect_stream_to_result(
+                        mock_response, first_token_timeout=30
+                    )
+
         print(f"Collected content: '{result.content}'")
         assert result.content == "Hello World"
         print("✓ Content collected correctly")
-    
+
     @pytest.mark.asyncio
     async def test_collects_tool_calls(self, mock_response, mock_parser):
         """
@@ -724,24 +765,30 @@ class TestCollectStreamToResult:
         mock_parser.get_tool_calls.return_value = [
             {"id": "call_1", "function": {"name": "func1", "arguments": "{}"}}
         ]
-        
+
         async def mock_aiter_bytes():
-            yield b'chunk1'
-        
+            yield b"chunk1"
+
         mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         print("Action: Collecting stream...")
-        
-        with patch('kiro.streaming_core.AwsEventStreamParser', return_value=mock_parser):
-            with patch('kiro.streaming_core.FAKE_REASONING_ENABLED', False):
-                with patch('kiro.streaming_core.parse_bracket_tool_calls', return_value=[]):
-                    result = await collect_stream_to_result(mock_response, first_token_timeout=30)
-        
+
+        with patch(
+            "kiro.streaming_core.AwsEventStreamParser", return_value=mock_parser
+        ):
+            with patch("kiro.streaming_core.FAKE_REASONING_ENABLED", False):
+                with patch(
+                    "kiro.streaming_core.parse_bracket_tool_calls", return_value=[]
+                ):
+                    result = await collect_stream_to_result(
+                        mock_response, first_token_timeout=30
+                    )
+
         print(f"Collected tool calls: {len(result.tool_calls)}")
         assert len(result.tool_calls) == 1
         assert result.tool_calls[0]["id"] == "call_1"
         print("✓ Tool calls collected correctly")
-    
+
     @pytest.mark.asyncio
     async def test_collects_usage(self, mock_response, mock_parser):
         """
@@ -751,26 +798,32 @@ class TestCollectStreamToResult:
         print("Setup: Mock parser with usage event...")
         mock_parser.feed.return_value = [
             {"type": "content", "data": "text"},
-            {"type": "usage", "data": {"credits": 0.002}}
+            {"type": "usage", "data": {"credits": 0.002}},
         ]
         mock_parser.get_tool_calls.return_value = []
-        
+
         async def mock_aiter_bytes():
-            yield b'chunk1'
-        
+            yield b"chunk1"
+
         mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         print("Action: Collecting stream...")
-        
-        with patch('kiro.streaming_core.AwsEventStreamParser', return_value=mock_parser):
-            with patch('kiro.streaming_core.FAKE_REASONING_ENABLED', False):
-                with patch('kiro.streaming_core.parse_bracket_tool_calls', return_value=[]):
-                    result = await collect_stream_to_result(mock_response, first_token_timeout=30)
-        
+
+        with patch(
+            "kiro.streaming_core.AwsEventStreamParser", return_value=mock_parser
+        ):
+            with patch("kiro.streaming_core.FAKE_REASONING_ENABLED", False):
+                with patch(
+                    "kiro.streaming_core.parse_bracket_tool_calls", return_value=[]
+                ):
+                    result = await collect_stream_to_result(
+                        mock_response, first_token_timeout=30
+                    )
+
         print(f"Collected usage: {result.usage}")
         assert result.usage == {"credits": 0.002}
         print("✓ Usage collected correctly")
-    
+
     @pytest.mark.asyncio
     async def test_collects_context_usage_percentage(self, mock_response, mock_parser):
         """
@@ -780,26 +833,32 @@ class TestCollectStreamToResult:
         print("Setup: Mock parser with context_usage event...")
         mock_parser.feed.return_value = [
             {"type": "content", "data": "text"},
-            {"type": "context_usage", "data": 8.5}
+            {"type": "context_usage", "data": 8.5},
         ]
         mock_parser.get_tool_calls.return_value = []
-        
+
         async def mock_aiter_bytes():
-            yield b'chunk1'
-        
+            yield b"chunk1"
+
         mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         print("Action: Collecting stream...")
-        
-        with patch('kiro.streaming_core.AwsEventStreamParser', return_value=mock_parser):
-            with patch('kiro.streaming_core.FAKE_REASONING_ENABLED', False):
-                with patch('kiro.streaming_core.parse_bracket_tool_calls', return_value=[]):
-                    result = await collect_stream_to_result(mock_response, first_token_timeout=30)
-        
+
+        with patch(
+            "kiro.streaming_core.AwsEventStreamParser", return_value=mock_parser
+        ):
+            with patch("kiro.streaming_core.FAKE_REASONING_ENABLED", False):
+                with patch(
+                    "kiro.streaming_core.parse_bracket_tool_calls", return_value=[]
+                ):
+                    result = await collect_stream_to_result(
+                        mock_response, first_token_timeout=30
+                    )
+
         print(f"Collected context_usage_percentage: {result.context_usage_percentage}")
         assert result.context_usage_percentage == 8.5
         print("✓ Context usage percentage collected correctly")
-    
+
     @pytest.mark.asyncio
     async def test_collects_thinking_content(self, mock_response, mock_parser):
         """
@@ -810,34 +869,36 @@ class TestCollectStreamToResult:
         # We need to mock the thinking parser behavior
         mock_parser.feed.return_value = [{"type": "content", "data": "thinking text"}]
         mock_parser.get_tool_calls.return_value = []
-        
+
         async def mock_aiter_bytes():
-            yield b'chunk1'
-        
+            yield b"chunk1"
+
         mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         # Create mock events that include thinking
         mock_events = [
             KiroEvent(type="thinking", thinking_content="Let me think..."),
-            KiroEvent(type="content", content="Here is my answer")
+            KiroEvent(type="content", content="Here is my answer"),
         ]
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             for event in mock_events:
                 yield event
-        
+
         print("Action: Collecting stream with thinking...")
-        
-        with patch('kiro.streaming_core.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_core.parse_bracket_tool_calls', return_value=[]):
-                result = await collect_stream_to_result(mock_response, first_token_timeout=30)
-        
+
+        with patch("kiro.streaming_core.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_core.parse_bracket_tool_calls", return_value=[]):
+                result = await collect_stream_to_result(
+                    mock_response, first_token_timeout=30
+                )
+
         print(f"Collected thinking_content: '{result.thinking_content}'")
         print(f"Collected content: '{result.content}'")
         assert result.thinking_content == "Let me think..."
         assert result.content == "Here is my answer"
         print("✓ Thinking content collected correctly")
-    
+
     @pytest.mark.asyncio
     async def test_deduplicates_bracket_tool_calls(self, mock_response, mock_parser):
         """
@@ -849,29 +910,47 @@ class TestCollectStreamToResult:
         mock_parser.get_tool_calls.return_value = [
             {"id": "call_1", "function": {"name": "func1", "arguments": "{}"}}
         ]
-        
+
         bracket_tool_calls = [
-            {"id": "call_1", "function": {"name": "func1", "arguments": "{}"}},  # Duplicate
-            {"id": "call_2", "function": {"name": "func2", "arguments": "{}"}}   # New
+            {
+                "id": "call_1",
+                "function": {"name": "func1", "arguments": "{}"},
+            },  # Duplicate
+            {"id": "call_2", "function": {"name": "func2", "arguments": "{}"}},  # New
         ]
-        
+
         async def mock_aiter_bytes():
-            yield b'chunk1'
-        
+            yield b"chunk1"
+
         mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         print("Action: Collecting stream with duplicates...")
-        
-        with patch('kiro.streaming_core.AwsEventStreamParser', return_value=mock_parser):
-            with patch('kiro.streaming_core.FAKE_REASONING_ENABLED', False):
-                with patch('kiro.streaming_core.parse_bracket_tool_calls', return_value=bracket_tool_calls):
-                    with patch('kiro.streaming_core.deduplicate_tool_calls') as mock_dedup:
+
+        with patch(
+            "kiro.streaming_core.AwsEventStreamParser", return_value=mock_parser
+        ):
+            with patch("kiro.streaming_core.FAKE_REASONING_ENABLED", False):
+                with patch(
+                    "kiro.streaming_core.parse_bracket_tool_calls",
+                    return_value=bracket_tool_calls,
+                ):
+                    with patch(
+                        "kiro.streaming_core.deduplicate_tool_calls"
+                    ) as mock_dedup:
                         mock_dedup.return_value = [
-                            {"id": "call_1", "function": {"name": "func1", "arguments": "{}"}},
-                            {"id": "call_2", "function": {"name": "func2", "arguments": "{}"}}
+                            {
+                                "id": "call_1",
+                                "function": {"name": "func1", "arguments": "{}"},
+                            },
+                            {
+                                "id": "call_2",
+                                "function": {"name": "func2", "arguments": "{}"},
+                            },
                         ]
-                        result = await collect_stream_to_result(mock_response, first_token_timeout=30)
-        
+                        result = await collect_stream_to_result(
+                            mock_response, first_token_timeout=30
+                        )
+
         print(f"Collected tool calls: {len(result.tool_calls)}")
         assert len(result.tool_calls) == 2
         print("✓ Tool calls deduplicated correctly")
@@ -881,9 +960,10 @@ class TestCollectStreamToResult:
 # Tests for calculate_tokens_from_context_usage()
 # ==================================================================================================
 
+
 class TestCalculateTokensFromContextUsage:
     """Tests for calculate_tokens_from_context_usage() function."""
-    
+
     def test_calculates_tokens_from_percentage(self, mock_model_cache):
         """
         What it does: Calculates tokens from context usage percentage.
@@ -892,12 +972,17 @@ class TestCalculateTokensFromContextUsage:
         print("Setup: Context usage 10% with 200000 max tokens...")
         context_usage_percentage = 10.0
         completion_tokens = 100
-        
+
         print("Action: Calculating tokens...")
-        prompt_tokens, total_tokens, prompt_source, total_source = calculate_tokens_from_context_usage(
-            context_usage_percentage, completion_tokens, mock_model_cache, "claude-sonnet-4"
+        prompt_tokens, total_tokens, prompt_source, total_source = (
+            calculate_tokens_from_context_usage(
+                context_usage_percentage,
+                completion_tokens,
+                mock_model_cache,
+                "claude-sonnet-4",
+            )
         )
-        
+
         # 10% of 200000 = 20000 total tokens
         # prompt_tokens = 20000 - 100 = 19900
         print(f"Comparing total_tokens: Expected 20000, Got {total_tokens}")
@@ -907,7 +992,7 @@ class TestCalculateTokensFromContextUsage:
         assert prompt_source == "subtraction"
         assert total_source == "API Kiro"
         print("✓ Tokens calculated correctly")
-    
+
     def test_handles_zero_percentage(self, mock_model_cache):
         """
         What it does: Handles zero context usage percentage.
@@ -916,12 +1001,17 @@ class TestCalculateTokensFromContextUsage:
         print("Setup: Context usage 0%...")
         context_usage_percentage = 0.0
         completion_tokens = 100
-        
+
         print("Action: Calculating tokens...")
-        prompt_tokens, total_tokens, prompt_source, total_source = calculate_tokens_from_context_usage(
-            context_usage_percentage, completion_tokens, mock_model_cache, "claude-sonnet-4"
+        prompt_tokens, total_tokens, prompt_source, total_source = (
+            calculate_tokens_from_context_usage(
+                context_usage_percentage,
+                completion_tokens,
+                mock_model_cache,
+                "claude-sonnet-4",
+            )
         )
-        
+
         print(f"Comparing prompt_tokens: Expected 0, Got {prompt_tokens}")
         assert prompt_tokens == 0
         print(f"Comparing total_tokens: Expected 100, Got {total_tokens}")
@@ -929,7 +1019,7 @@ class TestCalculateTokensFromContextUsage:
         assert prompt_source == "unknown"
         assert total_source == "tiktoken"
         print("✓ Zero percentage handled correctly")
-    
+
     def test_handles_none_percentage(self, mock_model_cache):
         """
         What it does: Handles None context usage percentage.
@@ -938,12 +1028,17 @@ class TestCalculateTokensFromContextUsage:
         print("Setup: Context usage None...")
         context_usage_percentage = None
         completion_tokens = 100
-        
+
         print("Action: Calculating tokens...")
-        prompt_tokens, total_tokens, prompt_source, total_source = calculate_tokens_from_context_usage(
-            context_usage_percentage, completion_tokens, mock_model_cache, "claude-sonnet-4"
+        prompt_tokens, total_tokens, prompt_source, total_source = (
+            calculate_tokens_from_context_usage(
+                context_usage_percentage,
+                completion_tokens,
+                mock_model_cache,
+                "claude-sonnet-4",
+            )
         )
-        
+
         print(f"Comparing prompt_tokens: Expected 0, Got {prompt_tokens}")
         assert prompt_tokens == 0
         print(f"Comparing total_tokens: Expected 100, Got {total_tokens}")
@@ -951,7 +1046,7 @@ class TestCalculateTokensFromContextUsage:
         assert prompt_source == "unknown"
         assert total_source == "tiktoken"
         print("✓ None percentage handled correctly")
-    
+
     def test_prevents_negative_prompt_tokens(self, mock_model_cache):
         """
         What it does: Prevents negative prompt tokens.
@@ -960,39 +1055,51 @@ class TestCalculateTokensFromContextUsage:
         print("Setup: Very small context usage with large completion...")
         context_usage_percentage = 0.01  # 0.01% of 200000 = 20 total tokens
         completion_tokens = 100  # More than total!
-        
+
         print("Action: Calculating tokens...")
-        prompt_tokens, total_tokens, prompt_source, total_source = calculate_tokens_from_context_usage(
-            context_usage_percentage, completion_tokens, mock_model_cache, "claude-sonnet-4"
+        prompt_tokens, total_tokens, prompt_source, total_source = (
+            calculate_tokens_from_context_usage(
+                context_usage_percentage,
+                completion_tokens,
+                mock_model_cache,
+                "claude-sonnet-4",
+            )
         )
-        
+
         print(f"Comparing prompt_tokens: Expected >= 0, Got {prompt_tokens}")
         assert prompt_tokens >= 0
         print("✓ Negative prompt tokens prevented")
-    
+
     def test_uses_model_specific_max_tokens(self, mock_model_cache):
         """
         What it does: Uses model-specific max input tokens.
         Goal: Verify model cache is queried correctly.
         """
         print("Setup: Different max tokens for model...")
-        mock_model_cache.get_max_input_tokens.return_value = 100000  # Different from default
+        mock_model_cache.get_max_input_tokens.return_value = (
+            100000  # Different from default
+        )
         context_usage_percentage = 10.0
         completion_tokens = 100
-        
+
         print("Action: Calculating tokens...")
-        prompt_tokens, total_tokens, prompt_source, total_source = calculate_tokens_from_context_usage(
-            context_usage_percentage, completion_tokens, mock_model_cache, "claude-haiku-3"
+        prompt_tokens, total_tokens, prompt_source, total_source = (
+            calculate_tokens_from_context_usage(
+                context_usage_percentage,
+                completion_tokens,
+                mock_model_cache,
+                "claude-haiku-3",
+            )
         )
-        
+
         # 10% of 100000 = 10000 total tokens
         print(f"Comparing total_tokens: Expected 10000, Got {total_tokens}")
         assert total_tokens == 10000
-        
+
         # Verify model cache was called with correct model
         mock_model_cache.get_max_input_tokens.assert_called_with("claude-haiku-3")
         print("✓ Model-specific max tokens used correctly")
-    
+
     def test_small_percentage_calculation(self, mock_model_cache):
         """
         What it does: Calculates tokens for small percentage.
@@ -1001,12 +1108,17 @@ class TestCalculateTokensFromContextUsage:
         print("Setup: Context usage 0.5%...")
         context_usage_percentage = 0.5
         completion_tokens = 50
-        
+
         print("Action: Calculating tokens...")
-        prompt_tokens, total_tokens, prompt_source, total_source = calculate_tokens_from_context_usage(
-            context_usage_percentage, completion_tokens, mock_model_cache, "claude-sonnet-4"
+        prompt_tokens, total_tokens, prompt_source, total_source = (
+            calculate_tokens_from_context_usage(
+                context_usage_percentage,
+                completion_tokens,
+                mock_model_cache,
+                "claude-sonnet-4",
+            )
         )
-        
+
         # 0.5% of 200000 = 1000 total tokens
         # prompt_tokens = 1000 - 50 = 950
         print(f"Comparing total_tokens: Expected 1000, Got {total_tokens}")
@@ -1014,7 +1126,7 @@ class TestCalculateTokensFromContextUsage:
         print(f"Comparing prompt_tokens: Expected 950, Got {prompt_tokens}")
         assert prompt_tokens == 950
         print("✓ Small percentage calculated correctly")
-    
+
     def test_large_percentage_calculation(self, mock_model_cache):
         """
         What it does: Calculates tokens for large percentage.
@@ -1023,12 +1135,17 @@ class TestCalculateTokensFromContextUsage:
         print("Setup: Context usage 95%...")
         context_usage_percentage = 95.0
         completion_tokens = 1000
-        
+
         print("Action: Calculating tokens...")
-        prompt_tokens, total_tokens, prompt_source, total_source = calculate_tokens_from_context_usage(
-            context_usage_percentage, completion_tokens, mock_model_cache, "claude-sonnet-4"
+        prompt_tokens, total_tokens, prompt_source, total_source = (
+            calculate_tokens_from_context_usage(
+                context_usage_percentage,
+                completion_tokens,
+                mock_model_cache,
+                "claude-sonnet-4",
+            )
         )
-        
+
         # 95% of 200000 = 190000 total tokens
         # prompt_tokens = 190000 - 1000 = 189000
         print(f"Comparing total_tokens: Expected 190000, Got {total_tokens}")
@@ -1042,11 +1159,14 @@ class TestCalculateTokensFromContextUsage:
 # Tests for thinking parser integration
 # ==================================================================================================
 
+
 class TestThinkingParserIntegration:
     """Tests for thinking parser integration in streaming."""
-    
+
     @pytest.mark.asyncio
-    async def test_thinking_parser_enabled_when_fake_reasoning_on(self, mock_response, mock_parser):
+    async def test_thinking_parser_enabled_when_fake_reasoning_on(
+        self, mock_response, mock_parser
+    ):
         """
         What it does: Enables thinking parser when FAKE_REASONING_ENABLED is True.
         Goal: Verify thinking parser is created.
@@ -1054,44 +1174,52 @@ class TestThinkingParserIntegration:
         print("Setup: Enable fake reasoning...")
         mock_parser.feed.return_value = [{"type": "content", "data": "Hello"}]
         mock_parser.get_tool_calls.return_value = []
-        
+
         async def mock_aiter_bytes():
-            yield b'chunk1'
-        
+            yield b"chunk1"
+
         mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         print("Action: Parsing stream with fake reasoning enabled...")
         events = []
-        
-        with patch('kiro.streaming_core.AwsEventStreamParser', return_value=mock_parser):
-            with patch('kiro.streaming_core.FAKE_REASONING_ENABLED', True):
-                with patch('kiro.streaming_core.ThinkingParser') as mock_thinking_parser_class:
+
+        with patch(
+            "kiro.streaming_core.AwsEventStreamParser", return_value=mock_parser
+        ):
+            with patch("kiro.streaming_core.FAKE_REASONING_ENABLED", True):
+                with patch(
+                    "kiro.streaming_core.ThinkingParser"
+                ) as mock_thinking_parser_class:
                     mock_thinking_parser = MagicMock()
                     mock_thinking_parser.feed.return_value = MagicMock(
                         thinking_content=None,
                         regular_content="Hello",
                         is_first_thinking_chunk=False,
-                        is_last_thinking_chunk=False
+                        is_last_thinking_chunk=False,
                     )
                     mock_thinking_parser.finalize.return_value = MagicMock(
                         thinking_content=None,
                         regular_content=None,
                         is_first_thinking_chunk=False,
-                        is_last_thinking_chunk=False
+                        is_last_thinking_chunk=False,
                     )
                     mock_thinking_parser.found_thinking_block = False
                     mock_thinking_parser_class.return_value = mock_thinking_parser
-                    
-                    async for event in parse_kiro_stream(mock_response, first_token_timeout=30):
+
+                    async for event in parse_kiro_stream(
+                        mock_response, first_token_timeout=30
+                    ):
                         events.append(event)
-                    
+
                     # Verify ThinkingParser was instantiated
                     mock_thinking_parser_class.assert_called_once()
-        
+
         print("✓ Thinking parser enabled when fake reasoning is on")
-    
+
     @pytest.mark.asyncio
-    async def test_thinking_parser_disabled_when_fake_reasoning_off(self, mock_response, mock_parser):
+    async def test_thinking_parser_disabled_when_fake_reasoning_off(
+        self, mock_response, mock_parser
+    ):
         """
         What it does: Disables thinking parser when FAKE_REASONING_ENABLED is False.
         Goal: Verify thinking parser is not created.
@@ -1099,28 +1227,36 @@ class TestThinkingParserIntegration:
         print("Setup: Disable fake reasoning...")
         mock_parser.feed.return_value = [{"type": "content", "data": "Hello"}]
         mock_parser.get_tool_calls.return_value = []
-        
+
         async def mock_aiter_bytes():
-            yield b'chunk1'
-        
+            yield b"chunk1"
+
         mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         print("Action: Parsing stream with fake reasoning disabled...")
         events = []
-        
-        with patch('kiro.streaming_core.AwsEventStreamParser', return_value=mock_parser):
-            with patch('kiro.streaming_core.FAKE_REASONING_ENABLED', False):
-                with patch('kiro.streaming_core.ThinkingParser') as mock_thinking_parser_class:
-                    async for event in parse_kiro_stream(mock_response, first_token_timeout=30):
+
+        with patch(
+            "kiro.streaming_core.AwsEventStreamParser", return_value=mock_parser
+        ):
+            with patch("kiro.streaming_core.FAKE_REASONING_ENABLED", False):
+                with patch(
+                    "kiro.streaming_core.ThinkingParser"
+                ) as mock_thinking_parser_class:
+                    async for event in parse_kiro_stream(
+                        mock_response, first_token_timeout=30
+                    ):
                         events.append(event)
-                    
+
                     # Verify ThinkingParser was NOT instantiated
                     mock_thinking_parser_class.assert_not_called()
-        
+
         print("✓ Thinking parser disabled when fake reasoning is off")
-    
+
     @pytest.mark.asyncio
-    async def test_thinking_parser_can_be_disabled_via_parameter(self, mock_response, mock_parser):
+    async def test_thinking_parser_can_be_disabled_via_parameter(
+        self, mock_response, mock_parser
+    ):
         """
         What it does: Disables thinking parser via enable_thinking_parser parameter.
         Goal: Verify parameter overrides config.
@@ -1128,28 +1264,32 @@ class TestThinkingParserIntegration:
         print("Setup: Enable fake reasoning but disable via parameter...")
         mock_parser.feed.return_value = [{"type": "content", "data": "Hello"}]
         mock_parser.get_tool_calls.return_value = []
-        
+
         async def mock_aiter_bytes():
-            yield b'chunk1'
-        
+            yield b"chunk1"
+
         mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         print("Action: Parsing stream with thinking parser disabled via parameter...")
         events = []
-        
-        with patch('kiro.streaming_core.AwsEventStreamParser', return_value=mock_parser):
-            with patch('kiro.streaming_core.FAKE_REASONING_ENABLED', True):
-                with patch('kiro.streaming_core.ThinkingParser') as mock_thinking_parser_class:
+
+        with patch(
+            "kiro.streaming_core.AwsEventStreamParser", return_value=mock_parser
+        ):
+            with patch("kiro.streaming_core.FAKE_REASONING_ENABLED", True):
+                with patch(
+                    "kiro.streaming_core.ThinkingParser"
+                ) as mock_thinking_parser_class:
                     async for event in parse_kiro_stream(
                         mock_response,
                         first_token_timeout=30,
-                        enable_thinking_parser=False
+                        enable_thinking_parser=False,
                     ):
                         events.append(event)
-                    
+
                     # Verify ThinkingParser was NOT instantiated
                     mock_thinking_parser_class.assert_not_called()
-        
+
         print("✓ Thinking parser disabled via parameter")
 
 
@@ -1157,9 +1297,10 @@ class TestThinkingParserIntegration:
 # Tests for error handling
 # ==================================================================================================
 
+
 class TestStreamingCoreErrorHandling:
     """Tests for error handling in streaming_core."""
-    
+
     @pytest.mark.asyncio
     async def test_propagates_first_token_timeout_error(self, mock_response):
         """
@@ -1167,24 +1308,28 @@ class TestStreamingCoreErrorHandling:
         Goal: Verify timeout error is not caught internally.
         """
         print("Setup: Mock response that times out...")
-        
+
         async def mock_aiter_bytes():
-            yield b'chunk'
-        
+            yield b"chunk"
+
         mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         async def mock_wait_for_timeout(*args, **kwargs):
             raise asyncio.TimeoutError()
-        
+
         print("Action: Parsing stream with timeout...")
-        
-        with patch('kiro.streaming_core.asyncio.wait_for', side_effect=mock_wait_for_timeout):
+
+        with patch(
+            "kiro.streaming_core.asyncio.wait_for", side_effect=mock_wait_for_timeout
+        ):
             with pytest.raises(FirstTokenTimeoutError):
-                async for event in parse_kiro_stream(mock_response, first_token_timeout=30):
+                async for event in parse_kiro_stream(
+                    mock_response, first_token_timeout=30
+                ):
                     pass
-        
+
         print("✓ FirstTokenTimeoutError propagated correctly")
-    
+
     @pytest.mark.asyncio
     async def test_propagates_generator_exit(self, mock_response, mock_parser):
         """
@@ -1192,24 +1337,28 @@ class TestStreamingCoreErrorHandling:
         Goal: Verify client disconnect is handled.
         """
         print("Setup: Mock response that raises GeneratorExit...")
-        
+
         async def mock_aiter_bytes():
-            yield b'chunk1'
+            yield b"chunk1"
             raise GeneratorExit()
-        
+
         mock_response.aiter_bytes = mock_aiter_bytes
         mock_parser.feed.return_value = [{"type": "content", "data": "Hello"}]
-        
+
         print("Action: Parsing stream with GeneratorExit...")
-        
-        with patch('kiro.streaming_core.AwsEventStreamParser', return_value=mock_parser):
-            with patch('kiro.streaming_core.FAKE_REASONING_ENABLED', False):
+
+        with patch(
+            "kiro.streaming_core.AwsEventStreamParser", return_value=mock_parser
+        ):
+            with patch("kiro.streaming_core.FAKE_REASONING_ENABLED", False):
                 with pytest.raises(GeneratorExit):
-                    async for event in parse_kiro_stream(mock_response, first_token_timeout=30):
+                    async for event in parse_kiro_stream(
+                        mock_response, first_token_timeout=30
+                    ):
                         pass
-        
+
         print("✓ GeneratorExit propagated correctly")
-    
+
     @pytest.mark.asyncio
     async def test_propagates_other_exceptions(self, mock_response, mock_parser):
         """
@@ -1217,22 +1366,26 @@ class TestStreamingCoreErrorHandling:
         Goal: Verify errors are not swallowed.
         """
         print("Setup: Mock response that raises RuntimeError...")
-        
+
         async def mock_aiter_bytes():
-            yield b'chunk1'
+            yield b"chunk1"
             raise RuntimeError("Test error")
-        
+
         mock_response.aiter_bytes = mock_aiter_bytes
         mock_parser.feed.return_value = [{"type": "content", "data": "Hello"}]
-        
+
         print("Action: Parsing stream with RuntimeError...")
-        
-        with patch('kiro.streaming_core.AwsEventStreamParser', return_value=mock_parser):
-            with patch('kiro.streaming_core.FAKE_REASONING_ENABLED', False):
+
+        with patch(
+            "kiro.streaming_core.AwsEventStreamParser", return_value=mock_parser
+        ):
+            with patch("kiro.streaming_core.FAKE_REASONING_ENABLED", False):
                 with pytest.raises(RuntimeError) as exc_info:
-                    async for event in parse_kiro_stream(mock_response, first_token_timeout=30):
+                    async for event in parse_kiro_stream(
+                        mock_response, first_token_timeout=30
+                    ):
                         pass
-        
+
         print(f"Caught exception: {exc_info.value}")
         assert "Test error" in str(exc_info.value)
         print("✓ RuntimeError propagated correctly")
@@ -1242,14 +1395,15 @@ class TestStreamingCoreErrorHandling:
 # Tests for stream_with_first_token_retry()
 # ==================================================================================================
 
+
 class TestStreamWithFirstTokenRetryCore:
     """
     Tests for stream_with_first_token_retry() generic function.
-    
+
     This function provides automatic retry logic on first token timeout.
     It is used by both OpenAI and Anthropic streaming implementations.
     """
-    
+
     @pytest.mark.asyncio
     async def test_yields_chunks_on_success(self):
         """
@@ -1257,35 +1411,35 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify normal operation without retries.
         """
         print("Setup: Mock successful request...")
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.aclose = AsyncMock()
-        
+
         async def mock_make_request():
             return mock_response
-        
+
         async def mock_stream_processor(response):
             yield "chunk1"
             yield "chunk2"
             yield "chunk3"
-        
+
         print("Action: Streaming with retry wrapper...")
         chunks = []
-        
+
         async for chunk in stream_with_first_token_retry(
             make_request=mock_make_request,
             stream_processor=mock_stream_processor,
             max_retries=3,
-            first_token_timeout=30
+            first_token_timeout=30,
         ):
             chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
         assert len(chunks) == 3
         assert chunks == ["chunk1", "chunk2", "chunk3"]
         print("✓ Chunks yielded on success")
-    
+
     @pytest.mark.asyncio
     async def test_retries_on_first_token_timeout(self):
         """
@@ -1293,9 +1447,9 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify retry logic is triggered.
         """
         print("Setup: Mock request that times out then succeeds...")
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
@@ -1303,32 +1457,32 @@ class TestStreamWithFirstTokenRetryCore:
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             nonlocal call_count
             if call_count == 1:
                 raise FirstTokenTimeoutError("Timeout on first attempt")
             yield "success_chunk"
-        
+
         print("Action: Streaming with retry on timeout...")
         chunks = []
-        
+
         async for chunk in stream_with_first_token_retry(
             make_request=mock_make_request,
             stream_processor=mock_stream_processor,
             max_retries=3,
-            first_token_timeout=30
+            first_token_timeout=30,
         ):
             chunks.append(chunk)
-        
+
         print(f"Call count: {call_count}")
         print(f"Received {len(chunks)} chunks")
-        
+
         assert call_count == 2  # First timeout, second success
         assert len(chunks) == 1
         assert chunks[0] == "success_chunk"
         print("✓ Retry on timeout works correctly")
-    
+
     @pytest.mark.asyncio
     async def test_raises_exception_after_all_retries(self):
         """
@@ -1336,9 +1490,9 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify error handling when all retries fail.
         """
         print("Setup: Mock request that always times out...")
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
@@ -1346,30 +1500,30 @@ class TestStreamWithFirstTokenRetryCore:
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         print("Action: Streaming with all retries failing...")
-        
+
         with pytest.raises(Exception) as exc_info:
             async for chunk in stream_with_first_token_retry(
                 make_request=mock_make_request,
                 stream_processor=mock_stream_processor,
                 max_retries=3,
-                first_token_timeout=30
+                first_token_timeout=30,
             ):
                 pass
-        
+
         print(f"Call count: {call_count}")
         print(f"Exception: {exc_info.value}")
-        
+
         assert call_count == 3  # Should try exactly 3 times
         assert "30" in str(exc_info.value)  # Timeout value in message
         assert "3" in str(exc_info.value)  # Retry count in message
         print("✓ Exception raised after all retries")
-    
+
     @pytest.mark.asyncio
     async def test_uses_custom_error_callbacks(self):
         """
@@ -1377,38 +1531,40 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify on_http_error and on_all_retries_failed callbacks.
         """
         print("Setup: Mock request that always times out with custom callbacks...")
-        
+
         async def mock_make_request():
             response = AsyncMock()
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         def custom_all_retries_failed(max_retries, timeout):
-            return ValueError(f"Custom error: {max_retries} retries, {timeout}s timeout")
-        
+            return ValueError(
+                f"Custom error: {max_retries} retries, {timeout}s timeout"
+            )
+
         print("Action: Streaming with custom callback...")
-        
+
         with pytest.raises(ValueError) as exc_info:
             async for chunk in stream_with_first_token_retry(
                 make_request=mock_make_request,
                 stream_processor=mock_stream_processor,
                 max_retries=2,
                 first_token_timeout=15,
-                on_all_retries_failed=custom_all_retries_failed
+                on_all_retries_failed=custom_all_retries_failed,
             ):
                 pass
-        
+
         print(f"Exception: {exc_info.value}")
         assert "Custom error" in str(exc_info.value)
         assert "2 retries" in str(exc_info.value)
         assert "15" in str(exc_info.value)
         print("✓ Custom callback used correctly")
-    
+
     @pytest.mark.asyncio
     async def test_handles_http_error(self):
         """
@@ -1416,33 +1572,33 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify HTTP errors are handled correctly.
         """
         print("Setup: Mock request that returns HTTP error...")
-        
+
         async def mock_make_request():
             response = AsyncMock()
             response.status_code = 500
             response.aread = AsyncMock(return_value=b"Internal Server Error")
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             yield "should not reach"
-        
+
         print("Action: Streaming with HTTP error...")
-        
+
         with pytest.raises(Exception) as exc_info:
             async for chunk in stream_with_first_token_retry(
                 make_request=mock_make_request,
                 stream_processor=mock_stream_processor,
                 max_retries=3,
-                first_token_timeout=30
+                first_token_timeout=30,
             ):
                 pass
-        
+
         print(f"Exception: {exc_info.value}")
         assert "500" in str(exc_info.value)
         assert "Internal Server Error" in str(exc_info.value)
         print("✓ HTTP error handled correctly")
-    
+
     @pytest.mark.asyncio
     async def test_uses_custom_http_error_callback(self):
         """
@@ -1450,38 +1606,38 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify on_http_error callback is used.
         """
         print("Setup: Mock request with custom HTTP error callback...")
-        
+
         async def mock_make_request():
             response = AsyncMock()
             response.status_code = 429
             response.aread = AsyncMock(return_value=b"Rate limited")
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             yield "should not reach"
-        
+
         def custom_http_error(status_code, error_text):
             return RuntimeError(f"Custom HTTP error: {status_code} - {error_text}")
-        
+
         print("Action: Streaming with custom HTTP error callback...")
-        
+
         with pytest.raises(RuntimeError) as exc_info:
             async for chunk in stream_with_first_token_retry(
                 make_request=mock_make_request,
                 stream_processor=mock_stream_processor,
                 max_retries=3,
                 first_token_timeout=30,
-                on_http_error=custom_http_error
+                on_http_error=custom_http_error,
             ):
                 pass
-        
+
         print(f"Exception: {exc_info.value}")
         assert "Custom HTTP error" in str(exc_info.value)
         assert "429" in str(exc_info.value)
         assert "Rate limited" in str(exc_info.value)
         print("✓ Custom HTTP error callback used correctly")
-    
+
     @pytest.mark.asyncio
     async def test_closes_response_on_timeout(self):
         """
@@ -1489,42 +1645,42 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify response is properly closed after timeout.
         """
         print("Setup: Mock request that times out...")
-        
+
         responses = []
-        
+
         async def mock_make_request():
             response = AsyncMock()
             response.status_code = 200
             response.aclose = AsyncMock()
             responses.append(response)
             return response
-        
+
         async def mock_stream_processor(response):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         print("Action: Streaming with timeout...")
-        
+
         try:
             async for chunk in stream_with_first_token_retry(
                 make_request=mock_make_request,
                 stream_processor=mock_stream_processor,
                 max_retries=2,
-                first_token_timeout=30
+                first_token_timeout=30,
             ):
                 pass
         except Exception:
             pass
-        
+
         print(f"Created {len(responses)} responses")
-        
+
         # All responses should have been closed
         for i, response in enumerate(responses):
             print(f"Response {i} aclose called: {response.aclose.called}")
             response.aclose.assert_called()
-        
+
         print("✓ Responses closed on timeout")
-    
+
     @pytest.mark.asyncio
     async def test_propagates_non_timeout_exceptions(self):
         """
@@ -1532,9 +1688,9 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify other exceptions are not retried.
         """
         print("Setup: Mock request that raises RuntimeError...")
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
@@ -1542,29 +1698,29 @@ class TestStreamWithFirstTokenRetryCore:
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             raise RuntimeError("Not a timeout error")
             yield  # Make it a generator
-        
+
         print("Action: Streaming with non-timeout error...")
-        
+
         with pytest.raises(RuntimeError) as exc_info:
             async for chunk in stream_with_first_token_retry(
                 make_request=mock_make_request,
                 stream_processor=mock_stream_processor,
                 max_retries=3,
-                first_token_timeout=30
+                first_token_timeout=30,
             ):
                 pass
-        
+
         print(f"Call count: {call_count}")
         print(f"Exception: {exc_info.value}")
-        
+
         assert call_count == 1  # Should NOT retry
         assert "Not a timeout error" in str(exc_info.value)
         print("✓ Non-timeout exceptions propagated without retry")
-    
+
     @pytest.mark.asyncio
     async def test_uses_configured_max_retries(self):
         """
@@ -1572,9 +1728,9 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify max_retries parameter is respected.
         """
         print("Setup: Mock request that always times out...")
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
@@ -1582,28 +1738,28 @@ class TestStreamWithFirstTokenRetryCore:
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         print("Action: Streaming with max_retries=5...")
-        
+
         try:
             async for chunk in stream_with_first_token_retry(
                 make_request=mock_make_request,
                 stream_processor=mock_stream_processor,
                 max_retries=5,
-                first_token_timeout=30
+                first_token_timeout=30,
             ):
                 pass
         except Exception:
             pass
-        
+
         print(f"Call count: {call_count}")
         assert call_count == 5  # Should try exactly 5 times
         print("✓ max_retries parameter respected")
-    
+
     @pytest.mark.asyncio
     async def test_multiple_retries_then_success(self):
         """
@@ -1611,9 +1767,9 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify recovery after multiple failures.
         """
         print("Setup: Mock request that fails twice then succeeds...")
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
@@ -1621,32 +1777,32 @@ class TestStreamWithFirstTokenRetryCore:
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             nonlocal call_count
             if call_count < 3:
                 raise FirstTokenTimeoutError(f"Timeout on attempt {call_count}")
             yield "finally_success"
-        
+
         print("Action: Streaming with multiple retries...")
         chunks = []
-        
+
         async for chunk in stream_with_first_token_retry(
             make_request=mock_make_request,
             stream_processor=mock_stream_processor,
             max_retries=5,
-            first_token_timeout=30
+            first_token_timeout=30,
         ):
             chunks.append(chunk)
-        
+
         print(f"Call count: {call_count}")
         print(f"Received {len(chunks)} chunks")
-        
+
         assert call_count == 3  # Failed twice, succeeded on third
         assert len(chunks) == 1
         assert chunks[0] == "finally_success"
         print("✓ Multiple retries then success works correctly")
-    
+
     @pytest.mark.asyncio
     async def test_closes_response_on_http_error(self):
         """
@@ -1654,31 +1810,31 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify response is properly closed after HTTP error.
         """
         print("Setup: Mock request that returns HTTP error...")
-        
+
         response = AsyncMock()
         response.status_code = 503
         response.aread = AsyncMock(return_value=b"Service Unavailable")
         response.aclose = AsyncMock()
-        
+
         async def mock_make_request():
             return response
-        
+
         async def mock_stream_processor(resp):
             yield "should not reach"
-        
+
         print("Action: Streaming with HTTP error...")
-        
+
         try:
             async for chunk in stream_with_first_token_retry(
                 make_request=mock_make_request,
                 stream_processor=mock_stream_processor,
                 max_retries=3,
-                first_token_timeout=30
+                first_token_timeout=30,
             ):
                 pass
         except Exception:
             pass
-        
+
         print(f"Response aclose called: {response.aclose.called}")
         response.aclose.assert_called()
         print("✓ Response closed on HTTP error")

--- a/tests/unit/test_streaming_openai.py
+++ b/tests/unit/test_streaming_openai.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 
 """
@@ -13,12 +12,10 @@ Tests for:
 
 import pytest
 import json
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from kiro.streaming_openai import (
     stream_kiro_to_openai,
-    stream_kiro_to_openai_internal,
     stream_with_first_token_retry,
     collect_stream_response,
     FirstTokenTimeoutError,
@@ -29,6 +26,7 @@ from kiro.streaming_core import KiroEvent
 # ==================================================================================================
 # Fixtures
 # ==================================================================================================
+
 
 @pytest.fixture
 def mock_model_cache():
@@ -65,198 +63,253 @@ def mock_response():
 # Tests for stream_kiro_to_openai()
 # ==================================================================================================
 
+
 class TestStreamKiroToOpenai:
     """Tests for stream_kiro_to_openai() generator."""
-    
+
     @pytest.mark.asyncio
-    async def test_yields_content_chunks(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_yields_content_chunks(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Yields content chunks in OpenAI format.
         Goal: Verify content streaming.
         """
         print("Setup: Mock stream with content events...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             yield KiroEvent(type="content", content=" World")
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Should have content chunks
-        content_chunks = [c for c in chunks if "content" in c and '"Hello"' in c or '" World"' in c]
+        content_chunks = [
+            c for c in chunks if "content" in c and '"Hello"' in c or '" World"' in c
+        ]
         assert len(content_chunks) >= 2
         print("✓ Content chunks yielded correctly")
-    
+
     @pytest.mark.asyncio
-    async def test_first_chunk_has_role(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_first_chunk_has_role(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: First chunk includes role: assistant.
         Goal: Verify OpenAI streaming protocol.
         """
         print("Setup: Mock stream with content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # First content chunk should have role
-        first_content_chunk = [c for c in chunks if '"content"' in c and '"Hello"' in c][0]
+        first_content_chunk = [
+            c for c in chunks if '"content"' in c and '"Hello"' in c
+        ][0]
         assert '"role": "assistant"' in first_content_chunk
         print("✓ First chunk has role: assistant")
-    
+
     @pytest.mark.asyncio
-    async def test_yields_done_at_end(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_yields_done_at_end(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Yields [DONE] at end of stream.
         Goal: Verify stream termination.
         """
         print("Setup: Mock stream with content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Last chunk should be [DONE]
         assert chunks[-1] == "data: [DONE]\n\n"
         print("✓ [DONE] yielded at end")
-    
+
     @pytest.mark.asyncio
-    async def test_yields_final_chunk_with_usage(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_yields_final_chunk_with_usage(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Yields final chunk with usage info.
         Goal: Verify usage is included.
         """
         print("Setup: Mock stream with content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             yield KiroEvent(type="context_usage", context_usage_percentage=5.0)
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Should have chunk with usage before [DONE]
         usage_chunks = [c for c in chunks if '"usage"' in c]
         assert len(usage_chunks) >= 1
         print("✓ Final chunk with usage yielded")
-    
+
     @pytest.mark.asyncio
-    async def test_yields_tool_calls_chunk(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_yields_tool_calls_chunk(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Yields tool_calls chunk when tools present.
         Goal: Verify tool call streaming.
         """
         print("Setup: Mock stream with tool call...")
-        
+
         tool_use_data = {
             "id": "call_123",
             "type": "function",
-            "function": {"name": "get_weather", "arguments": '{"city": "Moscow"}'}
+            "function": {"name": "get_weather", "arguments": '{"city": "Moscow"}'},
         }
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Let me check")
             yield KiroEvent(type="tool_use", tool_use=tool_use_data)
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Should have tool_calls chunk
         tool_chunks = [c for c in chunks if '"tool_calls"' in c]
         assert len(tool_chunks) >= 1
         assert "get_weather" in tool_chunks[0]
         print("✓ Tool calls chunk yielded")
-    
+
     @pytest.mark.asyncio
-    async def test_tool_calls_have_index(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_tool_calls_have_index(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Tool calls have index field.
         Goal: Verify OpenAI streaming spec compliance.
         """
         print("Setup: Mock stream with multiple tool calls...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_1", "type": "function",
-                "function": {"name": "func1", "arguments": "{}"}
-            })
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_2", "type": "function",
-                "function": {"name": "func2", "arguments": "{}"}
-            })
-        
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "func1", "arguments": "{}"},
+                },
+            )
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={
+                    "id": "call_2",
+                    "type": "function",
+                    "function": {"name": "func2", "arguments": "{}"},
+                },
+            )
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Find tool_calls chunk and verify indices
         tool_chunks = [c for c in chunks if '"tool_calls"' in c]
         assert len(tool_chunks) >= 1
-        
+
         # Parse and check indices
         for chunk in tool_chunks:
             if chunk.startswith("data: "):
@@ -268,120 +321,152 @@ class TestStreamKiroToOpenai:
                         if "tool_calls" in delta:
                             for tc in delta["tool_calls"]:
                                 assert "index" in tc
-        
+
         print("✓ Tool calls have index field")
-    
+
     @pytest.mark.asyncio
-    async def test_finish_reason_is_tool_calls_when_tools_present(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_finish_reason_is_tool_calls_when_tools_present(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Sets finish_reason to tool_calls when tools present.
         Goal: Verify correct finish reason.
         """
         print("Setup: Mock stream with tool call...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_1", "type": "function",
-                "function": {"name": "func1", "arguments": "{}"}
-            })
-        
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "func1", "arguments": "{}"},
+                },
+            )
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Final chunk before [DONE] should have finish_reason: tool_calls
         final_chunk = chunks[-2]  # Before [DONE]
         assert '"finish_reason": "tool_calls"' in final_chunk
         print("✓ finish_reason is tool_calls")
-    
+
     @pytest.mark.asyncio
-    async def test_finish_reason_is_stop_without_tools(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_finish_reason_is_stop_without_tools(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Sets finish_reason to stop without tools.
         Goal: Verify correct finish reason.
         """
         print("Setup: Mock stream without tool calls...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Final chunk before [DONE] should have finish_reason: stop
         final_chunk = chunks[-2]  # Before [DONE]
         assert '"finish_reason": "stop"' in final_chunk
         print("✓ finish_reason is stop")
-    
+
     @pytest.mark.asyncio
-    async def test_closes_response_on_completion(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_closes_response_on_completion(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Closes response on completion.
         Goal: Verify resource cleanup.
         """
         print("Setup: Mock stream...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Streaming to OpenAI format...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     pass
-        
+
         print("Check: response.aclose() should be called...")
         mock_response.aclose.assert_called()
         print("✓ Response closed on completion")
-    
+
     @pytest.mark.asyncio
-    async def test_closes_response_on_error(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_closes_response_on_error(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Closes response on error.
         Goal: Verify resource cleanup on error.
         """
         print("Setup: Mock stream that raises error...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             raise RuntimeError("Test error")
-        
+
         print("Action: Streaming to OpenAI format with error...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 try:
                     async for chunk in stream_kiro_to_openai(
-                        mock_http_client, mock_response, "claude-sonnet-4",
-                        mock_model_cache, mock_auth_manager
+                        mock_http_client,
+                        mock_response,
+                        "claude-sonnet-4",
+                        mock_model_cache,
+                        mock_auth_manager,
                     ):
                         pass
                 except RuntimeError:
                     pass
-        
+
         print("Check: response.aclose() should be called...")
         mock_response.aclose.assert_called()
         print("✓ Response closed on error")
@@ -391,67 +476,87 @@ class TestStreamKiroToOpenai:
 # Tests for thinking content handling
 # ==================================================================================================
 
+
 class TestStreamingOpenaiThinkingContent:
     """Tests for thinking content handling in OpenAI streaming."""
-    
+
     @pytest.mark.asyncio
-    async def test_yields_thinking_as_reasoning_content(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_yields_thinking_as_reasoning_content(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Yields thinking as reasoning_content when configured.
         Goal: Verify thinking content handling.
         """
         print("Setup: Mock stream with thinking content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="thinking", thinking_content="Let me think...")
             yield KiroEvent(type="content", content="Here is my answer")
-        
+
         print("Action: Streaming to OpenAI format with reasoning mode...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
-                with patch('kiro.streaming_openai.FAKE_REASONING_HANDLING', 'as_reasoning_content'):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
+                with patch(
+                    "kiro.streaming_openai.FAKE_REASONING_HANDLING",
+                    "as_reasoning_content",
+                ):
                     async for chunk in stream_kiro_to_openai(
-                        mock_http_client, mock_response, "claude-sonnet-4",
-                        mock_model_cache, mock_auth_manager
+                        mock_http_client,
+                        mock_response,
+                        "claude-sonnet-4",
+                        mock_model_cache,
+                        mock_auth_manager,
                     ):
                         chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Should have reasoning_content
         reasoning_chunks = [c for c in chunks if '"reasoning_content"' in c]
         assert len(reasoning_chunks) >= 1
         assert "Let me think" in reasoning_chunks[0]
         print("✓ Thinking yielded as reasoning_content")
-    
+
     @pytest.mark.asyncio
-    async def test_yields_thinking_as_content_when_configured(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_yields_thinking_as_content_when_configured(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Yields thinking as content when configured.
         Goal: Verify thinking content handling.
         """
         print("Setup: Mock stream with thinking content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="thinking", thinking_content="Let me think...")
             yield KiroEvent(type="content", content="Here is my answer")
-        
+
         print("Action: Streaming to OpenAI format with content mode...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
-                with patch('kiro.streaming_openai.FAKE_REASONING_HANDLING', 'include_as_text'):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
+                with patch(
+                    "kiro.streaming_openai.FAKE_REASONING_HANDLING", "include_as_text"
+                ):
                     async for chunk in stream_kiro_to_openai(
-                        mock_http_client, mock_response, "claude-sonnet-4",
-                        mock_model_cache, mock_auth_manager
+                        mock_http_client,
+                        mock_response,
+                        "claude-sonnet-4",
+                        mock_model_cache,
+                        mock_auth_manager,
                     ):
                         chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Should have thinking as content
         content_chunks = [c for c in chunks if '"content"' in c and "Let me think" in c]
         assert len(content_chunks) >= 1
@@ -462,40 +567,52 @@ class TestStreamingOpenaiThinkingContent:
 # Tests for None protection in tool calls
 # ==================================================================================================
 
+
 class TestStreamingOpenaiNoneProtection:
     """Tests for None protection in tool calls."""
-    
+
     @pytest.mark.asyncio
-    async def test_handles_none_function_name(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_handles_none_function_name(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Handles None in function.name.
         Goal: Verify None is replaced with empty string.
         """
         print("Setup: Mock stream with None function name...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_1", "type": "function",
-                "function": {"name": None, "arguments": "{}"}
-            })
-        
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": None, "arguments": "{}"},
+                },
+            )
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Should handle None gracefully
         tool_chunks = [c for c in chunks if '"tool_calls"' in c]
         assert len(tool_chunks) >= 1
-        
+
         # Parse and verify name is empty string
         for chunk in tool_chunks:
             if chunk.startswith("data: "):
@@ -507,40 +624,51 @@ class TestStreamingOpenaiNoneProtection:
                         if "tool_calls" in delta:
                             for tc in delta["tool_calls"]:
                                 assert tc["function"]["name"] == ""
-        
+
         print("✓ None function name handled")
-    
+
     @pytest.mark.asyncio
-    async def test_handles_none_function_arguments(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_handles_none_function_arguments(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Handles None in function.arguments.
         Goal: Verify None is replaced with "{}".
         """
         print("Setup: Mock stream with None arguments...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_1", "type": "function",
-                "function": {"name": "func1", "arguments": None}
-            })
-        
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "func1", "arguments": None},
+                },
+            )
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Should handle None gracefully
         tool_chunks = [c for c in chunks if '"tool_calls"' in c]
         assert len(tool_chunks) >= 1
-        
+
         # Parse and verify arguments is "{}"
         for chunk in tool_chunks:
             if chunk.startswith("data: "):
@@ -552,36 +680,43 @@ class TestStreamingOpenaiNoneProtection:
                         if "tool_calls" in delta:
                             for tc in delta["tool_calls"]:
                                 assert tc["function"]["arguments"] == "{}"
-        
+
         print("✓ None function arguments handled")
-    
+
     @pytest.mark.asyncio
-    async def test_handles_none_function_object(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_handles_none_function_object(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Handles None function object.
         Goal: Verify None function is handled.
         """
         print("Setup: Mock stream with None function...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_1", "type": "function",
-                "function": None
-            })
-        
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={"id": "call_1", "type": "function", "function": None},
+            )
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Should handle None gracefully without error
         assert len(chunks) > 0
         print("✓ None function object handled")
@@ -591,44 +726,51 @@ class TestStreamingOpenaiNoneProtection:
 # Tests for stream_with_first_token_retry()
 # ==================================================================================================
 
+
 class TestStreamWithFirstTokenRetry:
     """Tests for stream_with_first_token_retry() function."""
-    
+
     @pytest.mark.asyncio
-    async def test_retries_on_first_token_timeout(self, mock_http_client, mock_model_cache, mock_auth_manager):
+    async def test_retries_on_first_token_timeout(
+        self, mock_http_client, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Retries on first token timeout.
         Goal: Verify retry logic.
         """
         print("Setup: Mock make_request that succeeds on second attempt...")
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.aclose = AsyncMock()
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
             print(f"make_request called (attempt {call_count})")
             return mock_response
-        
+
         # First call raises timeout, second succeeds
         timeout_raised = False
-        
+
         async def mock_parse_kiro_stream_with_retry(*args, **kwargs):
             nonlocal timeout_raised
             if not timeout_raised:
                 timeout_raised = True
                 raise FirstTokenTimeoutError("Timeout!")
             yield KiroEvent(type="content", content="Success")
-        
+
         print("Action: Running stream_with_first_token_retry...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream_with_retry):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch(
+            "kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream_with_retry
+        ):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for chunk in stream_with_first_token_retry(
                     mock_make_request,
                     mock_http_client,
@@ -636,47 +778,54 @@ class TestStreamWithFirstTokenRetry:
                     mock_model_cache,
                     mock_auth_manager,
                     max_retries=3,
-                    first_token_timeout=15
+                    first_token_timeout=15,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
         print(f"make_request was called {call_count} times")
-        
+
         assert call_count == 2
         assert len(chunks) > 0
         print("✓ Retry logic worked correctly")
-    
+
     @pytest.mark.asyncio
-    async def test_raises_504_after_all_retries_exhausted(self, mock_http_client, mock_model_cache, mock_auth_manager):
+    async def test_raises_504_after_all_retries_exhausted(
+        self, mock_http_client, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Raises 504 after all retries exhausted.
         Goal: Verify error handling.
         """
         from fastapi import HTTPException
-        
+
         print("Setup: Mock make_request that always times out...")
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.aclose = AsyncMock()
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
             return mock_response
-        
+
         async def mock_parse_kiro_stream_always_timeout(*args, **kwargs):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         max_retries = 3
-        
-        print(f"Action: Running stream_with_first_token_retry with max_retries={max_retries}...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream_always_timeout):
+
+        print(
+            f"Action: Running stream_with_first_token_retry with max_retries={max_retries}..."
+        )
+
+        with patch(
+            "kiro.streaming_openai.parse_kiro_stream",
+            mock_parse_kiro_stream_always_timeout,
+        ):
             with pytest.raises(HTTPException) as exc_info:
                 async for chunk in stream_with_first_token_retry(
                     mock_make_request,
@@ -685,38 +834,40 @@ class TestStreamWithFirstTokenRetry:
                     mock_model_cache,
                     mock_auth_manager,
                     max_retries=max_retries,
-                    first_token_timeout=15
+                    first_token_timeout=15,
                 ):
                     pass
-        
+
         print(f"Caught HTTPException: {exc_info.value.status_code}")
         print(f"make_request was called {call_count} times")
-        
+
         assert exc_info.value.status_code == 504
         assert call_count == max_retries
         print("✓ 504 raised after all retries exhausted")
-    
+
     @pytest.mark.asyncio
-    async def test_handles_api_error_response(self, mock_http_client, mock_model_cache, mock_auth_manager):
+    async def test_handles_api_error_response(
+        self, mock_http_client, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Handles API error response.
         Goal: Verify error response handling.
         """
         from fastapi import HTTPException
-        
+
         print("Setup: Mock make_request that returns error...")
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 500
         # Use simple error text without curly braces to avoid loguru format issues
-        mock_response.aread = AsyncMock(return_value=b'Internal server error')
+        mock_response.aread = AsyncMock(return_value=b"Internal server error")
         mock_response.aclose = AsyncMock()
-        
+
         async def mock_make_request():
             return mock_response
-        
+
         print("Action: Running stream_with_first_token_retry with error response...")
-        
+
         with pytest.raises(HTTPException) as exc_info:
             async for chunk in stream_with_first_token_retry(
                 mock_make_request,
@@ -725,40 +876,44 @@ class TestStreamWithFirstTokenRetry:
                 mock_model_cache,
                 mock_auth_manager,
                 max_retries=3,
-                first_token_timeout=15
+                first_token_timeout=15,
             ):
                 pass
-        
+
         print(f"Caught HTTPException: {exc_info.value.status_code}")
         assert exc_info.value.status_code == 500
         print("✓ API error response handled")
-    
+
     @pytest.mark.asyncio
-    async def test_propagates_non_timeout_errors(self, mock_http_client, mock_model_cache, mock_auth_manager):
+    async def test_propagates_non_timeout_errors(
+        self, mock_http_client, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Propagates non-timeout errors without retry.
         Goal: Verify only timeout errors trigger retry.
         """
         print("Setup: Mock make_request that raises RuntimeError...")
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.aclose = AsyncMock()
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
             return mock_response
-        
+
         async def mock_parse_kiro_stream_error(*args, **kwargs):
             raise RuntimeError("Test error")
             yield  # Make it a generator
-        
+
         print("Action: Running stream_with_first_token_retry with RuntimeError...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream_error):
+
+        with patch(
+            "kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream_error
+        ):
             with pytest.raises(RuntimeError) as exc_info:
                 async for chunk in stream_with_first_token_retry(
                     mock_make_request,
@@ -767,57 +922,63 @@ class TestStreamWithFirstTokenRetry:
                     mock_model_cache,
                     mock_auth_manager,
                     max_retries=3,
-                    first_token_timeout=15
+                    first_token_timeout=15,
                 ):
                     pass
-        
+
         print(f"Caught RuntimeError: {exc_info.value}")
         print(f"make_request was called {call_count} times")
-        
+
         # Should only be called once - no retry for non-timeout errors
         assert call_count == 1
         assert "Test error" in str(exc_info.value)
         print("✓ Non-timeout errors propagated without retry")
-    
+
     @pytest.mark.asyncio
-    async def test_closes_response_on_retry(self, mock_http_client, mock_model_cache, mock_auth_manager):
+    async def test_closes_response_on_retry(
+        self, mock_http_client, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Closes response when retrying.
         Goal: Verify resource cleanup on retry.
         """
         print("Setup: Mock responses for retry...")
-        
+
         mock_response1 = AsyncMock()
         mock_response1.status_code = 200
         mock_response1.aclose = AsyncMock()
-        
+
         mock_response2 = AsyncMock()
         mock_response2.status_code = 200
         mock_response2.aclose = AsyncMock()
-        
+
         responses = [mock_response1, mock_response2]
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             response = responses[call_count]
             call_count += 1
             return response
-        
+
         # First call raises timeout, second succeeds
         timeout_raised = False
-        
+
         async def mock_parse_kiro_stream_with_retry(*args, **kwargs):
             nonlocal timeout_raised
             if not timeout_raised:
                 timeout_raised = True
                 raise FirstTokenTimeoutError("Timeout!")
             yield KiroEvent(type="content", content="Success")
-        
+
         print("Action: Running stream_with_first_token_retry...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream_with_retry):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch(
+            "kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream_with_retry
+        ):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for chunk in stream_with_first_token_retry(
                     mock_make_request,
                     mock_http_client,
@@ -825,10 +986,10 @@ class TestStreamWithFirstTokenRetry:
                     mock_model_cache,
                     mock_auth_manager,
                     max_retries=3,
-                    first_token_timeout=15
+                    first_token_timeout=15,
                 ):
                     pass
-        
+
         print("Check: First response should be closed...")
         mock_response1.aclose.assert_called()
         print("✓ Response closed on retry")
@@ -838,280 +999,366 @@ class TestStreamWithFirstTokenRetry:
 # Tests for collect_stream_response()
 # ==================================================================================================
 
+
 class TestCollectStreamResponse:
     """Tests for collect_stream_response() function."""
-    
+
     @pytest.mark.asyncio
-    async def test_collects_content(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_collects_content(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Collects content from stream.
         Goal: Verify content accumulation.
         """
         print("Setup: Mock stream with content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             yield KiroEvent(type="content", content=" World")
-        
+
         print("Action: Collecting stream response...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 result = await collect_stream_response(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 )
-        
+
         print(f"Result: {result}")
-        
+
         assert result["choices"][0]["message"]["content"] == "Hello World"
         print("✓ Content collected correctly")
-    
+
     @pytest.mark.asyncio
-    async def test_collects_reasoning_content(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_collects_reasoning_content(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Collects reasoning content from stream.
         Goal: Verify reasoning content accumulation.
         """
         print("Setup: Mock stream with thinking content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="thinking", thinking_content="Let me think...")
             yield KiroEvent(type="content", content="Answer")
-        
+
         print("Action: Collecting stream response with reasoning mode...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
-                with patch('kiro.streaming_openai.FAKE_REASONING_HANDLING', 'as_reasoning_content'):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
+                with patch(
+                    "kiro.streaming_openai.FAKE_REASONING_HANDLING",
+                    "as_reasoning_content",
+                ):
                     result = await collect_stream_response(
-                        mock_http_client, mock_response, "claude-sonnet-4",
-                        mock_model_cache, mock_auth_manager
+                        mock_http_client,
+                        mock_response,
+                        "claude-sonnet-4",
+                        mock_model_cache,
+                        mock_auth_manager,
                     )
-        
+
         print(f"Result: {result}")
-        
+
         message = result["choices"][0]["message"]
         assert "reasoning_content" in message
         assert message["reasoning_content"] == "Let me think..."
         print("✓ Reasoning content collected correctly")
-    
+
     @pytest.mark.asyncio
-    async def test_collects_tool_calls(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_collects_tool_calls(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Collects tool calls from stream.
         Goal: Verify tool call accumulation.
         """
         print("Setup: Mock stream with tool calls...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_1", "type": "function",
-                "function": {"name": "func1", "arguments": '{"a": 1}'}
-            })
-        
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "func1", "arguments": '{"a": 1}'},
+                },
+            )
+
         print("Action: Collecting stream response...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 result = await collect_stream_response(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 )
-        
+
         print(f"Result: {result}")
-        
+
         message = result["choices"][0]["message"]
         assert "tool_calls" in message
         assert len(message["tool_calls"]) == 1
         assert message["tool_calls"][0]["function"]["name"] == "func1"
         print("✓ Tool calls collected correctly")
-    
+
     @pytest.mark.asyncio
-    async def test_tool_calls_have_no_index(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_tool_calls_have_no_index(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Collected tool calls don't have index field.
         Goal: Verify index is removed for non-streaming.
         """
         print("Setup: Mock stream with tool calls...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_1", "type": "function",
-                "function": {"name": "func1", "arguments": "{}"}
-            })
-        
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "func1", "arguments": "{}"},
+                },
+            )
+
         print("Action: Collecting stream response...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 result = await collect_stream_response(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 )
-        
+
         print(f"Result: {result}")
-        
+
         message = result["choices"][0]["message"]
         for tc in message.get("tool_calls", []):
             assert "index" not in tc
-        
+
         print("✓ Tool calls have no index field")
-    
+
     @pytest.mark.asyncio
-    async def test_includes_usage(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_includes_usage(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Includes usage in response.
         Goal: Verify usage is included.
         """
         print("Setup: Mock stream with content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             yield KiroEvent(type="context_usage", context_usage_percentage=5.0)
-        
+
         print("Action: Collecting stream response...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 result = await collect_stream_response(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 )
-        
+
         print(f"Result: {result}")
-        
+
         assert "usage" in result
         assert "prompt_tokens" in result["usage"]
         assert "completion_tokens" in result["usage"]
         assert "total_tokens" in result["usage"]
         print("✓ Usage included in response")
-    
+
     @pytest.mark.asyncio
-    async def test_sets_finish_reason_tool_calls(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_sets_finish_reason_tool_calls(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Sets finish_reason to tool_calls when tools present.
         Goal: Verify correct finish reason.
         """
         print("Setup: Mock stream with tool calls...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_1", "type": "function",
-                "function": {"name": "func1", "arguments": "{}"}
-            })
-        
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "func1", "arguments": "{}"},
+                },
+            )
+
         print("Action: Collecting stream response...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 result = await collect_stream_response(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 )
-        
+
         print(f"Result: {result}")
-        
+
         assert result["choices"][0]["finish_reason"] == "tool_calls"
         print("✓ finish_reason is tool_calls")
-    
+
     @pytest.mark.asyncio
-    async def test_sets_finish_reason_stop(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_sets_finish_reason_stop(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Sets finish_reason to stop without tools.
         Goal: Verify correct finish reason.
         """
         print("Setup: Mock stream without tool calls...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Collecting stream response...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 result = await collect_stream_response(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 )
-        
+
         print(f"Result: {result}")
-        
+
         assert result["choices"][0]["finish_reason"] == "stop"
         print("✓ finish_reason is stop")
-    
+
     @pytest.mark.asyncio
-    async def test_generates_completion_id(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_generates_completion_id(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Generates completion ID.
         Goal: Verify ID is present.
         """
         print("Setup: Mock stream...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Collecting stream response...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 result = await collect_stream_response(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 )
-        
+
         print(f"ID: {result['id']}")
-        
+
         assert result["id"].startswith("chatcmpl-")
         print("✓ Completion ID generated")
-    
+
     @pytest.mark.asyncio
-    async def test_includes_model_name(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_includes_model_name(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Includes model name in response.
         Goal: Verify model is included.
         """
         print("Setup: Mock stream...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Collecting stream response...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 result = await collect_stream_response(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 )
-        
+
         print(f"Model: {result['model']}")
-        
+
         assert result["model"] == "claude-sonnet-4"
         print("✓ Model name included")
-    
+
     @pytest.mark.asyncio
-    async def test_object_is_chat_completion(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_object_is_chat_completion(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Sets object to chat.completion.
         Goal: Verify OpenAI format.
         """
         print("Setup: Mock stream...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Collecting stream response...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 result = await collect_stream_response(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 )
-        
+
         print(f"Object: {result['object']}")
-        
+
         assert result["object"] == "chat.completion"
         print("✓ Object is chat.completion")
 
@@ -1120,115 +1367,142 @@ class TestCollectStreamResponse:
 # Tests for error handling
 # ==================================================================================================
 
+
 class TestStreamingOpenaiErrorHandling:
     """Tests for error handling in streaming_openai."""
-    
+
     @pytest.mark.asyncio
-    async def test_propagates_first_token_timeout_error(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_propagates_first_token_timeout_error(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Propagates FirstTokenTimeoutError.
         Goal: Verify timeout error is propagated for retry.
         """
         print("Setup: Mock stream that raises timeout...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         print("Action: Streaming to OpenAI format with timeout...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
             with pytest.raises(FirstTokenTimeoutError):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     pass
-        
+
         print("✓ FirstTokenTimeoutError propagated correctly")
-    
+
     @pytest.mark.asyncio
-    async def test_handles_generator_exit_gracefully(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_handles_generator_exit_gracefully(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Handles GeneratorExit gracefully without re-raising.
         Goal: Verify client disconnect is handled without error.
         """
         print("Setup: Mock stream that raises GeneratorExit...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             raise GeneratorExit()
-        
+
         print("Action: Streaming to OpenAI format with GeneratorExit...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 # GeneratorExit is caught internally and not re-raised
                 # This is correct behavior - client disconnect should be handled gracefully
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks before disconnect")
         # Response should be closed
         mock_response.aclose.assert_called()
         print("✓ GeneratorExit handled gracefully")
-    
+
     @pytest.mark.asyncio
-    async def test_propagates_other_exceptions(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_propagates_other_exceptions(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Propagates other exceptions.
         Goal: Verify errors are not swallowed.
         """
         print("Setup: Mock stream that raises RuntimeError...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             raise RuntimeError("Test error")
-        
+
         print("Action: Streaming to OpenAI format with RuntimeError...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 with pytest.raises(RuntimeError) as exc_info:
                     async for chunk in stream_kiro_to_openai(
-                        mock_http_client, mock_response, "claude-sonnet-4",
-                        mock_model_cache, mock_auth_manager
+                        mock_http_client,
+                        mock_response,
+                        "claude-sonnet-4",
+                        mock_model_cache,
+                        mock_auth_manager,
                     ):
                         pass
-        
+
         print(f"Caught exception: {exc_info.value}")
         assert "Test error" in str(exc_info.value)
         print("✓ RuntimeError propagated correctly")
-    
+
     @pytest.mark.asyncio
-    async def test_aclose_error_does_not_mask_original(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_aclose_error_does_not_mask_original(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: aclose() error doesn't mask original error.
         Goal: Verify original exception is propagated.
         """
         print("Setup: Mock response with error in aclose()...")
-        
+
         mock_response.aclose = AsyncMock(side_effect=ConnectionError("Connection lost"))
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             raise RuntimeError("Original error")
-        
+
         print("Action: Streaming to OpenAI format with error and aclose error...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 with pytest.raises(RuntimeError) as exc_info:
                     async for chunk in stream_kiro_to_openai(
-                        mock_http_client, mock_response, "claude-sonnet-4",
-                        mock_model_cache, mock_auth_manager
+                        mock_http_client,
+                        mock_response,
+                        "claude-sonnet-4",
+                        mock_model_cache,
+                        mock_auth_manager,
                     ):
                         pass
-        
+
         print(f"Caught exception: {exc_info.value}")
         assert "Original error" in str(exc_info.value)
         print("✓ Original error not masked by aclose error")
@@ -1238,80 +1512,115 @@ class TestStreamingOpenaiErrorHandling:
 # Tests for bracket tool calls
 # ==================================================================================================
 
+
 class TestStreamingOpenaiBracketToolCalls:
     """Tests for bracket-style tool call handling."""
-    
+
     @pytest.mark.asyncio
-    async def test_detects_bracket_tool_calls(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_detects_bracket_tool_calls(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Detects bracket-style tool calls in content.
         Goal: Verify bracket tool call detection.
         """
         print("Setup: Mock stream with bracket tool calls...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="[tool_call: func1]")
-        
+
         bracket_tool_calls = [
-            {"id": "call_1", "type": "function", "function": {"name": "func1", "arguments": "{}"}}
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "func1", "arguments": "{}"},
+            }
         ]
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=bracket_tool_calls):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls",
+                return_value=bracket_tool_calls,
+            ):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Should have tool_calls chunk
         tool_chunks = [c for c in chunks if '"tool_calls"' in c]
         assert len(tool_chunks) >= 1
         print("✓ Bracket tool calls detected")
-    
+
     @pytest.mark.asyncio
-    async def test_deduplicates_tool_calls(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_deduplicates_tool_calls(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Deduplicates tool calls from stream and bracket.
         Goal: Verify deduplication.
         """
         print("Setup: Mock stream with duplicate tool calls...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="text")
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_1", "type": "function",
-                "function": {"name": "func1", "arguments": "{}"}
-            })
-        
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "func1", "arguments": "{}"},
+                },
+            )
+
         # Same tool call from bracket detection
         bracket_tool_calls = [
-            {"id": "call_1", "type": "function", "function": {"name": "func1", "arguments": "{}"}}
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "func1", "arguments": "{}"},
+            }
         ]
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=bracket_tool_calls):
-                with patch('kiro.streaming_openai.deduplicate_tool_calls') as mock_dedup:
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls",
+                return_value=bracket_tool_calls,
+            ):
+                with patch(
+                    "kiro.streaming_openai.deduplicate_tool_calls"
+                ) as mock_dedup:
                     mock_dedup.return_value = [
-                        {"id": "call_1", "type": "function", "function": {"name": "func1", "arguments": "{}"}}
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "func1", "arguments": "{}"},
+                        }
                     ]
                     async for chunk in stream_kiro_to_openai(
-                        mock_http_client, mock_response, "claude-sonnet-4",
-                        mock_model_cache, mock_auth_manager
+                        mock_http_client,
+                        mock_response,
+                        "claude-sonnet-4",
+                        mock_model_cache,
+                        mock_auth_manager,
                     ):
                         chunks.append(chunk)
-                    
+
                     # Verify deduplicate was called
                     mock_dedup.assert_called()
-        
+
         print("✓ Tool calls deduplicated")
 
 
@@ -1319,34 +1628,42 @@ class TestStreamingOpenaiBracketToolCalls:
 # Tests for metering data
 # ==================================================================================================
 
+
 class TestStreamingOpenaiMeteringData:
     """Tests for metering data handling."""
-    
+
     @pytest.mark.asyncio
-    async def test_includes_credits_used_in_usage(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_includes_credits_used_in_usage(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Includes credits_used in usage when metering data present.
         Goal: Verify metering data is included.
         """
         print("Setup: Mock stream with metering data...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             yield KiroEvent(type="usage", usage={"credits": 0.001})
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch(
+                "kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]
+            ):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client,
+                    mock_response,
+                    "claude-sonnet-4",
+                    mock_model_cache,
+                    mock_auth_manager,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Final chunk should have credits_used
         final_chunk = chunks[-2]  # Before [DONE]
         assert '"credits_used"' in final_chunk

--- a/tests/unit/test_thinking_parser.py
+++ b/tests/unit/test_thinking_parser.py
@@ -11,7 +11,6 @@ Tests cover:
 - Edge cases and error handling
 """
 
-import pytest
 from unittest.mock import patch
 
 from kiro.thinking_parser import (
@@ -23,7 +22,7 @@ from kiro.thinking_parser import (
 
 class TestParserStateEnum:
     """Tests for ParserState enum."""
-    
+
     def test_pre_content_value(self):
         """
         What it does: Verifies PRE_CONTENT enum value.
@@ -31,7 +30,7 @@ class TestParserStateEnum:
         """
         print("Checking PRE_CONTENT enum value...")
         assert ParserState.PRE_CONTENT == 0
-    
+
     def test_in_thinking_value(self):
         """
         What it does: Verifies IN_THINKING enum value.
@@ -39,7 +38,7 @@ class TestParserStateEnum:
         """
         print("Checking IN_THINKING enum value...")
         assert ParserState.IN_THINKING == 1
-    
+
     def test_streaming_value(self):
         """
         What it does: Verifies STREAMING enum value.
@@ -51,7 +50,7 @@ class TestParserStateEnum:
 
 class TestThinkingParseResult:
     """Tests for ThinkingParseResult dataclass."""
-    
+
     def test_default_values(self):
         """
         What it does: Verifies default values of ThinkingParseResult.
@@ -59,14 +58,14 @@ class TestThinkingParseResult:
         """
         print("Creating ThinkingParseResult with defaults...")
         result = ThinkingParseResult()
-        
+
         print(f"Comparing: Expected None, Got {result.thinking_content}")
         assert result.thinking_content is None
         assert result.regular_content is None
         assert result.is_first_thinking_chunk is False
         assert result.is_last_thinking_chunk is False
         assert result.state_changed is False
-    
+
     def test_custom_values(self):
         """
         What it does: Verifies custom values in ThinkingParseResult.
@@ -78,10 +77,12 @@ class TestThinkingParseResult:
             regular_content="regular",
             is_first_thinking_chunk=True,
             is_last_thinking_chunk=True,
-            state_changed=True
+            state_changed=True,
         )
-        
-        print(f"Comparing thinking_content: Expected 'thinking', Got '{result.thinking_content}'")
+
+        print(
+            f"Comparing thinking_content: Expected 'thinking', Got '{result.thinking_content}'"
+        )
         assert result.thinking_content == "thinking"
         assert result.regular_content == "regular"
         assert result.is_first_thinking_chunk is True
@@ -91,7 +92,7 @@ class TestThinkingParseResult:
 
 class TestThinkingParserInitialization:
     """Tests for ThinkingParser initialization."""
-    
+
     def test_default_initialization(self):
         """
         What it does: Verifies default initialization of ThinkingParser.
@@ -99,7 +100,7 @@ class TestThinkingParserInitialization:
         """
         print("Creating ThinkingParser with defaults...")
         parser = ThinkingParser()
-        
+
         print(f"Comparing state: Expected PRE_CONTENT, Got {parser.state}")
         assert parser.state == ParserState.PRE_CONTENT
         assert parser.initial_buffer == ""
@@ -108,7 +109,7 @@ class TestThinkingParserInitialization:
         assert parser.close_tag is None
         assert parser.is_first_thinking_chunk is True
         assert parser._thinking_block_found is False
-    
+
     def test_custom_handling_mode(self):
         """
         What it does: Verifies custom handling_mode parameter.
@@ -116,10 +117,12 @@ class TestThinkingParserInitialization:
         """
         print("Creating ThinkingParser with custom handling_mode...")
         parser = ThinkingParser(handling_mode="remove")
-        
-        print(f"Comparing handling_mode: Expected 'remove', Got '{parser.handling_mode}'")
+
+        print(
+            f"Comparing handling_mode: Expected 'remove', Got '{parser.handling_mode}'"
+        )
         assert parser.handling_mode == "remove"
-    
+
     def test_custom_open_tags(self):
         """
         What it does: Verifies custom open_tags parameter.
@@ -128,10 +131,10 @@ class TestThinkingParserInitialization:
         print("Creating ThinkingParser with custom open_tags...")
         custom_tags = ["<custom>", "<test>"]
         parser = ThinkingParser(open_tags=custom_tags)
-        
+
         print(f"Comparing open_tags: Expected {custom_tags}, Got {parser.open_tags}")
         assert parser.open_tags == custom_tags
-    
+
     def test_custom_initial_buffer_size(self):
         """
         What it does: Verifies custom initial_buffer_size parameter.
@@ -139,10 +142,12 @@ class TestThinkingParserInitialization:
         """
         print("Creating ThinkingParser with custom initial_buffer_size...")
         parser = ThinkingParser(initial_buffer_size=50)
-        
-        print(f"Comparing initial_buffer_size: Expected 50, Got {parser.initial_buffer_size}")
+
+        print(
+            f"Comparing initial_buffer_size: Expected 50, Got {parser.initial_buffer_size}"
+        )
         assert parser.initial_buffer_size == 50
-    
+
     def test_max_tag_length_calculated(self):
         """
         What it does: Verifies max_tag_length is calculated from open_tags.
@@ -150,17 +155,19 @@ class TestThinkingParserInitialization:
         """
         print("Creating ThinkingParser and checking max_tag_length...")
         parser = ThinkingParser(open_tags=["<thinking>", "<think>"])
-        
+
         # max_tag_length = max(len(tag) for tag in open_tags) * 2
         # len("<thinking>") = 10, so max_tag_length = 20
         expected = 20
-        print(f"Comparing max_tag_length: Expected {expected}, Got {parser.max_tag_length}")
+        print(
+            f"Comparing max_tag_length: Expected {expected}, Got {parser.max_tag_length}"
+        )
         assert parser.max_tag_length == expected
 
 
 class TestThinkingParserFeedPreContent:
     """Tests for ThinkingParser.feed() in PRE_CONTENT state."""
-    
+
     def test_empty_content_returns_empty_result(self):
         """
         What it does: Verifies empty content returns empty result.
@@ -169,13 +176,13 @@ class TestThinkingParserFeedPreContent:
         print("Feeding empty content...")
         parser = ThinkingParser()
         result = parser.feed("")
-        
-        print(f"Comparing result: Expected empty result")
+
+        print("Comparing result: Expected empty result")
         assert result.thinking_content is None
         assert result.regular_content is None
         assert result.state_changed is False
         assert parser.state == ParserState.PRE_CONTENT
-    
+
     def test_detects_thinking_tag(self):
         """
         What it does: Verifies <thinking> tag detection.
@@ -184,14 +191,14 @@ class TestThinkingParserFeedPreContent:
         print("Feeding content with <thinking> tag...")
         parser = ThinkingParser()
         result = parser.feed("<thinking>Hello")
-        
+
         print(f"Comparing state: Expected IN_THINKING, Got {parser.state}")
         assert parser.state == ParserState.IN_THINKING
         assert parser.open_tag == "<thinking>"
         assert parser.close_tag == "</thinking>"
         assert result.state_changed is True
         assert parser._thinking_block_found is True
-    
+
     def test_detects_think_tag(self):
         """
         What it does: Verifies <think> tag detection.
@@ -199,13 +206,13 @@ class TestThinkingParserFeedPreContent:
         """
         print("Feeding content with <think> tag...")
         parser = ThinkingParser()
-        result = parser.feed("<think>Hello")
-        
+        parser.feed("<think>Hello")
+
         print(f"Comparing open_tag: Expected '<think>', Got '{parser.open_tag}'")
         assert parser.state == ParserState.IN_THINKING
         assert parser.open_tag == "<think>"
         assert parser.close_tag == "</think>"
-    
+
     def test_detects_reasoning_tag(self):
         """
         What it does: Verifies <reasoning> tag detection.
@@ -213,13 +220,13 @@ class TestThinkingParserFeedPreContent:
         """
         print("Feeding content with <reasoning> tag...")
         parser = ThinkingParser()
-        result = parser.feed("<reasoning>Hello")
-        
+        parser.feed("<reasoning>Hello")
+
         print(f"Comparing open_tag: Expected '<reasoning>', Got '{parser.open_tag}'")
         assert parser.state == ParserState.IN_THINKING
         assert parser.open_tag == "<reasoning>"
         assert parser.close_tag == "</reasoning>"
-    
+
     def test_detects_thought_tag(self):
         """
         What it does: Verifies <thought> tag detection.
@@ -227,13 +234,13 @@ class TestThinkingParserFeedPreContent:
         """
         print("Feeding content with <thought> tag...")
         parser = ThinkingParser()
-        result = parser.feed("<thought>Hello")
-        
+        parser.feed("<thought>Hello")
+
         print(f"Comparing open_tag: Expected '<thought>', Got '{parser.open_tag}'")
         assert parser.state == ParserState.IN_THINKING
         assert parser.open_tag == "<thought>"
         assert parser.close_tag == "</thought>"
-    
+
     def test_strips_leading_whitespace_for_tag_detection(self):
         """
         What it does: Verifies leading whitespace is stripped for tag detection.
@@ -241,12 +248,12 @@ class TestThinkingParserFeedPreContent:
         """
         print("Feeding content with leading whitespace...")
         parser = ThinkingParser()
-        result = parser.feed("  \n\n<thinking>Hello")
-        
+        parser.feed("  \n\n<thinking>Hello")
+
         print(f"Comparing state: Expected IN_THINKING, Got {parser.state}")
         assert parser.state == ParserState.IN_THINKING
         assert parser.open_tag == "<thinking>"
-    
+
     def test_buffers_partial_tag(self):
         """
         What it does: Verifies partial tag is buffered.
@@ -255,12 +262,12 @@ class TestThinkingParserFeedPreContent:
         print("Feeding partial tag...")
         parser = ThinkingParser()
         result = parser.feed("<think")
-        
+
         print(f"Comparing state: Expected PRE_CONTENT, Got {parser.state}")
         assert parser.state == ParserState.PRE_CONTENT
         assert parser.initial_buffer == "<think"
         assert result.state_changed is False
-    
+
     def test_completes_partial_tag(self):
         """
         What it does: Verifies partial tag is completed across chunks.
@@ -268,16 +275,18 @@ class TestThinkingParserFeedPreContent:
         """
         print("Feeding partial tag in two chunks...")
         parser = ThinkingParser()
-        
-        result1 = parser.feed("<think")
-        print(f"After first chunk: state={parser.state}, buffer='{parser.initial_buffer}'")
+
+        parser.feed("<think")
+        print(
+            f"After first chunk: state={parser.state}, buffer='{parser.initial_buffer}'"
+        )
         assert parser.state == ParserState.PRE_CONTENT
-        
-        result2 = parser.feed("ing>Hello")
+
+        parser.feed("ing>Hello")
         print(f"After second chunk: state={parser.state}")
         assert parser.state == ParserState.IN_THINKING
         assert parser.open_tag == "<thinking>"
-    
+
     def test_no_tag_transitions_to_streaming(self):
         """
         What it does: Verifies transition to STREAMING when no tag found.
@@ -285,13 +294,18 @@ class TestThinkingParserFeedPreContent:
         """
         print("Feeding content without thinking tag...")
         parser = ThinkingParser()
-        result = parser.feed("Hello, this is regular content without any thinking tags.")
-        
+        result = parser.feed(
+            "Hello, this is regular content without any thinking tags."
+        )
+
         print(f"Comparing state: Expected STREAMING, Got {parser.state}")
         assert parser.state == ParserState.STREAMING
         assert result.state_changed is True
-        assert result.regular_content == "Hello, this is regular content without any thinking tags."
-    
+        assert (
+            result.regular_content
+            == "Hello, this is regular content without any thinking tags."
+        )
+
     def test_buffer_exceeds_limit_transitions_to_streaming(self):
         """
         What it does: Verifies transition to STREAMING when buffer exceeds limit.
@@ -300,7 +314,7 @@ class TestThinkingParserFeedPreContent:
         print("Feeding content that exceeds buffer limit...")
         parser = ThinkingParser(initial_buffer_size=10)
         result = parser.feed("This is a long content that exceeds the buffer limit")
-        
+
         print(f"Comparing state: Expected STREAMING, Got {parser.state}")
         assert parser.state == ParserState.STREAMING
         assert result.state_changed is True
@@ -308,7 +322,7 @@ class TestThinkingParserFeedPreContent:
 
 class TestThinkingParserFeedInThinking:
     """Tests for ThinkingParser.feed() in IN_THINKING state."""
-    
+
     def test_accumulates_thinking_content(self):
         """
         What it does: Verifies thinking content is accumulated.
@@ -317,14 +331,17 @@ class TestThinkingParserFeedInThinking:
         print("Feeding thinking content...")
         parser = ThinkingParser()
         parser.feed("<thinking>")
-        
+
         # Feed more content
         result = parser.feed("This is thinking content")
-        
+
         print(f"Comparing thinking_buffer: Got '{parser.thinking_buffer}'")
         # Content is in buffer due to cautious sending
-        assert "This is thinking content" in parser.thinking_buffer or result.thinking_content
-    
+        assert (
+            "This is thinking content" in parser.thinking_buffer
+            or result.thinking_content
+        )
+
     def test_detects_closing_tag(self):
         """
         What it does: Verifies closing tag detection.
@@ -334,12 +351,12 @@ class TestThinkingParserFeedInThinking:
         parser = ThinkingParser()
         parser.feed("<thinking>Hello")
         result = parser.feed("</thinking>World")
-        
+
         print(f"Comparing state: Expected STREAMING, Got {parser.state}")
         assert parser.state == ParserState.STREAMING
         assert result.is_last_thinking_chunk is True
         assert result.state_changed is True
-    
+
     def test_regular_content_after_closing_tag(self):
         """
         What it does: Verifies regular content after closing tag.
@@ -349,10 +366,10 @@ class TestThinkingParserFeedInThinking:
         parser = ThinkingParser()
         parser.feed("<thinking>Thinking")
         result = parser.feed("</thinking>Regular content")
-        
+
         print(f"Comparing regular_content: Got '{result.regular_content}'")
         assert result.regular_content == "Regular content"
-    
+
     def test_strips_whitespace_after_closing_tag(self):
         """
         What it does: Verifies whitespace is stripped after closing tag.
@@ -362,10 +379,10 @@ class TestThinkingParserFeedInThinking:
         parser = ThinkingParser()
         parser.feed("<thinking>Thinking")
         result = parser.feed("</thinking>\n\nRegular content")
-        
+
         print(f"Comparing regular_content: Got '{result.regular_content}'")
         assert result.regular_content == "Regular content"
-    
+
     def test_cautious_buffering(self):
         """
         What it does: Verifies cautious buffering keeps last max_tag_length chars.
@@ -374,15 +391,15 @@ class TestThinkingParserFeedInThinking:
         print("Testing cautious buffering...")
         parser = ThinkingParser(open_tags=["<t>"])  # Short tag for easier testing
         parser.feed("<t>")
-        
+
         # Feed content longer than max_tag_length
         long_content = "A" * 50
-        result = parser.feed(long_content)
-        
+        parser.feed(long_content)
+
         print(f"Comparing thinking_buffer length: Got {len(parser.thinking_buffer)}")
         # Buffer should keep last max_tag_length chars
         assert len(parser.thinking_buffer) <= parser.max_tag_length
-    
+
     def test_split_closing_tag(self):
         """
         What it does: Verifies split closing tag is handled.
@@ -392,15 +409,15 @@ class TestThinkingParserFeedInThinking:
         parser = ThinkingParser()
         parser.feed("<thinking>Hello")
         parser.feed("</think")
-        result = parser.feed("ing>World")
-        
+        parser.feed("ing>World")
+
         print(f"Comparing state: Expected STREAMING, Got {parser.state}")
         assert parser.state == ParserState.STREAMING
 
 
 class TestThinkingParserFeedStreaming:
     """Tests for ThinkingParser.feed() in STREAMING state."""
-    
+
     def test_passes_content_through(self):
         """
         What it does: Verifies content is passed through in STREAMING state.
@@ -410,13 +427,15 @@ class TestThinkingParserFeedStreaming:
         parser = ThinkingParser()
         # Transition to STREAMING by feeding non-tag content
         parser.feed("Regular content")
-        
+
         result = parser.feed("More content")
-        
-        print(f"Comparing regular_content: Expected 'More content', Got '{result.regular_content}'")
+
+        print(
+            f"Comparing regular_content: Expected 'More content', Got '{result.regular_content}'"
+        )
         assert result.regular_content == "More content"
         assert result.thinking_content is None
-    
+
     def test_ignores_thinking_tags_in_streaming(self):
         """
         What it does: Verifies thinking tags are ignored in STREAMING state.
@@ -425,9 +444,9 @@ class TestThinkingParserFeedStreaming:
         print("Feeding thinking tag in STREAMING state...")
         parser = ThinkingParser()
         parser.feed("Regular content")  # Transition to STREAMING
-        
+
         result = parser.feed("<thinking>This should be regular</thinking>")
-        
+
         print(f"Comparing regular_content: Got '{result.regular_content}'")
         assert result.regular_content == "<thinking>This should be regular</thinking>"
         assert result.thinking_content is None
@@ -435,7 +454,7 @@ class TestThinkingParserFeedStreaming:
 
 class TestThinkingParserFinalize:
     """Tests for ThinkingParser.finalize()."""
-    
+
     def test_flushes_thinking_buffer(self):
         """
         What it does: Verifies thinking buffer is flushed on finalize.
@@ -444,13 +463,13 @@ class TestThinkingParserFinalize:
         print("Finalizing parser with thinking buffer...")
         parser = ThinkingParser()
         parser.feed("<thinking>Incomplete thinking")
-        
+
         result = parser.finalize()
-        
+
         print(f"Comparing thinking_content: Got '{result.thinking_content}'")
         assert result.thinking_content is not None
         assert result.is_last_thinking_chunk is True
-    
+
     def test_flushes_initial_buffer(self):
         """
         What it does: Verifies initial buffer is flushed on finalize.
@@ -459,12 +478,12 @@ class TestThinkingParserFinalize:
         print("Finalizing parser with initial buffer...")
         parser = ThinkingParser()
         parser.feed("<thi")  # Partial tag, stays in initial_buffer
-        
+
         result = parser.finalize()
-        
+
         print(f"Comparing regular_content: Got '{result.regular_content}'")
         assert result.regular_content == "<thi"
-    
+
     def test_clears_buffers_after_finalize(self):
         """
         What it does: Verifies buffers are cleared after finalize.
@@ -474,15 +493,17 @@ class TestThinkingParserFinalize:
         parser = ThinkingParser()
         parser.feed("<thinking>Content")
         parser.finalize()
-        
-        print(f"Comparing buffers: thinking_buffer='{parser.thinking_buffer}', initial_buffer='{parser.initial_buffer}'")
+
+        print(
+            f"Comparing buffers: thinking_buffer='{parser.thinking_buffer}', initial_buffer='{parser.initial_buffer}'"
+        )
         assert parser.thinking_buffer == ""
         assert parser.initial_buffer == ""
 
 
 class TestThinkingParserReset:
     """Tests for ThinkingParser.reset()."""
-    
+
     def test_resets_to_initial_state(self):
         """
         What it does: Verifies reset returns parser to initial state.
@@ -491,9 +512,9 @@ class TestThinkingParserReset:
         print("Resetting parser after use...")
         parser = ThinkingParser()
         parser.feed("<thinking>Content</thinking>Regular")
-        
+
         parser.reset()
-        
+
         print(f"Comparing state: Expected PRE_CONTENT, Got {parser.state}")
         assert parser.state == ParserState.PRE_CONTENT
         assert parser.initial_buffer == ""
@@ -506,7 +527,7 @@ class TestThinkingParserReset:
 
 class TestThinkingParserFoundThinkingBlock:
     """Tests for ThinkingParser.found_thinking_block property."""
-    
+
     def test_false_initially(self):
         """
         What it does: Verifies found_thinking_block is False initially.
@@ -514,10 +535,10 @@ class TestThinkingParserFoundThinkingBlock:
         """
         print("Checking found_thinking_block initially...")
         parser = ThinkingParser()
-        
+
         print(f"Comparing: Expected False, Got {parser.found_thinking_block}")
         assert parser.found_thinking_block is False
-    
+
     def test_true_after_tag_detection(self):
         """
         What it does: Verifies found_thinking_block is True after tag detection.
@@ -526,10 +547,10 @@ class TestThinkingParserFoundThinkingBlock:
         print("Checking found_thinking_block after tag detection...")
         parser = ThinkingParser()
         parser.feed("<thinking>Content")
-        
+
         print(f"Comparing: Expected True, Got {parser.found_thinking_block}")
         assert parser.found_thinking_block is True
-    
+
     def test_false_when_no_tag(self):
         """
         What it does: Verifies found_thinking_block is False when no tag found.
@@ -538,14 +559,14 @@ class TestThinkingParserFoundThinkingBlock:
         print("Checking found_thinking_block with no tag...")
         parser = ThinkingParser()
         parser.feed("Regular content without thinking tags")
-        
+
         print(f"Comparing: Expected False, Got {parser.found_thinking_block}")
         assert parser.found_thinking_block is False
 
 
 class TestThinkingParserProcessForOutput:
     """Tests for ThinkingParser.process_for_output()."""
-    
+
     def test_as_reasoning_content_mode(self):
         """
         What it does: Verifies as_reasoning_content mode returns content as-is.
@@ -555,12 +576,14 @@ class TestThinkingParserProcessForOutput:
         parser = ThinkingParser(handling_mode="as_reasoning_content")
         parser.open_tag = "<thinking>"
         parser.close_tag = "</thinking>"
-        
-        result = parser.process_for_output("Thinking content", is_first=True, is_last=True)
-        
+
+        result = parser.process_for_output(
+            "Thinking content", is_first=True, is_last=True
+        )
+
         print(f"Comparing: Expected 'Thinking content', Got '{result}'")
         assert result == "Thinking content"
-    
+
     def test_remove_mode(self):
         """
         What it does: Verifies remove mode returns None.
@@ -568,12 +591,14 @@ class TestThinkingParserProcessForOutput:
         """
         print("Testing remove mode...")
         parser = ThinkingParser(handling_mode="remove")
-        
-        result = parser.process_for_output("Thinking content", is_first=True, is_last=True)
-        
+
+        result = parser.process_for_output(
+            "Thinking content", is_first=True, is_last=True
+        )
+
         print(f"Comparing: Expected None, Got {result}")
         assert result is None
-    
+
     def test_pass_mode_first_chunk(self):
         """
         What it does: Verifies pass mode adds opening tag to first chunk.
@@ -583,12 +608,12 @@ class TestThinkingParserProcessForOutput:
         parser = ThinkingParser(handling_mode="pass")
         parser.open_tag = "<thinking>"
         parser.close_tag = "</thinking>"
-        
+
         result = parser.process_for_output("Content", is_first=True, is_last=False)
-        
+
         print(f"Comparing: Expected '<thinking>Content', Got '{result}'")
         assert result == "<thinking>Content"
-    
+
     def test_pass_mode_last_chunk(self):
         """
         What it does: Verifies pass mode adds closing tag to last chunk.
@@ -598,12 +623,12 @@ class TestThinkingParserProcessForOutput:
         parser = ThinkingParser(handling_mode="pass")
         parser.open_tag = "<thinking>"
         parser.close_tag = "</thinking>"
-        
+
         result = parser.process_for_output("Content", is_first=False, is_last=True)
-        
+
         print(f"Comparing: Expected 'Content</thinking>', Got '{result}'")
         assert result == "Content</thinking>"
-    
+
     def test_pass_mode_first_and_last_chunk(self):
         """
         What it does: Verifies pass mode adds both tags when first and last.
@@ -613,12 +638,12 @@ class TestThinkingParserProcessForOutput:
         parser = ThinkingParser(handling_mode="pass")
         parser.open_tag = "<thinking>"
         parser.close_tag = "</thinking>"
-        
+
         result = parser.process_for_output("Content", is_first=True, is_last=True)
-        
+
         print(f"Comparing: Expected '<thinking>Content</thinking>', Got '{result}'")
         assert result == "<thinking>Content</thinking>"
-    
+
     def test_pass_mode_middle_chunk(self):
         """
         What it does: Verifies pass mode returns content as-is for middle chunk.
@@ -628,12 +653,12 @@ class TestThinkingParserProcessForOutput:
         parser = ThinkingParser(handling_mode="pass")
         parser.open_tag = "<thinking>"
         parser.close_tag = "</thinking>"
-        
+
         result = parser.process_for_output("Content", is_first=False, is_last=False)
-        
+
         print(f"Comparing: Expected 'Content', Got '{result}'")
         assert result == "Content"
-    
+
     def test_strip_tags_mode(self):
         """
         What it does: Verifies strip_tags mode returns content without tags.
@@ -641,12 +666,14 @@ class TestThinkingParserProcessForOutput:
         """
         print("Testing strip_tags mode...")
         parser = ThinkingParser(handling_mode="strip_tags")
-        
-        result = parser.process_for_output("Thinking content", is_first=True, is_last=True)
-        
+
+        result = parser.process_for_output(
+            "Thinking content", is_first=True, is_last=True
+        )
+
         print(f"Comparing: Expected 'Thinking content', Got '{result}'")
         assert result == "Thinking content"
-    
+
     def test_none_content_returns_none(self):
         """
         What it does: Verifies None content returns None.
@@ -654,12 +681,12 @@ class TestThinkingParserProcessForOutput:
         """
         print("Testing None content...")
         parser = ThinkingParser()
-        
+
         result = parser.process_for_output(None, is_first=True, is_last=True)
-        
+
         print(f"Comparing: Expected None, Got {result}")
         assert result is None
-    
+
     def test_empty_content_returns_none(self):
         """
         What it does: Verifies empty content returns None.
@@ -667,16 +694,16 @@ class TestThinkingParserProcessForOutput:
         """
         print("Testing empty content...")
         parser = ThinkingParser()
-        
+
         result = parser.process_for_output("", is_first=True, is_last=True)
-        
+
         print(f"Comparing: Expected None, Got {result}")
         assert result is None
 
 
 class TestThinkingParserFullFlow:
     """Integration tests for full parsing flow."""
-    
+
     def test_complete_thinking_block(self):
         """
         What it does: Verifies complete thinking block parsing.
@@ -684,18 +711,20 @@ class TestThinkingParserFullFlow:
         """
         print("Testing complete thinking block flow...")
         parser = ThinkingParser()
-        
+
         # Feed complete thinking block
-        result1 = parser.feed("<thinking>This is my reasoning process.</thinking>Here is the answer.")
-        
+        result1 = parser.feed(
+            "<thinking>This is my reasoning process.</thinking>Here is the answer."
+        )
+
         print(f"State: {parser.state}")
         print(f"Thinking content: {result1.thinking_content}")
         print(f"Regular content: {result1.regular_content}")
-        
+
         assert parser.state == ParserState.STREAMING
         assert parser.found_thinking_block is True
         assert result1.regular_content == "Here is the answer."
-    
+
     def test_multi_chunk_thinking_block(self):
         """
         What it does: Verifies thinking block split across multiple chunks.
@@ -703,25 +732,25 @@ class TestThinkingParserFullFlow:
         """
         print("Testing multi-chunk thinking block...")
         parser = ThinkingParser()
-        
+
         # Feed in multiple chunks
-        result1 = parser.feed("<think")
+        parser.feed("<think")
         print(f"After chunk 1: state={parser.state}")
         assert parser.state == ParserState.PRE_CONTENT
-        
-        result2 = parser.feed("ing>Let me think")
+
+        parser.feed("ing>Let me think")
         print(f"After chunk 2: state={parser.state}")
         assert parser.state == ParserState.IN_THINKING
-        
-        result3 = parser.feed(" about this...</think")
+
+        parser.feed(" about this...</think")
         print(f"After chunk 3: state={parser.state}")
         assert parser.state == ParserState.IN_THINKING
-        
+
         result4 = parser.feed("ing>The answer is 42.")
         print(f"After chunk 4: state={parser.state}")
         assert parser.state == ParserState.STREAMING
         assert result4.regular_content == "The answer is 42."
-    
+
     def test_no_thinking_block(self):
         """
         What it does: Verifies handling of content without thinking block.
@@ -729,16 +758,19 @@ class TestThinkingParserFullFlow:
         """
         print("Testing content without thinking block...")
         parser = ThinkingParser()
-        
+
         result = parser.feed("This is just regular content without any thinking tags.")
-        
+
         print(f"State: {parser.state}")
         print(f"Regular content: {result.regular_content}")
-        
+
         assert parser.state == ParserState.STREAMING
         assert parser.found_thinking_block is False
-        assert result.regular_content == "This is just regular content without any thinking tags."
-    
+        assert (
+            result.regular_content
+            == "This is just regular content without any thinking tags."
+        )
+
     def test_thinking_block_with_newlines(self):
         """
         What it does: Verifies thinking block with newlines after closing tag.
@@ -746,12 +778,12 @@ class TestThinkingParserFullFlow:
         """
         print("Testing thinking block with newlines...")
         parser = ThinkingParser()
-        
+
         result = parser.feed("<thinking>Reasoning</thinking>\n\n\nAnswer here")
-        
+
         print(f"Regular content: '{result.regular_content}'")
         assert result.regular_content == "Answer here"
-    
+
     def test_empty_thinking_block(self):
         """
         What it does: Verifies empty thinking block handling.
@@ -759,14 +791,14 @@ class TestThinkingParserFullFlow:
         """
         print("Testing empty thinking block...")
         parser = ThinkingParser()
-        
+
         result = parser.feed("<thinking></thinking>Answer")
-        
+
         print(f"State: {parser.state}")
         print(f"Regular content: '{result.regular_content}'")
         assert parser.state == ParserState.STREAMING
         assert result.regular_content == "Answer"
-    
+
     def test_thinking_block_only_whitespace_after(self):
         """
         What it does: Verifies thinking block with only whitespace after closing tag.
@@ -774,9 +806,9 @@ class TestThinkingParserFullFlow:
         """
         print("Testing thinking block with only whitespace after...")
         parser = ThinkingParser()
-        
+
         result = parser.feed("<thinking>Reasoning</thinking>   \n\n   ")
-        
+
         print(f"Regular content: {result.regular_content}")
         # Whitespace-only content should be stripped to None
         assert result.regular_content is None or result.regular_content == ""
@@ -784,7 +816,7 @@ class TestThinkingParserFullFlow:
 
 class TestThinkingParserEdgeCases:
     """Edge case tests for ThinkingParser."""
-    
+
     def test_nested_tags_not_supported(self):
         """
         What it does: Verifies nested tags are not specially handled.
@@ -792,13 +824,15 @@ class TestThinkingParserEdgeCases:
         """
         print("Testing nested tags...")
         parser = ThinkingParser()
-        
-        result = parser.feed("<thinking>Outer<thinking>Inner</thinking>Still outer</thinking>Answer")
-        
+
+        parser.feed(
+            "<thinking>Outer<thinking>Inner</thinking>Still outer</thinking>Answer"
+        )
+
         print(f"State: {parser.state}")
         # First </thinking> closes the block
         assert parser.state == ParserState.STREAMING
-    
+
     def test_tag_in_middle_of_content(self):
         """
         What it does: Verifies tag in middle of content is not detected.
@@ -806,15 +840,17 @@ class TestThinkingParserEdgeCases:
         """
         print("Testing tag in middle of content...")
         parser = ThinkingParser()
-        
-        result = parser.feed("Some text <thinking>This is not a thinking block</thinking>")
-        
+
+        result = parser.feed(
+            "Some text <thinking>This is not a thinking block</thinking>"
+        )
+
         print(f"State: {parser.state}")
         print(f"Regular content: '{result.regular_content}'")
         assert parser.state == ParserState.STREAMING
         assert parser.found_thinking_block is False
         assert "<thinking>" in result.regular_content
-    
+
     def test_malformed_closing_tag(self):
         """
         What it does: Verifies malformed closing tag is not detected.
@@ -822,14 +858,14 @@ class TestThinkingParserEdgeCases:
         """
         print("Testing malformed closing tag...")
         parser = ThinkingParser()
-        
+
         parser.feed("<thinking>Content")
-        result = parser.feed("</THINKING>More content")  # Wrong case
-        
+        parser.feed("</THINKING>More content")  # Wrong case
+
         print(f"State: {parser.state}")
         # Should still be in thinking state
         assert parser.state == ParserState.IN_THINKING
-    
+
     def test_unicode_content(self):
         """
         What it does: Verifies Unicode content is handled correctly.
@@ -837,13 +873,13 @@ class TestThinkingParserEdgeCases:
         """
         print("Testing Unicode content...")
         parser = ThinkingParser()
-        
+
         result = parser.feed("<thinking>Думаю о проблеме 🤔</thinking>Ответ: 42")
-        
+
         print(f"Regular content: '{result.regular_content}'")
         assert parser.state == ParserState.STREAMING
         assert result.regular_content == "Ответ: 42"
-    
+
     def test_very_long_thinking_content(self):
         """
         What it does: Verifies very long thinking content is handled.
@@ -851,14 +887,14 @@ class TestThinkingParserEdgeCases:
         """
         print("Testing very long thinking content...")
         parser = ThinkingParser()
-        
+
         long_content = "A" * 10000
         result = parser.feed(f"<thinking>{long_content}</thinking>Done")
-        
+
         print(f"State: {parser.state}")
         assert parser.state == ParserState.STREAMING
         assert result.regular_content == "Done"
-    
+
     def test_special_characters_in_content(self):
         """
         What it does: Verifies special characters are handled.
@@ -866,13 +902,15 @@ class TestThinkingParserEdgeCases:
         """
         print("Testing special characters...")
         parser = ThinkingParser()
-        
-        result = parser.feed("<thinking>Content with <b>bold</b> and &amp; entities</thinking>Answer")
-        
+
+        result = parser.feed(
+            "<thinking>Content with <b>bold</b> and &amp; entities</thinking>Answer"
+        )
+
         print(f"State: {parser.state}")
         assert parser.state == ParserState.STREAMING
         assert result.regular_content == "Answer"
-    
+
     def test_multiple_feeds_after_streaming(self):
         """
         What it does: Verifies multiple feeds in STREAMING state.
@@ -880,11 +918,11 @@ class TestThinkingParserEdgeCases:
         """
         print("Testing multiple feeds in STREAMING state...")
         parser = ThinkingParser()
-        
+
         parser.feed("<thinking>Thinking</thinking>First")
         result2 = parser.feed(" Second")
         result3 = parser.feed(" Third")
-        
+
         print(f"Result 2: '{result2.regular_content}'")
         print(f"Result 3: '{result3.regular_content}'")
         assert result2.regular_content == " Second"
@@ -893,19 +931,19 @@ class TestThinkingParserEdgeCases:
 
 class TestThinkingParserConfigIntegration:
     """Tests for ThinkingParser integration with config."""
-    
+
     def test_uses_config_handling_mode(self):
         """
         What it does: Verifies parser uses FAKE_REASONING_HANDLING from config.
         Purpose: Ensure config integration works.
         """
         print("Testing config handling mode...")
-        with patch('kiro.thinking_parser.FAKE_REASONING_HANDLING', 'remove'):
+        with patch("kiro.thinking_parser.FAKE_REASONING_HANDLING", "remove"):
             parser = ThinkingParser()
-            
+
             print(f"Handling mode: {parser.handling_mode}")
             assert parser.handling_mode == "remove"
-    
+
     def test_uses_config_open_tags(self):
         """
         What it does: Verifies parser uses FAKE_REASONING_OPEN_TAGS from config.
@@ -913,26 +951,26 @@ class TestThinkingParserConfigIntegration:
         """
         print("Testing config open tags...")
         custom_tags = ["<custom>"]
-        with patch('kiro.thinking_parser.FAKE_REASONING_OPEN_TAGS', custom_tags):
+        with patch("kiro.thinking_parser.FAKE_REASONING_OPEN_TAGS", custom_tags):
             parser = ThinkingParser()
-            
+
             print(f"Open tags: {parser.open_tags}")
             assert parser.open_tags == custom_tags
-    
+
     def test_default_initial_buffer_size_from_config(self):
         """
         What it does: Verifies parser uses default initial_buffer_size from config.
         Purpose: Ensure config value is used when not overridden.
-        
+
         Note: We can't easily patch the config value after import, so we just
         verify the default is used. Custom values are tested in
         TestThinkingParserInitialization.test_custom_initial_buffer_size.
         """
         print("Testing default initial buffer size from config...")
         from kiro.config import FAKE_REASONING_INITIAL_BUFFER_SIZE
-        
+
         parser = ThinkingParser()
-        
+
         print(f"Initial buffer size: {parser.initial_buffer_size}")
         print(f"Config value: {FAKE_REASONING_INITIAL_BUFFER_SIZE}")
         assert parser.initial_buffer_size == FAKE_REASONING_INITIAL_BUFFER_SIZE
@@ -940,7 +978,7 @@ class TestThinkingParserConfigIntegration:
 
 class TestInjectThinkingTags:
     """Tests for inject_thinking_tags function in converters."""
-    
+
     def test_injects_tags_when_enabled(self):
         """
         What it does: Verifies tags are injected when FAKE_REASONING_ENABLED is True.
@@ -948,16 +986,16 @@ class TestInjectThinkingTags:
         """
         print("Testing tag injection when enabled...")
         from kiro.converters_core import inject_thinking_tags
-        
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-            with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 4000):
+
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 4000):
                 result = inject_thinking_tags("Hello")
-        
+
         print(f"Result: '{result}'")
         assert "<thinking_mode>enabled</thinking_mode>" in result
         assert "<max_thinking_length>4000</max_thinking_length>" in result
         assert "Hello" in result
-    
+
     def test_no_injection_when_disabled(self):
         """
         What it does: Verifies tags are not injected when FAKE_REASONING_ENABLED is False.
@@ -965,14 +1003,14 @@ class TestInjectThinkingTags:
         """
         print("Testing no tag injection when disabled...")
         from kiro.converters_core import inject_thinking_tags
-        
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', False):
+
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
             result = inject_thinking_tags("Hello")
-        
+
         print(f"Result: '{result}'")
         assert result == "Hello"
         assert "<thinking_mode>" not in result
-    
+
     def test_injection_preserves_content(self):
         """
         What it does: Verifies original content is preserved after injection.
@@ -980,13 +1018,12 @@ class TestInjectThinkingTags:
         """
         print("Testing content preservation...")
         from kiro.converters_core import inject_thinking_tags
-        
+
         original = "This is my original content with special chars: <>&"
-        
-        with patch('kiro.converters_core.FAKE_REASONING_ENABLED', True):
-            with patch('kiro.converters_core.FAKE_REASONING_MAX_TOKENS', 4000):
+
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            with patch("kiro.converters_core.FAKE_REASONING_MAX_TOKENS", 4000):
                 result = inject_thinking_tags(original)
-        
+
         print(f"Result ends with original: {result.endswith(original)}")
         assert result.endswith(original)
-        

--- a/tests/unit/test_tokenizer.py
+++ b/tests/unit/test_tokenizer.py
@@ -12,8 +12,7 @@ Unit-тесты для модуля токенизатора (kiro/tokenizer.py)
 - Fallback при отсутствии tiktoken
 """
 
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from kiro.tokenizer import (
     count_tokens,
@@ -21,13 +20,13 @@ from kiro.tokenizer import (
     count_tools_tokens,
     estimate_request_tokens,
     CLAUDE_CORRECTION_FACTOR,
-    _get_encoding
+    _get_encoding,
 )
 
 
 class TestCountTokens:
     """Тесты для функции count_tokens."""
-    
+
     def test_empty_string_returns_zero(self):
         """
         Что он делает: Проверяет, что пустая строка возвращает 0 токенов.
@@ -37,7 +36,7 @@ class TestCountTokens:
         result = count_tokens("")
         print(f"Результат: {result}")
         assert result == 0, "Пустая строка должна возвращать 0 токенов"
-    
+
     def test_none_returns_zero(self):
         """
         Что он делает: Проверяет, что None возвращает 0 токенов.
@@ -47,7 +46,7 @@ class TestCountTokens:
         result = count_tokens(None)
         print(f"Результат: {result}")
         assert result == 0, "None должен возвращать 0 токенов"
-    
+
     def test_simple_text_returns_positive(self):
         """
         Что он делает: Проверяет, что простой текст возвращает положительное число токенов.
@@ -57,7 +56,7 @@ class TestCountTokens:
         result = count_tokens("Hello, world!")
         print(f"Результат: {result}")
         assert result > 0, "Простой текст должен возвращать положительное число токенов"
-    
+
     def test_longer_text_returns_more_tokens(self):
         """
         Что он делает: Проверяет, что более длинный текст возвращает больше токенов.
@@ -66,15 +65,15 @@ class TestCountTokens:
         print("Тест: Сравнение длинного и короткого текста...")
         short_text = "Hello"
         long_text = "Hello, this is a much longer text that should have more tokens"
-        
+
         short_tokens = count_tokens(short_text)
         long_tokens = count_tokens(long_text)
-        
+
         print(f"Короткий текст: {short_tokens} токенов")
         print(f"Длинный текст: {long_tokens} токенов")
-        
+
         assert long_tokens > short_tokens, "Длинный текст должен иметь больше токенов"
-    
+
     def test_claude_correction_applied_by_default(self):
         """
         Что он делает: Проверяет, что коэффициент коррекции Claude применяется по умолчанию.
@@ -82,21 +81,25 @@ class TestCountTokens:
         """
         print("Тест: Коэффициент коррекции Claude...")
         text = "This is a test text for token counting"
-        
+
         with_correction = count_tokens(text, apply_claude_correction=True)
         without_correction = count_tokens(text, apply_claude_correction=False)
-        
+
         print(f"С коррекцией: {with_correction}")
         print(f"Без коррекции: {without_correction}")
-        
+
         # С коррекцией должно быть больше (коэффициент 1.15)
-        assert with_correction > without_correction, "С коррекцией должно быть больше токенов"
-        
+        assert with_correction > without_correction, (
+            "С коррекцией должно быть больше токенов"
+        )
+
         # Проверяем примерное соотношение
         ratio = with_correction / without_correction
         print(f"Соотношение: {ratio}")
-        assert 1.1 <= ratio <= 1.2, f"Соотношение должно быть около {CLAUDE_CORRECTION_FACTOR}"
-    
+        assert 1.1 <= ratio <= 1.2, (
+            f"Соотношение должно быть около {CLAUDE_CORRECTION_FACTOR}"
+        )
+
     def test_without_claude_correction(self):
         """
         Что он делает: Проверяет подсчёт без коэффициента коррекции.
@@ -104,12 +107,12 @@ class TestCountTokens:
         """
         print("Тест: Без коэффициента коррекции...")
         text = "Test text"
-        
+
         result = count_tokens(text, apply_claude_correction=False)
         print(f"Результат: {result}")
-        
+
         assert result > 0, "Должен вернуть положительное число токенов"
-    
+
     def test_unicode_text(self):
         """
         Что он делает: Проверяет подсчёт токенов для Unicode текста.
@@ -117,12 +120,12 @@ class TestCountTokens:
         """
         print("Тест: Unicode текст...")
         text = "Привет, мир! 你好世界 🌍"
-        
+
         result = count_tokens(text)
         print(f"Результат: {result}")
-        
+
         assert result > 0, "Unicode текст должен возвращать положительное число токенов"
-    
+
     def test_multiline_text(self):
         """
         Что он делает: Проверяет подсчёт токенов для многострочного текста.
@@ -132,12 +135,14 @@ class TestCountTokens:
         text = """Line 1
         Line 2
         Line 3"""
-        
+
         result = count_tokens(text)
         print(f"Результат: {result}")
-        
-        assert result > 0, "Многострочный текст должен возвращать положительное число токенов"
-    
+
+        assert result > 0, (
+            "Многострочный текст должен возвращать положительное число токенов"
+        )
+
     def test_json_text(self):
         """
         Что он делает: Проверяет подсчёт токенов для JSON строки.
@@ -145,45 +150,45 @@ class TestCountTokens:
         """
         print("Тест: JSON текст...")
         text = '{"name": "test", "value": 123, "nested": {"key": "value"}}'
-        
+
         result = count_tokens(text)
         print(f"Результат: {result}")
-        
+
         assert result > 0, "JSON текст должен возвращать положительное число токенов"
 
 
 class TestCountTokensFallback:
     """Тесты для fallback логики при отсутствии tiktoken."""
-    
+
     def test_fallback_when_tiktoken_unavailable(self):
         """
         Что он делает: Проверяет fallback подсчёт когда tiktoken недоступен.
         Цель: Убедиться, что система работает без tiktoken.
         """
         print("Тест: Fallback без tiktoken...")
-        
+
         # Мокируем _get_encoding чтобы вернуть None
-        with patch('kiro.tokenizer._get_encoding', return_value=None):
+        with patch("kiro.tokenizer._get_encoding", return_value=None):
             result = count_tokens("Hello world test")
             print(f"Результат: {result}")
-            
+
             # Fallback: len(text) // 4 + 1, затем * 1.15
             # "Hello world test" = 16 символов
             # 16 // 4 + 1 = 5
             # 5 * 1.15 = 5.75 -> 5
             assert result > 0, "Fallback должен вернуть положительное число"
-    
+
     def test_fallback_without_correction(self):
         """
         Что он делает: Проверяет fallback без коэффициента коррекции.
         Цель: Убедиться, что fallback работает с apply_claude_correction=False.
         """
         print("Тест: Fallback без коррекции...")
-        
-        with patch('kiro.tokenizer._get_encoding', return_value=None):
+
+        with patch("kiro.tokenizer._get_encoding", return_value=None):
             result = count_tokens("Test", apply_claude_correction=False)
             print(f"Результат: {result}")
-            
+
             # "Test" = 4 символа
             # 4 // 4 + 1 = 2
             assert result > 0, "Fallback должен вернуть положительное число"
@@ -191,7 +196,7 @@ class TestCountTokensFallback:
 
 class TestCountMessageTokens:
     """Тесты для функции count_message_tokens."""
-    
+
     def test_empty_list_returns_zero(self):
         """
         Что он делает: Проверяет, что пустой список возвращает 0 токенов.
@@ -201,7 +206,7 @@ class TestCountMessageTokens:
         result = count_message_tokens([])
         print(f"Результат: {result}")
         assert result == 0, "Пустой список должен возвращать 0 токенов"
-    
+
     def test_none_returns_zero(self):
         """
         Что он делает: Проверяет, что None возвращает 0 токенов.
@@ -211,7 +216,7 @@ class TestCountMessageTokens:
         result = count_message_tokens(None)
         print(f"Результат: {result}")
         assert result == 0, "None должен возвращать 0 токенов"
-    
+
     def test_single_user_message(self):
         """
         Что он делает: Проверяет подсчёт токенов для одного user сообщения.
@@ -219,12 +224,12 @@ class TestCountMessageTokens:
         """
         print("Тест: Одно user сообщение...")
         messages = [{"role": "user", "content": "Hello, AI!"}]
-        
+
         result = count_message_tokens(messages)
         print(f"Результат: {result}")
-        
+
         assert result > 0, "Должен вернуть положительное число токенов"
-    
+
     def test_multiple_messages(self):
         """
         Что он делает: Проверяет подсчёт токенов для нескольких сообщений.
@@ -235,16 +240,18 @@ class TestCountMessageTokens:
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "Hello!"},
             {"role": "assistant", "content": "Hi there! How can I help you?"},
-            {"role": "user", "content": "What is the weather?"}
+            {"role": "user", "content": "What is the weather?"},
         ]
-        
+
         result = count_message_tokens(messages)
         print(f"Результат: {result}")
-        
+
         # Больше сообщений = больше токенов
         single_message = count_message_tokens([messages[0]])
-        assert result > single_message, "Несколько сообщений должны иметь больше токенов"
-    
+        assert result > single_message, (
+            "Несколько сообщений должны иметь больше токенов"
+        )
+
     def test_message_with_tool_calls(self):
         """
         Что он делает: Проверяет подсчёт токенов для сообщения с tool_calls.
@@ -261,18 +268,18 @@ class TestCountMessageTokens:
                         "type": "function",
                         "function": {
                             "name": "get_weather",
-                            "arguments": '{"location": "Moscow"}'
-                        }
+                            "arguments": '{"location": "Moscow"}',
+                        },
                     }
-                ]
+                ],
             }
         ]
-        
+
         result = count_message_tokens(messages)
         print(f"Результат: {result}")
-        
+
         assert result > 0, "Сообщение с tool_calls должно иметь токены"
-    
+
     def test_message_with_tool_call_id(self):
         """
         Что он делает: Проверяет подсчёт токенов для tool response сообщения.
@@ -283,15 +290,15 @@ class TestCountMessageTokens:
             {
                 "role": "tool",
                 "content": "The weather in Moscow is sunny, 25°C",
-                "tool_call_id": "call_123"
+                "tool_call_id": "call_123",
             }
         ]
-        
+
         result = count_message_tokens(messages)
         print(f"Результат: {result}")
-        
+
         assert result > 0, "Tool response должен иметь токены"
-    
+
     def test_message_with_list_content(self):
         """
         Что он делает: Проверяет подсчёт токенов для мультимодального контента.
@@ -303,16 +310,19 @@ class TestCountMessageTokens:
                 "role": "user",
                 "content": [
                     {"type": "text", "text": "What is in this image?"},
-                    {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
-                ]
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/image.jpg"},
+                    },
+                ],
             }
         ]
-        
+
         result = count_message_tokens(messages)
         print(f"Результат: {result}")
-        
+
         assert result > 0, "Мультимодальный контент должен иметь токены"
-    
+
     def test_without_claude_correction(self):
         """
         Что он делает: Проверяет подсчёт без коэффициента коррекции.
@@ -320,15 +330,17 @@ class TestCountMessageTokens:
         """
         print("Тест: Без коэффициента коррекции...")
         messages = [{"role": "user", "content": "Test message"}]
-        
+
         with_correction = count_message_tokens(messages, apply_claude_correction=True)
-        without_correction = count_message_tokens(messages, apply_claude_correction=False)
-        
+        without_correction = count_message_tokens(
+            messages, apply_claude_correction=False
+        )
+
         print(f"С коррекцией: {with_correction}")
         print(f"Без коррекции: {without_correction}")
-        
+
         assert with_correction > without_correction, "С коррекцией должно быть больше"
-    
+
     def test_message_with_empty_content(self):
         """
         Что он делает: Проверяет подсчёт для сообщения с пустым content.
@@ -336,13 +348,13 @@ class TestCountMessageTokens:
         """
         print("Тест: Пустой content...")
         messages = [{"role": "user", "content": ""}]
-        
+
         result = count_message_tokens(messages)
         print(f"Результат: {result}")
-        
+
         # Должны быть служебные токены (role, разделители)
         assert result > 0, "Даже пустое сообщение должно иметь служебные токены"
-    
+
     def test_message_with_none_content(self):
         """
         Что он делает: Проверяет подсчёт для сообщения с None content.
@@ -350,16 +362,16 @@ class TestCountMessageTokens:
         """
         print("Тест: None content...")
         messages = [{"role": "assistant", "content": None}]
-        
+
         result = count_message_tokens(messages)
         print(f"Результат: {result}")
-        
+
         assert result > 0, "Сообщение с None content должно иметь служебные токены"
 
 
 class TestCountToolsTokens:
     """Тесты для функции count_tools_tokens."""
-    
+
     def test_none_returns_zero(self):
         """
         Что он делает: Проверяет, что None возвращает 0 токенов.
@@ -369,7 +381,7 @@ class TestCountToolsTokens:
         result = count_tools_tokens(None)
         print(f"Результат: {result}")
         assert result == 0, "None должен возвращать 0 токенов"
-    
+
     def test_empty_list_returns_zero(self):
         """
         Что он делает: Проверяет, что пустой список возвращает 0 токенов.
@@ -379,7 +391,7 @@ class TestCountToolsTokens:
         result = count_tools_tokens([])
         print(f"Результат: {result}")
         assert result == 0, "Пустой список должен возвращать 0 токенов"
-    
+
     def test_single_tool(self):
         """
         Что он делает: Проверяет подсчёт токенов для одного инструмента.
@@ -397,17 +409,17 @@ class TestCountToolsTokens:
                         "properties": {
                             "location": {"type": "string", "description": "City name"}
                         },
-                        "required": ["location"]
-                    }
-                }
+                        "required": ["location"],
+                    },
+                },
             }
         ]
-        
+
         result = count_tools_tokens(tools)
         print(f"Результат: {result}")
-        
+
         assert result > 0, "Инструмент должен иметь токены"
-    
+
     def test_multiple_tools(self):
         """
         Что он делает: Проверяет подсчёт токенов для нескольких инструментов.
@@ -420,27 +432,27 @@ class TestCountToolsTokens:
                 "function": {
                     "name": "get_weather",
                     "description": "Get weather",
-                    "parameters": {"type": "object", "properties": {}}
-                }
+                    "parameters": {"type": "object", "properties": {}},
+                },
             },
             {
                 "type": "function",
                 "function": {
                     "name": "search_web",
                     "description": "Search the web",
-                    "parameters": {"type": "object", "properties": {}}
-                }
-            }
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
         ]
-        
+
         result = count_tools_tokens(tools)
         single_tool = count_tools_tokens([tools[0]])
-        
+
         print(f"Два инструмента: {result}")
         print(f"Один инструмент: {single_tool}")
-        
+
         assert result > single_tool, "Больше инструментов = больше токенов"
-    
+
     def test_tool_with_complex_parameters(self):
         """
         Что он делает: Проверяет подсчёт для инструмента со сложными параметрами.
@@ -463,25 +475,22 @@ class TestCountToolsTokens:
                                 "properties": {
                                     "street": {"type": "string"},
                                     "city": {"type": "string"},
-                                    "country": {"type": "string"}
-                                }
+                                    "country": {"type": "string"},
+                                },
                             },
-                            "tags": {
-                                "type": "array",
-                                "items": {"type": "string"}
-                            }
+                            "tags": {"type": "array", "items": {"type": "string"}},
                         },
-                        "required": ["name", "age"]
-                    }
-                }
+                        "required": ["name", "age"],
+                    },
+                },
             }
         ]
-        
+
         result = count_tools_tokens(tools)
         print(f"Результат: {result}")
-        
+
         assert result > 0, "Сложный инструмент должен иметь токены"
-    
+
     def test_tool_without_parameters(self):
         """
         Что он делает: Проверяет подсчёт для инструмента без параметров.
@@ -493,16 +502,16 @@ class TestCountToolsTokens:
                 "type": "function",
                 "function": {
                     "name": "no_params_func",
-                    "description": "A function without parameters"
-                }
+                    "description": "A function without parameters",
+                },
             }
         ]
-        
+
         result = count_tools_tokens(tools)
         print(f"Результат: {result}")
-        
+
         assert result > 0, "Инструмент без параметров должен иметь токены"
-    
+
     def test_tool_with_empty_description(self):
         """
         Что он делает: Проверяет подсчёт для инструмента с пустым description.
@@ -515,35 +524,30 @@ class TestCountToolsTokens:
                 "function": {
                     "name": "func",
                     "description": "",
-                    "parameters": {"type": "object", "properties": {}}
-                }
+                    "parameters": {"type": "object", "properties": {}},
+                },
             }
         ]
-        
+
         result = count_tools_tokens(tools)
         print(f"Результат: {result}")
-        
+
         assert result > 0, "Инструмент с пустым description должен иметь токены"
-    
+
     def test_non_function_tool_type(self):
         """
         Что он делает: Проверяет обработку инструмента с type != "function".
         Цель: Убедиться, что non-function tools обрабатываются.
         """
         print("Тест: Non-function tool...")
-        tools = [
-            {
-                "type": "other_type",
-                "some_field": "value"
-            }
-        ]
-        
+        tools = [{"type": "other_type", "some_field": "value"}]
+
         result = count_tools_tokens(tools)
         print(f"Результат: {result}")
-        
+
         # Должны быть хотя бы служебные токены
         assert result >= 0, "Non-function tool не должен ломать подсчёт"
-    
+
     def test_without_claude_correction(self):
         """
         Что он делает: Проверяет подсчёт без коэффициента коррекции.
@@ -556,23 +560,23 @@ class TestCountToolsTokens:
                 "function": {
                     "name": "test_func",
                     "description": "Test function",
-                    "parameters": {"type": "object", "properties": {}}
-                }
+                    "parameters": {"type": "object", "properties": {}},
+                },
             }
         ]
-        
+
         with_correction = count_tools_tokens(tools, apply_claude_correction=True)
         without_correction = count_tools_tokens(tools, apply_claude_correction=False)
-        
+
         print(f"С коррекцией: {with_correction}")
         print(f"Без коррекции: {without_correction}")
-        
+
         assert with_correction > without_correction, "С коррекцией должно быть больше"
 
 
 class TestEstimateRequestTokens:
     """Тесты для функции estimate_request_tokens."""
-    
+
     def test_messages_only(self):
         """
         Что он делает: Проверяет оценку токенов только для сообщений.
@@ -580,20 +584,20 @@ class TestEstimateRequestTokens:
         """
         print("Тест: Только сообщения...")
         messages = [{"role": "user", "content": "Hello!"}]
-        
+
         result = estimate_request_tokens(messages)
         print(f"Результат: {result}")
-        
+
         assert "messages_tokens" in result
         assert "tools_tokens" in result
         assert "system_tokens" in result
         assert "total_tokens" in result
-        
+
         assert result["messages_tokens"] > 0
         assert result["tools_tokens"] == 0
         assert result["system_tokens"] == 0
         assert result["total_tokens"] == result["messages_tokens"]
-    
+
     def test_messages_with_tools(self):
         """
         Что он делает: Проверяет оценку токенов для сообщений с инструментами.
@@ -607,18 +611,20 @@ class TestEstimateRequestTokens:
                 "function": {
                     "name": "get_weather",
                     "description": "Get weather",
-                    "parameters": {"type": "object", "properties": {}}
-                }
+                    "parameters": {"type": "object", "properties": {}},
+                },
             }
         ]
-        
+
         result = estimate_request_tokens(messages, tools=tools)
         print(f"Результат: {result}")
-        
+
         assert result["messages_tokens"] > 0
         assert result["tools_tokens"] > 0
-        assert result["total_tokens"] == result["messages_tokens"] + result["tools_tokens"]
-    
+        assert (
+            result["total_tokens"] == result["messages_tokens"] + result["tools_tokens"]
+        )
+
     def test_messages_with_system_prompt(self):
         """
         Что он делает: Проверяет оценку токенов с отдельным system prompt.
@@ -627,23 +633,24 @@ class TestEstimateRequestTokens:
         print("Тест: С system prompt...")
         messages = [{"role": "user", "content": "Hello!"}]
         system_prompt = "You are a helpful assistant."
-        
+
         result = estimate_request_tokens(messages, system_prompt=system_prompt)
         print(f"Результат: {result}")
-        
+
         assert result["messages_tokens"] > 0
         assert result["system_tokens"] > 0
-        assert result["total_tokens"] == result["messages_tokens"] + result["system_tokens"]
-    
+        assert (
+            result["total_tokens"]
+            == result["messages_tokens"] + result["system_tokens"]
+        )
+
     def test_full_request(self):
         """
         Что он делает: Проверяет оценку токенов для полного запроса.
         Цель: Убедиться, что все компоненты суммируются.
         """
         print("Тест: Полный запрос...")
-        messages = [
-            {"role": "user", "content": "What is the weather in Moscow?"}
-        ]
+        messages = [{"role": "user", "content": "What is the weather in Moscow?"}]
         tools = [
             {
                 "type": "function",
@@ -652,21 +659,25 @@ class TestEstimateRequestTokens:
                     "description": "Get weather for a location",
                     "parameters": {
                         "type": "object",
-                        "properties": {
-                            "location": {"type": "string"}
-                        }
-                    }
-                }
+                        "properties": {"location": {"type": "string"}},
+                    },
+                },
             }
         ]
         system_prompt = "You are a weather assistant."
-        
-        result = estimate_request_tokens(messages, tools=tools, system_prompt=system_prompt)
+
+        result = estimate_request_tokens(
+            messages, tools=tools, system_prompt=system_prompt
+        )
         print(f"Результат: {result}")
-        
-        expected_total = result["messages_tokens"] + result["tools_tokens"] + result["system_tokens"]
-        assert result["total_tokens"] == expected_total, "Total должен быть суммой компонентов"
-    
+
+        expected_total = (
+            result["messages_tokens"] + result["tools_tokens"] + result["system_tokens"]
+        )
+        assert result["total_tokens"] == expected_total, (
+            "Total должен быть суммой компонентов"
+        )
+
     def test_empty_messages(self):
         """
         Что он делает: Проверяет оценку для пустого списка сообщений.
@@ -675,14 +686,14 @@ class TestEstimateRequestTokens:
         print("Тест: Пустые сообщения...")
         result = estimate_request_tokens([])
         print(f"Результат: {result}")
-        
+
         assert result["messages_tokens"] == 0
         assert result["total_tokens"] == 0
 
 
 class TestClaudeCorrectionFactor:
     """Тесты для коэффициента коррекции Claude."""
-    
+
     def test_correction_factor_value(self):
         """
         Что он делает: Проверяет значение коэффициента коррекции.
@@ -690,7 +701,7 @@ class TestClaudeCorrectionFactor:
         """
         print(f"Коэффициент коррекции: {CLAUDE_CORRECTION_FACTOR}")
         assert CLAUDE_CORRECTION_FACTOR == 1.15, "Коэффициент должен быть 1.15"
-    
+
     def test_correction_increases_token_count(self):
         """
         Что он делает: Проверяет, что коррекция увеличивает количество токенов.
@@ -698,81 +709,90 @@ class TestClaudeCorrectionFactor:
         """
         print("Тест: Коррекция увеличивает токены...")
         text = "This is a test text for checking the correction factor"
-        
+
         with_correction = count_tokens(text, apply_claude_correction=True)
         without_correction = count_tokens(text, apply_claude_correction=False)
-        
+
         print(f"С коррекцией: {with_correction}")
         print(f"Без коррекции: {without_correction}")
-        
+
         assert with_correction > without_correction
-        
+
         # Проверяем, что разница примерно 15%
-        increase_percent = (with_correction - without_correction) / without_correction * 100
+        increase_percent = (
+            (with_correction - without_correction) / without_correction * 100
+        )
         print(f"Увеличение: {increase_percent:.1f}%")
-        
+
         # Допускаем погрешность из-за округления
         assert 10 <= increase_percent <= 20, "Увеличение должно быть около 15%"
+
+
 class TestGetEncoding:
     """Тесты для функции _get_encoding."""
-    
+
     def test_returns_encoding_when_tiktoken_available(self):
         """
         Что он делает: Проверяет, что _get_encoding возвращает encoding когда tiktoken доступен.
         Цель: Убедиться в корректной инициализации tiktoken.
         """
         print("Тест: tiktoken доступен...")
-        
+
         # Сбрасываем глобальную переменную для чистого теста
         import kiro.tokenizer as tokenizer_module
+
         original_encoding = tokenizer_module._encoding
         tokenizer_module._encoding = None
-        
+
         try:
             encoding = _get_encoding()
             print(f"Encoding: {encoding}")
-            
+
             # Если tiktoken установлен, должен вернуть encoding
             if encoding is not None:
-                assert hasattr(encoding, 'encode'), "Encoding должен иметь метод encode"
+                assert hasattr(encoding, "encode"), "Encoding должен иметь метод encode"
         finally:
             # Восстанавливаем
             tokenizer_module._encoding = original_encoding
-    
+
     def test_caches_encoding(self):
         """
         Что он делает: Проверяет, что encoding кэшируется.
         Цель: Убедиться в ленивой инициализации.
         """
         print("Тест: Кэширование encoding...")
-        
+
         encoding1 = _get_encoding()
         encoding2 = _get_encoding()
-        
+
         print(f"Encoding 1: {encoding1}")
         print(f"Encoding 2: {encoding2}")
-        
+
         # Должен вернуть тот же объект
         assert encoding1 is encoding2, "Encoding должен кэшироваться"
-    
+
     def test_handles_import_error(self):
         """
         Что он делает: Проверяет обработку ImportError при отсутствии tiktoken.
         Цель: Убедиться, что система работает без tiktoken.
         """
         print("Тест: ImportError...")
-        
+
         import kiro.tokenizer as tokenizer_module
+
         original_encoding = tokenizer_module._encoding
         tokenizer_module._encoding = None
-        
+
         try:
             # Мокируем import tiktoken чтобы выбросить ImportError
-            with patch.dict('sys.modules', {'tiktoken': None}):
-                with patch('builtins.__import__', side_effect=ImportError("No module named 'tiktoken'")):
+            with patch.dict("sys.modules", {"tiktoken": None}):
+                with patch(
+                    "builtins.__import__",
+                    side_effect=ImportError("No module named 'tiktoken'"),
+                ):
                     # Сбрасываем кэш
                     tokenizer_module._encoding = None
-                    
+
                     # Должен вернуть None и не упасть
                     # Примечание: из-за кэширования этот тест может не работать идеально
                     # но главное - проверить что код не падает
@@ -783,21 +803,24 @@ class TestGetEncoding:
 
 class TestTokenizerIntegration:
     """Интеграционные тесты для токенизатора."""
-    
+
     def test_realistic_chat_request(self):
         """
         Что он делает: Проверяет подсчёт токенов для реалистичного chat запроса.
         Цель: Убедиться в корректной работе на реальных данных.
         """
         print("Тест: Реалистичный chat запрос...")
-        
+
         messages = [
-            {"role": "system", "content": "You are a helpful AI assistant. Be concise and accurate."},
+            {
+                "role": "system",
+                "content": "You are a helpful AI assistant. Be concise and accurate.",
+            },
             {"role": "user", "content": "What is the capital of France?"},
             {"role": "assistant", "content": "The capital of France is Paris."},
-            {"role": "user", "content": "What is its population?"}
+            {"role": "user", "content": "What is its population?"},
         ]
-        
+
         tools = [
             {
                 "type": "function",
@@ -809,51 +832,51 @@ class TestTokenizerIntegration:
                         "properties": {
                             "query": {"type": "string", "description": "Search query"}
                         },
-                        "required": ["query"]
-                    }
-                }
+                        "required": ["query"],
+                    },
+                },
             }
         ]
-        
+
         result = estimate_request_tokens(messages, tools=tools)
         print(f"Результат: {result}")
-        
+
         # Проверяем разумность значений
         assert result["messages_tokens"] > 50, "Сообщения должны иметь > 50 токенов"
         assert result["tools_tokens"] > 20, "Tools должны иметь > 20 токенов"
         assert result["total_tokens"] > 70, "Total должен быть > 70 токенов"
-    
+
     def test_large_context(self):
         """
         Что он делает: Проверяет подсчёт токенов для большого контекста.
         Цель: Убедиться в производительности на больших данных.
         """
         print("Тест: Большой контекст...")
-        
+
         # Создаём большой текст
         large_text = "This is a test sentence. " * 1000  # ~5000 слов
-        
+
         messages = [{"role": "user", "content": large_text}]
-        
+
         result = estimate_request_tokens(messages)
         print(f"Токенов в большом тексте: {result['total_tokens']}")
-        
+
         # Должно быть много токенов
-        assert result["total_tokens"] > 1000, "Большой текст должен иметь > 1000 токенов"
-    
+        assert result["total_tokens"] > 1000, (
+            "Большой текст должен иметь > 1000 токенов"
+        )
+
     def test_consistency_across_calls(self):
         """
         Что он делает: Проверяет консистентность подсчёта при повторных вызовах.
         Цель: Убедиться, что результаты детерминированы.
         """
         print("Тест: Консистентность...")
-        
+
         text = "This is a test for consistency checking"
-        
+
         results = [count_tokens(text) for _ in range(5)]
         print(f"Результаты: {results}")
-        
+
         # Все результаты должны быть одинаковыми
         assert len(set(results)) == 1, "Результаты должны быть консистентными"
-    
-    


### PR DESCRIPTION
### Summary
This PR addresses critical API changes regarding the host migration from `codewhisperer` to `q` endpoints and updates client signatures to match the latest Kiro IDE version.

### Changes
- **Host Migration**: Updated `KIRO_API_HOST_TEMPLATE` and `KIRO_Q_HOST_TEMPLATE` in `kiro/config.py` to point to `q.{region}.amazonaws.com` instead of the legacy `codewhisperer` endpoints, based on recent traffic inspection.
- **User-Agent Update**: Updated headers in `kiro/utils.py` to mimic Kiro IDE version `0.8.86` (latest).
- **Code Quality**: Applied `ruff` formatting and linting across the codebase. **Note:** This accounts for the larger number of file changes/diffs; these are purely stylistic and code quality improvements.

### Reasoning
The upstream API appears to have migrated its backend services. Using the old endpoints results in reliability issues. Updating the headers ensures better compatibility. The formatting changes ensure the codebase remains clean and consistent.

### CLA
I have read the CLA and I accept its terms