### PR TITLE
fix(anthropic): support deferred tool_reference blocks in tool_result

### DIFF
--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -109,6 +109,7 @@ def extract_text_content(content: Any) -> str:
     Supports multiple content formats used by different APIs:
     - String: "Hello, world!"
     - List of content blocks: [{"type": "text", "text": "Hello"}]
+    - Tool references: {"type": "tool_reference", "tool_name": "Read"}
     - None: empty message
     
     Args:
@@ -138,11 +139,23 @@ def extract_text_content(content: Any) -> str:
                     continue
                 if item.get("type") == "text":
                     text_parts.append(item.get("text", ""))
+                elif item.get("type") == "tool_reference":
+                    tool_name = item.get("tool_name", "")
+                    if tool_name:
+                        text_parts.append(f"[tool_reference: {tool_name}]")
+                    else:
+                        text_parts.append("[tool_reference]")
                 elif "text" in item:
                     text_parts.append(item["text"])
             elif hasattr(item, "text"):
                 # Handle Pydantic models like TextContentBlock
                 text_parts.append(getattr(item, "text", ""))
+            elif getattr(item, "type", None) == "tool_reference":
+                tool_name = getattr(item, "tool_name", "")
+                if tool_name:
+                    text_parts.append(f"[tool_reference: {tool_name}]")
+                else:
+                    text_parts.append("[tool_reference]")
             elif isinstance(item, str):
                 text_parts.append(item)
         return "".join(text_parts)

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -83,15 +83,39 @@ class ToolResultContentBlock(BaseModel):
     Tool result content block in Anthropic format.
 
     Represents the result of a tool call, sent by the user.
-    Tool results can contain text, images, or a mix of both.
+    Tool results can contain text, images, tool references, or a mix of them.
     """
 
     type: Literal["tool_result"] = "tool_result"
     tool_use_id: str
     content: Optional[
-        Union[str, List[Union["TextContentBlock", "ImageContentBlock"]]]
+        Union[
+            str,
+            List[
+                Union[
+                    "TextContentBlock",
+                    "ImageContentBlock",
+                    "ToolReferenceContentBlock",
+                    Dict[str, Any],
+                ]
+            ],
+        ]
     ] = None
     is_error: Optional[bool] = None
+
+
+class ToolReferenceContentBlock(BaseModel):
+    """
+    Tool reference content block in Anthropic-compatible format.
+
+    Some clients (for example Claude Code deferred-tools mode) can include
+    tool_reference blocks inside tool_result.content.
+    """
+
+    type: Literal["tool_reference"] = "tool_reference"
+    tool_name: str
+
+    model_config = {"extra": "allow"}
 
 
 # ==================================================================================================
@@ -153,6 +177,7 @@ ContentBlock = Union[
     ImageContentBlock,
     ToolUseContentBlock,
     ToolResultContentBlock,
+    ToolReferenceContentBlock,
 ]
 
 

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -480,6 +480,31 @@ class TestExtractToolResultsFromAnthropicContent:
         print(f"Result: {result}")
         assert result[0]["content"] == "List result"
 
+    def test_handles_tool_reference_list_content_in_tool_result(self):
+        """
+        What it does: Verifies handling of tool_reference list content in tool_result.
+        Purpose: Ensure deferred-tool references are preserved as readable text.
+        """
+        print("Setup: Tool result with tool_reference content...")
+        content = [
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_123",
+                "content": [
+                    {"type": "tool_reference", "tool_name": "Read"},
+                    {"type": "tool_reference", "tool_name": "Glob"},
+                ],
+            }
+        ]
+
+        print("Action: Extracting tool results...")
+        result = extract_tool_results_from_anthropic_content(content)
+
+        print(f"Result: {result}")
+        assert len(result) == 1
+        assert "[tool_reference: Read]" in result[0]["content"]
+        assert "[tool_reference: Glob]" in result[0]["content"]
+
     def test_skips_tool_result_without_tool_use_id(self):
         """
         What it does: Verifies that tool_result without tool_use_id is skipped.

--- a/tests/unit/test_converters_core.py
+++ b/tests/unit/test_converters_core.py
@@ -279,6 +279,26 @@ class TestExtractTextContent:
         print(f"Comparing result: Expected 'Before toolAfter tool', Got '{result}'")
         assert result == "Before toolAfter tool"
 
