### PR TITLE
fix(docker): remove :ro from kiro-cli SQLite volume mount

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,7 +197,7 @@ docker run -d \
 # Mount kiro-cli database
 docker run -d \
   -p 8000:8000 \
-  -v ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro \
+  -v ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli \
   -e KIRO_CLI_DB_FILE=/home/kiro/.local/share/kiro-cli/data.sqlite3 \
   -e PROXY_API_KEY="your-secret-key" \
   --name kiro-gateway \

--- a/README.md
+++ b/README.md
@@ -340,8 +340,8 @@ volumes:
   # - ${USERPROFILE}/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro  # Windows
   
   # kiro-cli database (choose your OS)
-  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro  # Linux/macOS
-  # - ${USERPROFILE}/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro  # Windows
+  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Linux/macOS
+  # - ${USERPROFILE}/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Windows
   
   # Debug logs (optional)
   - ./debug_logs:/app/debug_logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       
       # Mount kiro-cli database (if using KIRO_CLI_DB_FILE)
       # Uncomment and adjust path as needed:
-      # - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro
+      # - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli
       
       # Mount debug logs directory (optional, for debugging)
       - ./debug_logs:/app/debug_logs

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -340,8 +340,8 @@ volumes:
   # - ${USERPROFILE}/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro  # Windows
   
   # Base de datos kiro-cli (elige tu SO)
-  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro  # Linux/macOS
-  # - ${USERPROFILE}/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro  # Windows
+  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Linux/macOS
+  # - ${USERPROFILE}/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Windows
   
   # Logs de depuración (opcional)
   - ./debug_logs:/app/debug_logs

--- a/docs/id/README.md
+++ b/docs/id/README.md
@@ -340,8 +340,8 @@ volumes:
   # - ${USERPROFILE}/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro  # Windows
   
   # Database kiro-cli (pilih OS Anda)
-  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro  # Linux/macOS
-  # - ${USERPROFILE}/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro  # Windows
+  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Linux/macOS
+  # - ${USERPROFILE}/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Windows
   
   # Debug logs (opsional)
   - ./debug_logs:/app/debug_logs

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -340,8 +340,8 @@ volumes:
   # - ${USERPROFILE}/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro  # Windows
   
   # kiro-cli データベース（OS を選択）
-  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro  # Linux/macOS
-  # - ${USERPROFILE}/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro  # Windows
+  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Linux/macOS
+  # - ${USERPROFILE}/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Windows
   
   # デバッグログ（オプション）
   - ./debug_logs:/app/debug_logs

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -340,8 +340,8 @@ volumes:
   # - ${USERPROFILE}/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro  # Windows
   
   # kiro-cli 데이터베이스 (OS 선택)
-  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro  # Linux/macOS
-  # - ${USERPROFILE}/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro  # Windows
+  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Linux/macOS
+  # - ${USERPROFILE}/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Windows
   
   # 디버그 로그 (선택 사항)
   - ./debug_logs:/app/debug_logs

--- a/docs/pt/README.md
+++ b/docs/pt/README.md
@@ -340,8 +340,8 @@ volumes:
   # - ${USERPROFILE}/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro  # Windows
   
   # Banco de dados kiro-cli (escolha seu SO)
-  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro  # Linux/macOS
-  # - ${USERPROFILE}/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro  # Windows
+  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Linux/macOS
+  # - ${USERPROFILE}/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Windows
   
   # Logs de depuração (opcional)
   - ./debug_logs:/app/debug_logs

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -340,8 +340,8 @@ volumes:
   # - ${USERPROFILE}/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro  # Windows
   
   # База данных kiro-cli (выберите вашу ОС)
-  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro  # Linux/macOS
-  # - ${USERPROFILE}/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro  # Windows
+  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Linux/macOS
+  # - ${USERPROFILE}/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Windows
   
   # Логи отладки (опционально)
   - ./debug_logs:/app/debug_logs

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -340,8 +340,8 @@ volumes:
   # - ${USERPROFILE}/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro  # Windows
   
   # kiro-cli 数据库（选择您的操作系统）
-  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro  # Linux/macOS
-  # - ${USERPROFILE}/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro  # Windows
+  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Linux/macOS
+  # - ${USERPROFILE}/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Windows
   
   # 调试日志（可选）
   - ./debug_logs:/app/debug_logs


### PR DESCRIPTION
## Summary

Fixes #78

The kiro-cli SQLite database volume is documented as `:ro` (read-only), but `auth.py` writes refreshed tokens back to it via `_save_credentials_to_sqlite()`. This causes silent failures:

```
SQLite error saving credentials: attempt to write a readonly database
```

After container restart, stale tokens are loaded → authentication failures → downstream `Connection error` / `HTTP 504`.

## Changes

Removed `:ro` from kiro-cli SQLite volume mount in:
- `docker-compose.yml`
- `README.md`
- `AGENTS.md`
- All translated docs (`docs/ja/`, `docs/ru/`, `docs/pt/`, `docs/zh/`, `docs/ko/`, `docs/id/`, `docs/es/`)

> `~/.aws/sso/cache` mounts remain `:ro` — the gateway only reads from those.

## Test

- No code changes, documentation-only fix
- Verified locally: container starts with rw mount, `_save_credentials_to_sqlite()` succeeds without errors