### PR TITLE
feat: add Cursor compatibility and improve tool_results handling

### DIFF
--- a/kiro/models_openai.py
+++ b/kiro/models_openai.py
@@ -102,12 +102,27 @@ class Tool(BaseModel):
     """
     Tool in OpenAI format.
     
+    Supports two formats:
+    1. Standard OpenAI format: {"type": "function", "function": {...}}
+    2. Flat format (Cursor-style): {"name": "...", "description": "...", "input_schema": {...}}
+    
     Attributes:
         type: Tool type (usually "function")
-        function: Function description
+        function: Function description (standard format)
+        name: Function name (flat format)
+        description: Function description (flat format)
+        input_schema: Function parameters (flat format)
     """
+    # Standard OpenAI format fields
     type: str = "function"
-    function: ToolFunction
+    function: Optional[ToolFunction] = None
+    
+    # Flat format fields (Cursor-style)
+    name: Optional[str] = None
+    description: Optional[str] = None
+    input_schema: Optional[Dict[str, Any]] = None
+    
+    model_config = {"extra": "allow"}
 
 
 class ChatCompletionRequest(BaseModel):

--- a/tests/unit/test_converters_openai.py
+++ b/tests/unit/test_converters_openai.py
@@ -459,6 +459,74 @@ class TestConvertOpenAIToolsToUnified:
         assert result[0].name == "tool1"
         assert result[1].name == "tool2"
         assert result[2].name == "tool3"
+    
+    def test_converts_flat_format_tool(self):
+        """
+        What it does: Verifies conversion of flat format tool (Cursor-style).
+        Purpose: Ensure flat format tools are converted correctly.
+        """
+        print("Setup: Flat format tool (Cursor-style)...")
+        tools = [Tool(
+            type="function",
+            name="Shell",
+            description="Executes a shell command",
+            input_schema={"type": "object", "properties": {"command": {"type": "string"}}}
+        )]
+        
+        print("Action: Converting tools...")
+        result = convert_openai_tools_to_unified(tools)
+        
+        print(f"Result: {result}")
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].name == "Shell"
+        assert result[0].description == "Executes a shell command"
+        assert result[0].input_schema == {"type": "object", "properties": {"command": {"type": "string"}}}
+    
+    def test_converts_mixed_format_tools(self):
+        """
+        What it does: Verifies conversion of mixed format tools.
+        Purpose: Ensure both standard and flat format tools work together.
+        """
+        print("Setup: Mixed format tools...")
+        tools = [
+            # Standard OpenAI format
+            Tool(type="function", function=ToolFunction(name="standard_tool", description="Standard", parameters={})),
+            # Flat format (Cursor-style)
+            Tool(type="function", name="flat_tool", description="Flat", input_schema={"type": "object"})
+        ]
+        
+        print("Action: Converting tools...")
+        result = convert_openai_tools_to_unified(tools)
+        
+        print(f"Result: {result}")
+        assert len(result) == 2
+        assert result[0].name == "standard_tool"
+        assert result[1].name == "flat_tool"
+    
+    def test_standard_format_takes_priority(self):
+        """
+        What it does: Verifies that standard format takes priority over flat format.
+        Purpose: Ensure function field is used when both formats are present.
+        """
+        print("Setup: Tool with both formats (edge case)...")
+        tools = [Tool(
+            type="function",
+            function=ToolFunction(name="from_function", description="From function", parameters={}),
+            name="from_flat",
+            description="From flat",
+            input_schema={}
+        )]
+        
+        print("Action: Converting tools...")
+        result = convert_openai_tools_to_unified(tools)
+        
+        print(f"Result: {result}")
+        assert result is not None
+        assert len(result) == 1
+        # Standard format takes priority
+        assert result[0].name == "from_function"
+        assert result[0].description == "From function"
 
 
 # ==================================================================================================

--- a/tests/unit/test_models_openai.py
+++ b/tests/unit/test_models_openai.py
@@ -465,19 +465,44 @@ class TestTool:
         print(f"Comparing type: Expected 'function', Got '{tool.type}'")
         assert tool.type == "function"
     
-    def test_requires_function(self):
+    def test_function_is_optional_for_flat_format(self):
         """
-        What it does: Verifies that function is required.
-        Purpose: Ensure validation fails without function.
+        What it does: Verifies that function is optional (for flat format compatibility).
+        Purpose: Ensure Tool can be created without function field for Cursor-style flat format.
         """
-        print("Setup: Attempting to create Tool without function...")
+        print("Setup: Creating Tool without function (flat format)...")
         
-        print("Action: Creating model (should raise ValidationError)...")
-        with pytest.raises(ValidationError) as exc_info:
-            Tool(type="function")
+        print("Action: Creating model with flat format fields...")
+        tool = Tool(
+            type="function",
+            name="test_tool",
+            description="A test tool",
+            input_schema={"type": "object", "properties": {}}
+        )
         
