### PR TITLE
feat(auth): add KIRO_CLI_API_REGION env var for kiro-cli API region override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,11 @@ PROXY_API_KEY="my-super-secret-password-123"
 # AWS region (default: us-east-1)
 # KIRO_REGION="us-east-1"
 
+# API region for kiro-cli (AWS SSO OIDC) authentication (optional)
+# Only set this if kiro-cli uses a different API region than the SSO region
+# Leave empty to use KIRO_REGION for both SSO and API (default behavior)
+# KIRO_CLI_API_REGION="eu-central-1"
+
 # ===========================================
 # SERVER SETTINGS
 # ===========================================

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -133,6 +133,12 @@ PROFILE_ARN: str = os.getenv("PROFILE_ARN", "")
 # AWS region (default us-east-1)
 REGION: str = os.getenv("KIRO_REGION", "us-east-1")
 
+# API region for kiro-cli (AWS SSO OIDC) authentication
+# kiro-cli may use a different API region than the SSO region
+# Leave empty to use the same region as KIRO_REGION (default behavior)
+# Only set this if you experience 403 errors with kiro-cli credentials
+KIRO_CLI_API_REGION: str = os.getenv("KIRO_CLI_API_REGION", "")
+
 # Path to credentials file (optional, alternative to .env)
 # Read directly from .env to avoid escape sequence issues on Windows
 # (e.g., \a in path D:\Projects\adolf is interpreted as bell character)


### PR DESCRIPTION
## Summary

Adds support for configuring a separate API region for kiro-cli (AWS SSO OIDC) authentication via the `KIRO_CLI_API_REGION` environment variable.

## Problem

When using kiro-cli credentials (SQLite database), the SSO region (e.g., `us-east-1`) may differ from the API region where the Q service is hosted (e.g., `eu-central-1`). This can result in 403 "User is not authorized" errors.

## Solution

- Added `KIRO_CLI_API_REGION` environment variable to `config.py`
- When set, overrides the API region for kiro-cli auth while preserving the SSO region for token refresh
- By default (empty), uses `KIRO_REGION` for both SSO and API (no behavior change)

## Usage

```bash
# Only needed if experiencing 403 errors with kiro-cli credentials
KIRO_CLI_API_REGION="eu-central-1"
```

## Changes

- `kiro/config.py`: Added `KIRO_CLI_API_REGION` config
- `kiro/auth.py`: Updated `_detect_auth_type()` to apply region override when set
- `.env.example`: Documented the new option