+    def test_extracts_tool_reference_blocks_as_text_markers(self):
+        """
+        What it does: Verifies tool_reference blocks are converted to readable text markers.
+        Purpose: Ensure deferred-tool references are preserved instead of being dropped.
+        """
+        from kiro.models_anthropic import ToolReferenceContentBlock
+
+        print("Setup: Mixed tool_reference dict and Pydantic blocks...")
+        content = [
+            {"type": "tool_reference", "tool_name": "Read"},
+            ToolReferenceContentBlock(type="tool_reference", tool_name="Glob"),
+        ]
+
+        print("Action: Extracting text...")
+        result = extract_text_content(content)
+
+        print(f"Result: '{result}'")
+        assert "[tool_reference: Read]" in result
+        assert "[tool_reference: Glob]" in result
+
 
 # ==================================================================================================
 # Tests for extract_images_from_content (Issue #30 fix)

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -21,6 +21,7 @@ from kiro.models_anthropic import (
     ThinkingContentBlock,
     ToolUseContentBlock,
     ToolResultContentBlock,
+    ToolReferenceContentBlock,
     # Image models
     Base64ImageSource,
     URLImageSource,
@@ -385,6 +386,19 @@ class TestContentBlockUnion:
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'tool_result', Got '{block.type}'")
         assert block.type == "tool_result"
+
+    def test_accepts_tool_reference_content_block(self):
+        """
+        What it does: Verifies ContentBlock accepts ToolReferenceContentBlock.
+        Purpose: Ensure union supports deferred tool reference blocks.
+        """
+        print("Setup: Creating ToolReferenceContentBlock...")
+        block: ContentBlock = ToolReferenceContentBlock(tool_name="Read")
+
+        print(f"Result: {block}")
+        print(f"Comparing type: Expected 'tool_reference', Got '{block.type}'")
+        assert block.type == "tool_reference"
+        assert block.tool_name == "Read"
 
 
 # ==================================================================================================
@@ -949,6 +963,26 @@ class TestToolResultContentBlock:
         print(f"Comparing content type: Expected list, Got {type(block.content)}")
         assert isinstance(block.content, list)
         assert len(block.content) == 2
+
+    def test_accepts_tool_reference_list_content(self):
+        """
+        What it does: Verifies tool_reference blocks are accepted in tool_result content.
+        Purpose: Ensure deferred-tool format does not fail request validation.
+        """
+        print("Setup: Creating ToolResultContentBlock with tool_reference list...")
+        block = ToolResultContentBlock(
+            tool_use_id="call_1",
+            content=[
+                {"type": "tool_reference", "tool_name": "Read"},
+                {"type": "tool_reference", "tool_name": "Glob"},
+            ],
+        )
+
+        print(f"Comparing content type: Expected list, Got {type(block.content)}")
+        assert isinstance(block.content, list)
+        assert len(block.content) == 2
+        assert block.content[0].type == "tool_reference"
+        assert block.content[0].tool_name == "Read"
     
     def test_is_error_field(self):
         """

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -640,6 +640,52 @@ class TestMessagesToolUse:
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
+    def test_accepts_tool_reference_in_tool_result_content(self, test_client, valid_proxy_api_key):
+        """
+        What it does: Verifies tool_reference blocks in tool_result content are accepted.
+        Purpose: Ensure deferred-tools payloads pass request validation.
+        """
+        print("Action: POST /v1/messages with tool_reference in tool_result...")
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-4-5",
+                "max_tokens": 1024,
+                "messages": [
+                    {"role": "user", "content": "Use deferred tools"},
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "call_456",
+                                "name": "ListMcpResourcesTool",
+                                "input": {}
+                            }
+                        ]
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "call_456",
+                                "cache_control": {"type": "ephemeral"},
+                                "content": [
+                                    {"type": "tool_reference", "tool_name": "Read"},
+                                    {"type": "tool_reference", "tool_name": "Glob"}
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        )
+
+        print(f"Status: {response.status_code}")
+        assert response.status_code != 422
+
 
 # =============================================================================
 # Tests for /v1/messages optional parameters


### PR DESCRIPTION
## Summary
- add `ToolReferenceContentBlock` support in Anthropic models
- allow `tool_result.content` to accept `tool_reference` and unknown content blocks for forward compatibility
- preserve `tool_reference` values during text extraction as readable markers (`[tool_reference: <name>]`)
- add regression tests for models, converters, and route validation

## Problem
Claude Code can send deferred tool references inside `tool_result.content` (for example `{"type":"tool_reference","tool_name":"Read"}`), which caused request validation to fail with HTTP 422.

## Validation
- Unit tests (targeted): 5 passed
- Docker runtime regression: `/v1/messages` payload with `tool_reference` in `tool_result.content` now returns HTTP 200 (no 422)
