### PR TITLE
fix(lifespan): reuse shared HTTP client for startup model fetch

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ Usage:
 Priority: CLI args > Environment variables > Default values
 """
 
+from __future__ import annotations
 import argparse
 import logging
 import sys
@@ -366,8 +367,7 @@ async def lifespan(app: FastAPI):
         list_models_url = f"{app.state.auth_manager.q_host}/ListAvailableModels"
         logger.debug(f"Fetching models from: {list_models_url}")
         
-        async with httpx.AsyncClient(timeout=30) as client:
-            response = await client.get(
+        response = await app.state.http_client.get(
                 list_models_url,
                 headers=headers,
                 params=params


### PR DESCRIPTION
## Problem

The `lifespan` function in `main.py`:

1. Creates `app.state.http_client` — a pooled `httpx.AsyncClient` with carefully configured connection limits and timeouts.
2. Then **immediately** creates a second, separate `httpx.AsyncClient` (via `async with httpx.AsyncClient(timeout=30)`) just to call `/ListAvailableModels` at startup.

```python
# shared client created here ↓
app.state.http_client = httpx.AsyncClient(limits=limits, timeout=timeout, ...)

# ...then a brand-new throwaway client is created for the very next request ↓
async with httpx.AsyncClient(timeout=30) as client:
    response = await client.get(list_models_url, ...)
```

The throwaway client bypasses connection pooling, ignores the VPN proxy environment variables set just above (since it is constructed after `os.environ` is modified but before the env is inherited — this works incidentally, but is fragile), and adds unnecessary overhead.

## Fix

Replace the throwaway client with the shared `app.state.http_client`:

```python
response = await app.state.http_client.get(list_models_url, headers=headers, params=params)
```

This is consistent with how the rest of the application makes HTTP requests and avoids creating a redundant client at startup.

Also adds `from __future__ import annotations` (PEP 563) to enable the `tuple[str, int]` return annotation on `resolve_server_config` on Python < 3.10.

## Test plan

- [ ] Start the gateway — model list loads correctly from Kiro API at startup
- [ ] Start the gateway with `VPN_PROXY_URL` set — proxy is used for the model fetch
- [ ] Start the gateway with an unreachable Kiro API — falls back to `FALLBACK_MODELS` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)