### PR TITLE
fix(auth): guarantee SQLite connections are closed via try/finally

### DIFF
--- a/kiro/auth.py
+++ b/kiro/auth.py
@@ -223,78 +223,80 @@ class KiroAuthManager:
             if not path.exists():
                 logger.warning(f"SQLite database not found: {db_path}")
                 return
-            
+
             conn = sqlite3.connect(str(path))
-            cursor = conn.cursor()
-            
-            # Try all possible token keys in priority order
-            token_row = None
-            for key in SQLITE_TOKEN_KEYS:
-                cursor.execute("SELECT value FROM auth_kv WHERE key = ?", (key,))
-                token_row = cursor.fetchone()
+            try:
+                cursor = conn.cursor()
+
+                # Try all possible token keys in priority order
+                token_row = None
+                for key in SQLITE_TOKEN_KEYS:
+                    cursor.execute("SELECT value FROM auth_kv WHERE key = ?", (key,))
+                    token_row = cursor.fetchone()
+                    if token_row:
+                        self._sqlite_token_key = key  # Remember which key we loaded from
+                        logger.debug(f"Loaded credentials from SQLite key: {key}")
+                        break
+
                 if token_row:
-                    self._sqlite_token_key = key  # Remember which key we loaded from
-                    logger.debug(f"Loaded credentials from SQLite key: {key}")
-                    break
-            
-            if token_row:
-                token_data = json.loads(token_row[0])
-                if token_data:
-                    # Load token fields (using snake_case as in Rust struct)
-                    if 'access_token' in token_data:
-                        self._access_token = token_data['access_token']
-                    if 'refresh_token' in token_data:
-                        self._refresh_token = token_data['refresh_token']
-                    if 'profile_arn' in token_data:
-                        self._profile_arn = token_data['profile_arn']
-                    if 'region' in token_data:
-                        # Store SSO region for OIDC token refresh only
-                        # IMPORTANT: CodeWhisperer API is only available in us-east-1,
-                        # so we don't update _api_host and _q_host here.
-                        # The SSO region (e.g., ap-southeast-1) is only used for OIDC token refresh.
-                        self._sso_region = token_data['region']
-                        logger.debug(f"SSO region from SQLite: {self._sso_region} (API stays at {self._region})")
-                    
-                    # Load scopes if available
-                    if 'scopes' in token_data:
-                        self._scopes = token_data['scopes']
-                    
-                    # Parse expires_at (RFC3339 format)
-                    if 'expires_at' in token_data:
-                        try:
-                            expires_str = token_data['expires_at']
-                            # Handle various ISO 8601 formats
-                            if expires_str.endswith('Z'):
-                                self._expires_at = datetime.fromisoformat(expires_str.replace('Z', '+00:00'))
-                            else:
-                                self._expires_at = datetime.fromisoformat(expires_str)
-                        except Exception as e:
-                            logger.warning(f"Failed to parse expires_at from SQLite: {e}")
-            
-            # Load device registration (client_id, client_secret) - try all possible keys
-            registration_row = None
-            for key in SQLITE_REGISTRATION_KEYS:
-                cursor.execute("SELECT value FROM auth_kv WHERE key = ?", (key,))
-                registration_row = cursor.fetchone()
+                    token_data = json.loads(token_row[0])
+                    if token_data:
+                        # Load token fields (using snake_case as in Rust struct)
+                        if 'access_token' in token_data:
+                            self._access_token = token_data['access_token']
+                        if 'refresh_token' in token_data:
+                            self._refresh_token = token_data['refresh_token']
+                        if 'profile_arn' in token_data:
+                            self._profile_arn = token_data['profile_arn']
+                        if 'region' in token_data:
+                            # Store SSO region for OIDC token refresh only
+                            # IMPORTANT: CodeWhisperer API is only available in us-east-1,
+                            # so we don't update _api_host and _q_host here.
+                            # The SSO region (e.g., ap-southeast-1) is only used for OIDC token refresh.
+                            self._sso_region = token_data['region']
+                            logger.debug(f"SSO region from SQLite: {self._sso_region} (API stays at {self._region})")
+
+                        # Load scopes if available
+                        if 'scopes' in token_data:
+                            self._scopes = token_data['scopes']
+
+                        # Parse expires_at (RFC3339 format)
+                        if 'expires_at' in token_data:
+                            try:
+                                expires_str = token_data['expires_at']
+                                # Handle various ISO 8601 formats
+                                if expires_str.endswith('Z'):
+                                    self._expires_at = datetime.fromisoformat(expires_str.replace('Z', '+00:00'))
+                                else:
+                                    self._expires_at = datetime.fromisoformat(expires_str)
+                            except Exception as e:
+                                logger.warning(f"Failed to parse expires_at from SQLite: {e}")
+
+                # Load device registration (client_id, client_secret) - try all possible keys
+                registration_row = None
+                for key in SQLITE_REGISTRATION_KEYS:
+                    cursor.execute("SELECT value FROM auth_kv WHERE key = ?", (key,))
+                    registration_row = cursor.fetchone()
+                    if registration_row:
+                        logger.debug(f"Loaded device registration from SQLite key: {key}")
+                        break
+
                 if registration_row:
-                    logger.debug(f"Loaded device registration from SQLite key: {key}")
-                    break
-            
-            if registration_row:
-                registration_data = json.loads(registration_row[0])
-                if registration_data:
-                    if 'client_id' in registration_data:
-                        self._client_id = registration_data['client_id']
-                    if 'client_secret' in registration_data:
-                        self._client_secret = registration_data['client_secret']
-                    # SSO region from registration (fallback if not in token data)
-                    if 'region' in registration_data and not self._sso_region:
-                        self._sso_region = registration_data['region']
-                        logger.debug(f"SSO region from device-registration: {self._sso_region}")
-            
-            conn.close()
+                    registration_data = json.loads(registration_row[0])
+                    if registration_data:
+                        if 'client_id' in registration_data:
+                            self._client_id = registration_data['client_id']
+                        if 'client_secret' in registration_data:
+                            self._client_secret = registration_data['client_secret']
+                        # SSO region from registration (fallback if not in token data)
+                        if 'region' in registration_data and not self._sso_region:
+                            self._sso_region = registration_data['region']
+                            logger.debug(f"SSO region from device-registration: {self._sso_region}")
+            finally:
+                conn.close()
+
             logger.info(f"Credentials loaded from SQLite database: {db_path}")
-            
+
         except sqlite3.Error as e:
             logger.error(f"SQLite error loading credentials: {e}")
         except json.JSONDecodeError as e:
@@ -472,49 +474,49 @@ class KiroAuthManager:
             
             # Use timeout to avoid blocking if database is locked
             conn = sqlite3.connect(str(path), timeout=5.0)
-            cursor = conn.cursor()
-            
-            # Prepare token data matching the structure from _load_credentials_from_sqlite
-            token_data = {
-                "access_token": self._access_token,
-                "refresh_token": self._refresh_token,
-                "expires_at": self._expires_at.isoformat() if self._expires_at else None,
-                "region": self._sso_region or self._region,
-            }
-            if self._scopes:
-                token_data["scopes"] = self._scopes
-            
-            token_json = json.dumps(token_data)
-            
-            # Save back to the same key we loaded from (if known)
-            if self._sqlite_token_key:
-                cursor.execute(
-                    "UPDATE auth_kv SET value = ? WHERE key = ?",
-                    (token_json, self._sqlite_token_key)
-                )
-                if cursor.rowcount > 0:
-                    conn.commit()
-                    conn.close()
-                    logger.debug(f"Credentials saved to SQLite key: {self._sqlite_token_key}")
-                    return
-                else:
-                    logger.warning(f"Failed to update SQLite key: {self._sqlite_token_key}, trying fallback")
-            
-            # Fallback: try all keys (for edge cases where source key is unknown)
-            for key in SQLITE_TOKEN_KEYS:
-                cursor.execute(
-                    "UPDATE auth_kv SET value = ? WHERE key = ?",
-                    (token_json, key)
-                )
-                if cursor.rowcount > 0:
-                    conn.commit()
-                    conn.close()
-                    logger.debug(f"Credentials saved to SQLite key: {key} (fallback)")
-                    return
-            
-            # If we get here, no keys were updated
-            conn.close()
-            logger.warning(f"Failed to save credentials to SQLite: no matching keys found")
+            try:
+                cursor = conn.cursor()
+
+                # Prepare token data matching the structure from _load_credentials_from_sqlite
+                token_data = {
+                    "access_token": self._access_token,
+                    "refresh_token": self._refresh_token,
+                    "expires_at": self._expires_at.isoformat() if self._expires_at else None,
+                    "region": self._sso_region or self._region,
+                }
+                if self._scopes:
+                    token_data["scopes"] = self._scopes
+
+                token_json = json.dumps(token_data)
+
+                # Save back to the same key we loaded from (if known)
+                if self._sqlite_token_key:
+                    cursor.execute(
+                        "UPDATE auth_kv SET value = ? WHERE key = ?",
+                        (token_json, self._sqlite_token_key)
+                    )
+                    if cursor.rowcount > 0:
+                        conn.commit()
+                        logger.debug(f"Credentials saved to SQLite key: {self._sqlite_token_key}")
+                        return
+                    else:
+                        logger.warning(f"Failed to update SQLite key: {self._sqlite_token_key}, trying fallback")
+
+                # Fallback: try all keys (for edge cases where source key is unknown)
+                for key in SQLITE_TOKEN_KEYS:
+                    cursor.execute(
+                        "UPDATE auth_kv SET value = ? WHERE key = ?",
+                        (token_json, key)
+                    )
+                    if cursor.rowcount > 0:
+                        conn.commit()
+                        logger.debug(f"Credentials saved to SQLite key: {key} (fallback)")
+                        return
+
+                # If we get here, no keys were updated
+                logger.warning(f"Failed to save credentials to SQLite: no matching keys found")
+            finally:
+                conn.close()
             
         except sqlite3.Error as e:
             logger.error(f"SQLite error saving credentials: {e}")


### PR DESCRIPTION
## Problem

Both `_load_credentials_from_sqlite` and `_save_credentials_to_sqlite` used manual `conn.close()` calls scattered across multiple code paths. If any exception is raised between `sqlite3.connect()` and the final `close()` — for example a `json.JSONDecodeError` on a malformed row, or any unexpected Python error — the connection is silently leaked for the lifetime of the process.

`_save_credentials_to_sqlite` was especially fragile: it had **three separate** `conn.close()` calls in different `if/return` branches, making it easy to miss a path in a future refactor.

## Fix

Wrap the cursor work in `try/finally` blocks so `conn.close()` is unconditionally executed on every exit path, including exceptions and early returns:

```python
conn = sqlite3.connect(str(path))
try:
    cursor = conn.cursor()
    # ... all work ...
finally:
    conn.close()
```

This removes 2 out of 3 redundant `conn.close()` calls in `_save_credentials_to_sqlite` and makes the resource lifetime explicit and leak-proof.

## Test plan

- [ ] Start gateway with `KIRO_CLI_DB_FILE` pointing to a valid SQLite database — credentials load correctly
- [ ] Token refresh persists to the database as before
- [ ] Simulate a malformed SQLite row (e.g. invalid JSON) — connection closes cleanly, error is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)