-        print(f"ValidationError raised: {exc_info.value}")
-        assert "function" in str(exc_info.value)
+        print(f"Tool created: name={tool.name}, description={tool.description}")
+        assert tool.name == "test_tool"
+        assert tool.description == "A test tool"
+        assert tool.function is None
+    
+    def test_standard_format_still_works(self):
+        """
+        What it does: Verifies that standard OpenAI format still works.
+        Purpose: Ensure backward compatibility with standard format.
+        """
+        print("Setup: Creating Tool with standard format...")
+        
+        tool = Tool(
+            type="function",
+            function=ToolFunction(
+                name="standard_tool",
+                description="A standard tool"
+            )
+        )
+        
+        print(f"Tool created: function.name={tool.function.name}")
+        assert tool.function.name == "standard_tool"
+        assert tool.name is None
 
 
 # ==================================================================================================


### PR DESCRIPTION
## PR Description

### Summary
Add Cursor IDE compatibility and improve tool_results handling for better client support.

### Changes

#### 1. Cursor-style Flat Tool Format Support
Cursor IDE sends tools in a flat format instead of the standard OpenAI nested format:

```json
// Standard OpenAI format
{"type": "function", "function": {"name": "...", "description": "...", "parameters": {...}}}

// Cursor flat format (now supported)
{"type": "function", "name": "...", "description": "...", "input_schema": {...}}
```

**Files changed:**
- `kiro/models_openai.py` - Extended `Tool` model to accept both formats
- `kiro/converters_openai.py` - Added conversion logic for flat format

#### 2. Orphaned tool_results Handling Improvement
Previously, when a message contained `tool_results` without a preceding assistant message with `tool_calls`, the tool_results were silently stripped. Now they are converted to text representation and appended to the message content, preserving context for the model.

**Files changed:**
- `kiro/converters_core.py` - Convert orphaned tool_results to text instead of stripping

#### 3. Inverted Model Name Normalization
Added support for inverted model name format used by some clients:

```
claude-4.5-opus-high -> claude-opus-4.5
claude-4.5-sonnet-low -> claude-sonnet-4.5
```

**Files changed:**
- `kiro/model_resolver.py` - Added pattern matching for inverted format

### Testing
- All 392 existing tests pass
- Added new tests for Cursor flat tool format
- Added tests for inverted model name normalization






# Kiro Gateway - Cursor IDE API Compatibility Test Report

**Report Date:** January 21, 2026  
**Gateway Version:** Kiro Gateway (AGPL-3.0)  
**Test Client:** Cursor IDE  
**API Standard:** OpenAI Chat Completions API

---

## Executive Summary

This report evaluates the compatibility between **Kiro Gateway** and **Cursor IDE**'s AI agent functionality. The gateway acts as a proxy that translates OpenAI-compatible API requests to the Kiro (AWS CodeWhisperer) backend, enabling Cursor to use Claude models through the Kiro infrastructure.

| Category | Status | Notes |
|----------|--------|-------|
| **Overall Compatibility** | ✅ **Compatible** | Full support for Cursor's agent mode |
| **Streaming** | ✅ Supported | SSE streaming with `text/event-stream` |
| **Tool Calling** | ✅ Supported | Both OpenAI and Cursor-style formats |
| **Vision/Images** | ✅ Supported | Base64 and URL image formats |
| **Extended Thinking** | ✅ Supported | Automatic injection |

---

## 1. API Endpoint Compatibility

### 1.1 Supported Endpoints

| Endpoint | Method | Cursor Usage | Status |
|----------|--------|--------------|--------|
| `/v1/chat/completions` | POST | Primary agent endpoint | ✅ Fully Supported |
| `/v1/models` | GET | Model listing | ✅ Fully Supported |
| `/health` | GET | Health check | ✅ Supported |
| `/` | GET | Root health check | ✅ Supported |

### 1.2 Authentication

| Method | Status | Notes |
|--------|--------|-------|
| `Authorization: Bearer {key}` | ✅ Supported | Standard OpenAI format |
| `x-api-key` header | ✅ Supported | Anthropic format (alternative) |

---

## 2. Request Format Analysis

### 2.1 Captured Cursor Request Structure

Based on the captured `request_body.json`, Cursor sends requests with the following structure:

{
  "model": "claude-4.5-opus-high",
  "messages": [...],
  "tools": [...],
  "max_tokens": 4096,
  "system": [...],
  "metadata": {"user_id": "..."},
  "tool_choice": {"type": "auto"},
  "stream": true,
  "stream_options": {"include_usage": true}
}



There is still an unresolved problem: when using Cursor, the connection occasionally drops / the stream gets interrupted.
I’m not sure whether this is related to my FRP setup.
Since using the API in Cursor requires forwarding traffic through a public IP, FRP is involved in the network path.
