### PR TITLE
feat(api): add usage limits endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,9 @@ curl "http://localhost:8000/v1/usage" \
   -H "Authorization: Bearer my-super-secret-password-123"
 ```
 
-The endpoint proxies CodeWhisperer Runtime `GetUsageLimits` and returns the raw upstream JSON.
+The endpoint proxies CodeWhisperer Runtime `GetUsageLimits`, preserves the upstream JSON,
+and adds a derived `usageSummary` block with normalized key fields such as reset time,
+primary quota usage, and free trial usage.
 
 Default query parameters:
 - `origin=AI_EDITOR`

--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Leave `VPN_PROXY_URL` empty (default) if you don't need proxy support.
 | `/` | GET | Health check |
 | `/health` | GET | Detailed health check |
 | `/v1/models` | GET | List available models |
+| `/v1/usage` | GET | Current Kiro plan and usage limits |
 | `/v1/chat/completions` | POST | OpenAI Chat Completions API |
 | `/v1/messages` | POST | Anthropic Messages API |
 
@@ -454,6 +455,30 @@ curl http://localhost:8000/v1/chat/completions \
 ```
 
 > **Note:** Replace `my-super-secret-password-123` with the `PROXY_API_KEY` you set in your `.env` file.
+
+</details>
+
+<details>
+<summary>📊 Check Usage Limits</summary>
+
+```bash
+curl "http://localhost:8000/v1/usage" \
+  -H "Authorization: Bearer my-super-secret-password-123"
+```
+
+The endpoint proxies CodeWhisperer Runtime `GetUsageLimits` and returns the raw upstream JSON.
+
+Default query parameters:
+- `origin=AI_EDITOR`
+- `resource_type=AGENTIC_REQUEST`
+- `is_email_required=true`
+
+Custom example:
+
+```bash
+curl "http://localhost:8000/v1/usage?origin=AI_EDITOR&resource_type=AGENTIC_REQUEST&is_email_required=false" \
+  -H "Authorization: Bearer my-super-secret-password-123"
+```
 
 </details>
 

--- a/docs/en/ARCHITECTURE.md
+++ b/docs/en/ARCHITECTURE.md
@@ -385,6 +385,7 @@ Supports async context manager (`async with`).
 | `/` | GET | Health check (status, message, version) |
 | `/health` | GET | Detailed health check (status, timestamp, version) |
 | `/v1/models` | GET | List of available models (requires API key) |
+| `/v1/usage` | GET | Current Kiro plan and usage limits (requires API key) |
 | `/v1/chat/completions` | POST | Chat completions (requires API key) |
 
 **Authentication:** Bearer token in `Authorization` header
@@ -666,9 +667,17 @@ TOOL_DESCRIPTION_MAX_LENGTH="10000"
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/v1/models` | GET | List of available models |
+| `/v1/usage` | GET | Current Kiro plan and usage limits |
 | `/v1/chat/completions` | POST | Chat completions (streaming/non-streaming) |
 
 **Authentication:** `Authorization: Bearer {PROXY_API_KEY}`
+
+`/v1/usage` proxies CodeWhisperer Runtime `GetUsageLimits` using:
+- `origin=AI_EDITOR` by default
+- `resource_type=AGENTIC_REQUEST` by default
+- `is_email_required=true` by default
+
+The route also accepts those values as query parameters when callers need to override them.
 
 ### 7.3 Anthropic-compatible Endpoints
 

--- a/docs/en/ARCHITECTURE.md
+++ b/docs/en/ARCHITECTURE.md
@@ -679,6 +679,10 @@ TOOL_DESCRIPTION_MAX_LENGTH="10000"
 
 The route also accepts those values as query parameters when callers need to override them.
 
+The gateway preserves the upstream response body and adds a derived `usageSummary`
+block so clients can read normalized reset/free-trial values without parsing the
+nested runtime payload shape.
+
 ### 7.3 Anthropic-compatible Endpoints
 
 | Endpoint | Method | Description |

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -466,7 +466,9 @@ curl "http://localhost:8000/v1/usage" \
   -H "Authorization: Bearer my-super-secret-password-123"
 ```
 
-该端点会代理 CodeWhisperer Runtime 的 `GetUsageLimits`，并原样返回上游 JSON。
+该端点会代理 CodeWhisperer Runtime 的 `GetUsageLimits`，保留上游原始 JSON，
+并额外补充一个 `usageSummary` 摘要字段，方便直接读取重置时间、主额度用量和
+Free trial 用量等关键信息。
 
 默认查询参数：
 - `origin=AI_EDITOR`

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -430,6 +430,7 @@ VPN_PROXY_URL=192.168.1.100:8080
 | `/` | GET | 健康检查 |
 | `/health` | GET | 详细健康检查 |
 | `/v1/models` | GET | 列出可用模型 |
+| `/v1/usage` | GET | 当前 Kiro 套餐与用量限制 |
 | `/v1/chat/completions` | POST | OpenAI Chat Completions API |
 | `/v1/messages` | POST | Anthropic Messages API |
 
@@ -454,6 +455,30 @@ curl http://localhost:8000/v1/chat/completions \
 ```
 
 > **注意：** 将 `my-super-secret-password-123` 替换为您在 `.env` 文件中设置的 `PROXY_API_KEY`。
+
+</details>
+
+<details>
+<summary>📊 查询用量限制</summary>
+
+```bash
+curl "http://localhost:8000/v1/usage" \
+  -H "Authorization: Bearer my-super-secret-password-123"
+```
+
+该端点会代理 CodeWhisperer Runtime 的 `GetUsageLimits`，并原样返回上游 JSON。
+
+默认查询参数：
+- `origin=AI_EDITOR`
+- `resource_type=AGENTIC_REQUEST`
+- `is_email_required=true`
+
+自定义参数示例：
+
+```bash
+curl "http://localhost:8000/v1/usage?origin=AI_EDITOR&resource_type=AGENTIC_REQUEST&is_email_required=false" \
+  -H "Authorization: Bearer my-super-secret-password-123"
+```
 
 </details>
 

--- a/kiro/http_client.py
+++ b/kiro/http_client.py
@@ -31,7 +31,7 @@ with connection pooling for better resource management.
 """
 
 import asyncio
-from typing import Optional
+from typing import Any, Optional
 
 import httpx
 from fastapi import HTTPException
@@ -170,8 +170,9 @@ class KiroHttpClient:
         self,
         method: str,
         url: str,
-        json_data: dict,
-        stream: bool = False
+        json_data: Optional[dict[str, Any]] = None,
+        stream: bool = False,
+        params: Optional[dict[str, Any]] = None,
     ) -> httpx.Response:
         """
         Executes an HTTP request with retry logic.
@@ -188,9 +189,10 @@ class KiroHttpClient:
         Args:
             method: HTTP method (GET, POST, etc.)
             url: Request URL
-            json_data: Request body (JSON)
+            json_data: Optional request body (JSON)
             stream: Use streaming (default False)
-        
+            params: Optional query parameters
+
         Returns:
             httpx.Response with successful response
         
@@ -214,12 +216,24 @@ class KiroHttpClient:
                 if stream:
                     # Prevent CLOSE_WAIT connection leak (issue #38)
                     headers["Connection"] = "close"
-                    req = client.build_request(method, url, json=json_data, headers=headers)
+                    req = client.build_request(
+                        method,
+                        url,
+                        params=params,
+                        json=json_data,
+                        headers=headers,
+                    )
                     logger.debug("Sending request to Kiro API...")
                     response = await client.send(req, stream=True)
                 else:
                     logger.debug("Sending request to Kiro API...")
-                    response = await client.request(method, url, json=json_data, headers=headers)
+                    response = await client.request(
+                        method,
+                        url,
+                        params=params,
+                        json=json_data,
+                        headers=headers,
+                    )
                 
                 # Check status
                 if response.status_code == 200:

--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -23,6 +23,7 @@ FastAPI routes for Kiro Gateway.
 Contains all API endpoints:
 - / and /health: Health check
 - /v1/models: Models list
+- /v1/usage: Current Kiro usage and plan limits
 - /v1/chat/completions: Chat completions
 """
 
@@ -49,6 +50,7 @@ from kiro.model_resolver import ModelResolver
 from kiro.converters_openai import build_kiro_payload
 from kiro.streaming_openai import stream_kiro_to_openai, collect_stream_response, stream_with_first_token_retry
 from kiro.http_client import KiroHttpClient
+from kiro.runtime_usage import fetch_usage_limits
 from kiro.utils import generate_conversation_id
 
 # Import debug_logger
@@ -148,6 +150,48 @@ async def get_models(request: Request):
     ]
     
     return ModelList(data=openai_models)
+
+
+@router.get("/v1/usage", dependencies=[Depends(verify_api_key)])
+async def get_usage(
+    request: Request,
+    origin: str = "AI_EDITOR",
+    resource_type: str = "AGENTIC_REQUEST",
+    is_email_required: bool = True,
+):
+    """
+    Return current Kiro usage and plan limits.
+
+    Args:
+        request: FastAPI Request for accessing app.state
+        origin: Upstream runtime origin query parameter
+        resource_type: Upstream runtime resource type query parameter
+        is_email_required: Whether upstream should include user email
+
+    Returns:
+        Raw JSON payload from CodeWhisperer Runtime GetUsageLimits
+
+    Raises:
+        HTTPException: On authentication, validation, network, or upstream errors
+    """
+    logger.info(
+        "Request to /v1/usage "
+        f"(origin={origin}, resource_type={resource_type}, include_email={is_email_required})"
+    )
+
+    auth_manager: KiroAuthManager = request.app.state.auth_manager
+    shared_client = request.app.state.http_client
+
+    try:
+        return await fetch_usage_limits(
+            auth_manager=auth_manager,
+            shared_client=shared_client,
+            origin=origin,
+            resource_type=resource_type,
+            is_email_required=is_email_required,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post("/v1/chat/completions", dependencies=[Depends(verify_api_key)])

--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -169,7 +169,7 @@ async def get_usage(
         is_email_required: Whether upstream should include user email
 
     Returns:
-        Raw JSON payload from CodeWhisperer Runtime GetUsageLimits
+        Upstream GetUsageLimits payload plus a derived `usageSummary` block
 
     Raises:
         HTTPException: On authentication, validation, network, or upstream errors

--- a/kiro/runtime_usage.py
+++ b/kiro/runtime_usage.py
@@ -1,0 +1,150 @@
+"""
+Usage limit helpers for CodeWhisperer Runtime endpoints.
+
+This module keeps usage/plan retrieval separate from route handlers so
+additional runtime billing endpoints can reuse the same request flow.
+"""
+
+import json
+from typing import Any, Optional
+
+import httpx
+from fastapi import HTTPException
+from loguru import logger
+
+from kiro.auth import AuthType, KiroAuthManager
+from kiro.http_client import KiroHttpClient
+
+DEFAULT_USAGE_ORIGIN = "AI_EDITOR"
+DEFAULT_USAGE_RESOURCE_TYPE = "AGENTIC_REQUEST"
+
+
+def build_usage_limits_params(
+    auth_manager: KiroAuthManager,
+    origin: str = DEFAULT_USAGE_ORIGIN,
+    resource_type: str = DEFAULT_USAGE_RESOURCE_TYPE,
+    is_email_required: bool = True,
+) -> dict[str, str]:
+    """
+    Build query parameters for CodeWhisperer Runtime GetUsageLimits.
+
+    Args:
+        auth_manager: Authentication manager with auth type and optional profile ARN
+        origin: Request origin expected by CodeWhisperer Runtime
+        resource_type: Resource type to query usage for
+        is_email_required: Whether upstream should include user email in the response
+
+    Returns:
+        Query parameters for the `/getUsageLimits` runtime endpoint
+
+    Raises:
+        ValueError: If origin or resource_type is empty
+    """
+    if not origin:
+        raise ValueError("origin must not be empty")
+    if not resource_type:
+        raise ValueError("resource_type must not be empty")
+
+    params = {
+        "origin": origin,
+        "resourceType": resource_type,
+        "isEmailRequired": str(is_email_required).lower(),
+    }
+
+    if auth_manager.auth_type == AuthType.KIRO_DESKTOP and auth_manager.profile_arn:
+        params["profileArn"] = auth_manager.profile_arn
+
+    return params
+
+
+def _extract_usage_error_message(response: httpx.Response) -> str:
+    """
+    Extract a readable error message from an upstream usage response.
+
+    Args:
+        response: HTTP response returned by the runtime API
+
+    Returns:
+        Best-effort human-readable error message
+    """
+    try:
+        payload = response.json()
+    except json.JSONDecodeError:
+        return response.text or "Unknown upstream error"
+
+    if isinstance(payload, dict):
+        if isinstance(payload.get("Output"), dict):
+            nested_message = payload["Output"].get("message")
+            if isinstance(nested_message, str) and nested_message:
+                return nested_message
+
+        for key in ("message", "Message", "detail"):
+            value = payload.get(key)
+            if isinstance(value, str) and value:
+                return value
+
+    return response.text or "Unknown upstream error"
+
+
+async def fetch_usage_limits(
+    auth_manager: KiroAuthManager,
+    shared_client: Optional[httpx.AsyncClient],
+    origin: str = DEFAULT_USAGE_ORIGIN,
+    resource_type: str = DEFAULT_USAGE_RESOURCE_TYPE,
+    is_email_required: bool = True,
+) -> dict[str, Any]:
+    """
+    Fetch current usage limits from CodeWhisperer Runtime.
+
+    Args:
+        auth_manager: Authentication manager for token refresh and profile selection
+        shared_client: Shared HTTP client from app state
+        origin: Request origin expected by upstream
+        resource_type: Usage bucket to query
+        is_email_required: Whether upstream should include user email
+
+    Returns:
+        Parsed upstream JSON response
+
+    Raises:
+        HTTPException: If upstream returns an error or invalid JSON
+        ValueError: If the request parameters are invalid
+    """
+    params = build_usage_limits_params(
+        auth_manager=auth_manager,
+        origin=origin,
+        resource_type=resource_type,
+        is_email_required=is_email_required,
+    )
+    url = f"{auth_manager.q_host}/getUsageLimits"
+
+    logger.info(
+        "Fetching usage limits from CodeWhisperer Runtime "
+        f"(origin={origin}, resource_type={resource_type}, include_email={is_email_required})"
+    )
+
+    async with KiroHttpClient(auth_manager, shared_client=shared_client) as http_client:
+        response = await http_client.request_with_retry(
+            "GET",
+            url,
+            params=params,
+        )
+
+    if response.status_code != 200:
+        error_message = _extract_usage_error_message(response)
+        logger.error(
+            f"GetUsageLimits failed: status={response.status_code}, message={error_message}"
+        )
+        raise HTTPException(
+            status_code=response.status_code,
+            detail=f"Failed to fetch usage limits: {error_message}",
+        )
+
+    try:
+        return response.json()
+    except json.JSONDecodeError as exc:
+        logger.error(f"GetUsageLimits returned invalid JSON: {exc}")
+        raise HTTPException(
+            status_code=502,
+            detail="Kiro usage endpoint returned invalid JSON.",
+        ) from exc

--- a/kiro/runtime_usage.py
+++ b/kiro/runtime_usage.py
@@ -6,6 +6,7 @@ additional runtime billing endpoints can reuse the same request flow.
 """
 
 import json
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 import httpx
@@ -86,6 +87,88 @@ def _extract_usage_error_message(response: httpx.Response) -> str:
     return response.text or "Unknown upstream error"
 
 
+def _format_utc_timestamp(timestamp: Any) -> Optional[str]:
+    """
+    Convert a Unix timestamp into an ISO 8601 UTC string.
+
+    Args:
+        timestamp: Unix timestamp in seconds
+
+    Returns:
+        ISO 8601 UTC string, or None when the value is missing/invalid
+    """
+    if not isinstance(timestamp, (int, float)) or isinstance(timestamp, bool):
+        return None
+
+    dt = datetime.fromtimestamp(float(timestamp), tz=timezone.utc)
+    timespec = "seconds" if float(timestamp).is_integer() else "milliseconds"
+    return dt.isoformat(timespec=timespec).replace("+00:00", "Z")
+
+
+def _find_primary_usage_breakdown(payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    """
+    Select the primary usage breakdown from the upstream payload.
+
+    Args:
+        payload: Parsed upstream usage response
+
+    Returns:
+        Preferred usage breakdown entry, or None if unavailable
+    """
+    breakdown_list = payload.get("usageBreakdownList")
+    if isinstance(breakdown_list, list):
+        dict_items = [item for item in breakdown_list if isinstance(item, dict)]
+        for item in dict_items:
+            if item.get("resourceType") == "CREDIT":
+                return item
+        if dict_items:
+            return dict_items[0]
+
+    breakdown = payload.get("usageBreakdown")
+    if isinstance(breakdown, dict):
+        return breakdown
+
+    return None
+
+
+def build_usage_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    """
+    Build a stable summary block from the upstream usage payload.
+
+    The gateway keeps the original upstream structure intact and adds this
+    derived block so clients can read common usage fields without reverse
+    engineering the nested response shape.
+
+    Args:
+        payload: Raw upstream usage payload
+
+    Returns:
+        Derived usage summary with normalized timestamp fields
+    """
+    primary_breakdown = _find_primary_usage_breakdown(payload)
+    free_trial_info = (
+        primary_breakdown.get("freeTrialInfo")
+        if isinstance(primary_breakdown, dict) and isinstance(primary_breakdown.get("freeTrialInfo"), dict)
+        else {}
+    )
+
+    return {
+        "resetAt": _format_utc_timestamp(
+            primary_breakdown.get("nextDateReset")
+            if isinstance(primary_breakdown, dict)
+            else payload.get("nextDateReset")
+        ),
+        "primaryLimit": primary_breakdown.get("usageLimit") if isinstance(primary_breakdown, dict) else None,
+        "primaryUsed": primary_breakdown.get("currentUsageWithPrecision")
+        if isinstance(primary_breakdown, dict)
+        else None,
+        "primaryUnit": primary_breakdown.get("unit") if isinstance(primary_breakdown, dict) else None,
+        "freeTrialLimit": free_trial_info.get("usageLimit"),
+        "freeTrialUsed": free_trial_info.get("currentUsageWithPrecision"),
+        "freeTrialExpiresAt": _format_utc_timestamp(free_trial_info.get("freeTrialExpiry")),
+    }
+
+
 async def fetch_usage_limits(
     auth_manager: KiroAuthManager,
     shared_client: Optional[httpx.AsyncClient],
@@ -104,7 +187,7 @@ async def fetch_usage_limits(
         is_email_required: Whether upstream should include user email
 
     Returns:
-        Parsed upstream JSON response
+        Upstream JSON response plus a derived `usageSummary` block
 
     Raises:
         HTTPException: If upstream returns an error or invalid JSON
@@ -141,10 +224,20 @@ async def fetch_usage_limits(
         )
 
     try:
-        return response.json()
+        payload = response.json()
     except json.JSONDecodeError as exc:
         logger.error(f"GetUsageLimits returned invalid JSON: {exc}")
         raise HTTPException(
             status_code=502,
             detail="Kiro usage endpoint returned invalid JSON.",
         ) from exc
+
+    if not isinstance(payload, dict):
+        logger.error(f"GetUsageLimits returned unexpected JSON type: {type(payload).__name__}")
+        raise HTTPException(
+            status_code=502,
+            detail="Kiro usage endpoint returned an unexpected JSON structure.",
+        )
+
+    payload["usageSummary"] = build_usage_summary(payload)
+    return payload

--- a/tests/integration/test_full_flow.py
+++ b/tests/integration/test_full_flow.py
@@ -324,6 +324,15 @@ class TestUsageEndpointIntegration:
         mock_fetch_usage_limits.return_value = {
             "subscriptionInfo": {"subscriptionTitle": "KIRO PRO"},
             "usageBreakdownList": [{"usageLimit": 1000}],
+            "usageSummary": {
+                "resetAt": "2026-04-01T00:00:00Z",
+                "primaryLimit": 1000,
+                "primaryUsed": 0.0,
+                "primaryUnit": "INVOCATIONS",
+                "freeTrialLimit": 500,
+                "freeTrialUsed": 330.11,
+                "freeTrialExpiresAt": "2026-04-11T14:15:32.340Z",
+            },
         }
 
         print("Step 2: Request /v1/usage with valid authorization...")
@@ -335,6 +344,7 @@ class TestUsageEndpointIntegration:
         assert authorized.status_code == 200
         assert authorized.json()["subscriptionInfo"]["subscriptionTitle"] == "KIRO PRO"
         assert authorized.json()["usageBreakdownList"][0]["usageLimit"] == 1000
+        assert authorized.json()["usageSummary"]["freeTrialExpiresAt"] == "2026-04-11T14:15:32.340Z"
         print(f"Usage payload: {authorized.json()}")
 
 

--- a/tests/integration/test_full_flow.py
+++ b/tests/integration/test_full_flow.py
@@ -303,6 +303,41 @@ class TestModelsEndpointIntegration:
         print("Caching works correctly")
 
 
+class TestUsageEndpointIntegration:
+    """Integration tests for /v1/usage endpoint."""
+
+    @patch("kiro.routes_openai.fetch_usage_limits", new_callable=AsyncMock)
+    def test_usage_requires_auth_and_returns_payload(
+        self,
+        mock_fetch_usage_limits,
+        test_client,
+        valid_proxy_api_key,
+    ):
+        """
+        What it does: Checks authentication and successful payload flow for /v1/usage.
+        Goal: Ensure the gateway exposes GetUsageLimits through a protected endpoint.
+        """
+        print("Step 1: Request /v1/usage without authorization...")
+        unauthorized = test_client.get("/v1/usage")
+        assert unauthorized.status_code == 401
+
+        mock_fetch_usage_limits.return_value = {
+            "subscriptionInfo": {"subscriptionTitle": "KIRO PRO"},
+            "usageBreakdownList": [{"usageLimit": 1000}],
+        }
+
+        print("Step 2: Request /v1/usage with valid authorization...")
+        authorized = test_client.get(
+            "/v1/usage",
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
+        )
+
+        assert authorized.status_code == 200
+        assert authorized.json()["subscriptionInfo"]["subscriptionTitle"] == "KIRO PRO"
+        assert authorized.json()["usageBreakdownList"][0]["usageLimit"] == 1000
+        print(f"Usage payload: {authorized.json()}")
+
+
 class TestStreamingFlagHandling:
     """Integration tests for stream flag handling."""
     

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -212,6 +212,51 @@ class TestKiroHttpClientRequestWithRetry:
         print("Verification: Response received...")
         assert response.status_code == 200
         mock_client.request.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_successful_get_request_passes_query_params(self, mock_auth_manager_for_http):
+        """
+        What it does: Verifies GET requests forward query params to httpx.
+        Purpose: Ensure runtime endpoints like getUsageLimits can use request_with_retry.
+        """
+        print("Setup: Creating KiroHttpClient...")
+        http_client = KiroHttpClient(mock_auth_manager_for_http)
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+
+        captured_kwargs = {}
+
+        async def capture_request(method, url, params=None, json=None, headers=None):
+            captured_kwargs["method"] = method
+            captured_kwargs["url"] = url
+            captured_kwargs["params"] = params
+            captured_kwargs["json"] = json
+            captured_kwargs["headers"] = headers
+            return mock_response
+
+        mock_client = AsyncMock()
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(side_effect=capture_request)
+
+        print("Action: Executing GET request with query params...")
+        with patch.object(http_client, '_get_client', return_value=mock_client):
+            with patch('kiro.http_client.get_kiro_headers', return_value={}):
+                response = await http_client.request_with_retry(
+                    "GET",
+                    "https://api.example.com/getUsageLimits",
+                    params={"origin": "AI_EDITOR", "resourceType": "AGENTIC_REQUEST"},
+                )
+
+        print("Verification: Query params passed to request()...")
+        assert response.status_code == 200
+        assert captured_kwargs["method"] == "GET"
+        assert captured_kwargs["url"] == "https://api.example.com/getUsageLimits"
+        assert captured_kwargs["params"] == {
+            "origin": "AI_EDITOR",
+            "resourceType": "AGENTIC_REQUEST",
+        }
+        assert captured_kwargs["json"] is None
     
     @pytest.mark.asyncio
     async def test_403_triggers_token_refresh(self, mock_auth_manager_for_http):
@@ -1046,7 +1091,7 @@ class TestKiroHttpClientConnectionCloseHeader:
         mock_request = Mock()
         captured_headers = {}
         
-        def capture_build_request(method, url, json, headers):
+        def capture_build_request(method, url, params=None, json=None, headers=None):
             captured_headers.update(headers)
             return mock_request
         
@@ -1086,7 +1131,7 @@ class TestKiroHttpClientConnectionCloseHeader:
         
         captured_headers = {}
         
-        async def capture_request(method, url, json, headers):
+        async def capture_request(method, url, params=None, json=None, headers=None):
             captured_headers.update(headers)
             return mock_response
         
@@ -1124,7 +1169,7 @@ class TestKiroHttpClientConnectionCloseHeader:
         mock_request = Mock()
         captured_headers = {}
         
-        def capture_build_request(method, url, json, headers):
+        def capture_build_request(method, url, params=None, json=None, headers=None):
             captured_headers.update(headers)
             return mock_request
         
@@ -1156,3 +1201,45 @@ class TestKiroHttpClientConnectionCloseHeader:
         assert captured_headers["X-Custom-Header"] == "custom_value"
         assert captured_headers["Connection"] == "close"
         assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_streaming_request_passes_query_params_to_build_request(self, mock_auth_manager_for_http):
+        """
+        What it does: Verifies streaming requests pass query params to build_request.
+        Purpose: Ensure query-based streaming endpoints remain supported.
+        """
+        print("Setup: Creating KiroHttpClient...")
+        http_client = KiroHttpClient(mock_auth_manager_for_http)
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+
+        mock_request = Mock()
+        captured_params = {}
+
+        def capture_build_request(method, url, params=None, json=None, headers=None):
+            captured_params["method"] = method
+            captured_params["url"] = url
+            captured_params["params"] = params
+            return mock_request
+
+        mock_client = AsyncMock()
+        mock_client.is_closed = False
+        mock_client.build_request = Mock(side_effect=capture_build_request)
+        mock_client.send = AsyncMock(return_value=mock_response)
+
+        print("Action: Executing streaming GET request with query params...")
+        with patch.object(http_client, '_get_client', return_value=mock_client):
+            with patch('kiro.http_client.get_kiro_headers', return_value={"Authorization": "Bearer test"}):
+                response = await http_client.request_with_retry(
+                    "GET",
+                    "https://api.example.com/stream",
+                    params={"cursor": "abc123"},
+                    stream=True,
+                )
+
+        print("Verification: Query params passed to build_request()...")
+        assert response.status_code == 200
+        assert captured_params["method"] == "GET"
+        assert captured_params["url"] == "https://api.example.com/stream"
+        assert captured_params["params"] == {"cursor": "abc123"}

--- a/tests/unit/test_routes_openai.py
+++ b/tests/unit/test_routes_openai.py
@@ -413,6 +413,15 @@ class TestUsageEndpoint:
         mock_fetch_usage_limits.return_value = {
             "subscriptionInfo": {"subscriptionTitle": "KIRO PRO"},
             "usageBreakdownList": [],
+            "usageSummary": {
+                "resetAt": "2026-04-01T00:00:00Z",
+                "primaryLimit": 1000,
+                "primaryUsed": 0.0,
+                "primaryUnit": "INVOCATIONS",
+                "freeTrialLimit": 500,
+                "freeTrialUsed": 330.11,
+                "freeTrialExpiresAt": "2026-04-11T14:15:32.340Z",
+            },
         }
 
         print("Action: GET /v1/usage with valid auth...")
@@ -424,6 +433,8 @@ class TestUsageEndpoint:
         print(f"Response: {response.json()}")
         assert response.status_code == 200
         assert response.json()["subscriptionInfo"]["subscriptionTitle"] == "KIRO PRO"
+        assert response.json()["usageSummary"]["primaryLimit"] == 1000
+        assert response.json()["usageSummary"]["freeTrialUsed"] == 330.11
         mock_fetch_usage_limits.assert_awaited_once()
 
     @patch("kiro.routes_openai.fetch_usage_limits", new_callable=AsyncMock)

--- a/tests/unit/test_routes_openai.py
+++ b/tests/unit/test_routes_openai.py
@@ -8,6 +8,7 @@ Tests the following endpoints:
 - GET / - Root endpoint
 - GET /health - Health check
 - GET /v1/models - List available models
+- GET /v1/usage - Current Kiro usage and plan limits
 - POST /v1/chat/completions - Chat completions
 
 For Anthropic API tests, see test_routes_anthropic.py.
@@ -378,6 +379,106 @@ class TestModelsEndpoint:
         
         for model in response.json()["data"]:
             assert model["owned_by"] == "anthropic"
+
+
+# =============================================================================
+# Tests for usage endpoint (/v1/usage)
+# =============================================================================
+
+class TestUsageEndpoint:
+    """Tests for the GET /v1/usage endpoint."""
+
+    def test_usage_requires_authentication(self, test_client):
+        """
+        What it does: Verifies usage endpoint requires authentication.
+        Purpose: Ensure usage data is protected.
+        """
+        print("Action: GET /v1/usage without auth...")
+        response = test_client.get("/v1/usage")
+
+        print(f"Response: {response.status_code} {response.json()}")
+        assert response.status_code == 401
+
+    @patch("kiro.routes_openai.fetch_usage_limits", new_callable=AsyncMock)
+    def test_usage_returns_service_payload(
+        self,
+        mock_fetch_usage_limits,
+        test_client,
+        valid_proxy_api_key,
+    ):
+        """
+        What it does: Verifies usage endpoint returns service payload unchanged.
+        Purpose: Preserve upstream GetUsageLimits shape.
+        """
+        mock_fetch_usage_limits.return_value = {
+            "subscriptionInfo": {"subscriptionTitle": "KIRO PRO"},
+            "usageBreakdownList": [],
+        }
+
+        print("Action: GET /v1/usage with valid auth...")
+        response = test_client.get(
+            "/v1/usage",
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
+        )
+
+        print(f"Response: {response.json()}")
+        assert response.status_code == 200
+        assert response.json()["subscriptionInfo"]["subscriptionTitle"] == "KIRO PRO"
+        mock_fetch_usage_limits.assert_awaited_once()
+
+    @patch("kiro.routes_openai.fetch_usage_limits", new_callable=AsyncMock)
+    def test_usage_forwards_query_parameters(
+        self,
+        mock_fetch_usage_limits,
+        test_client,
+        valid_proxy_api_key,
+    ):
+        """
+        What it does: Verifies route forwards query parameters to usage service.
+        Purpose: Keep usage endpoint configurable without duplicating service logic.
+        """
+        mock_fetch_usage_limits.return_value = {"usageBreakdownList": []}
+
+        print("Action: GET /v1/usage with custom query params...")
+        response = test_client.get(
+            "/v1/usage",
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
+            params={
+                "origin": "CUSTOM_ORIGIN",
+                "resource_type": "CUSTOM_RESOURCE",
+                "is_email_required": "false",
+            },
+        )
+
+        print(f"Response: {response.json()}")
+        assert response.status_code == 200
+        _, kwargs = mock_fetch_usage_limits.await_args
+        assert kwargs["origin"] == "CUSTOM_ORIGIN"
+        assert kwargs["resource_type"] == "CUSTOM_RESOURCE"
+        assert kwargs["is_email_required"] is False
+
+    @patch("kiro.routes_openai.fetch_usage_limits", new_callable=AsyncMock)
+    def test_usage_returns_400_for_invalid_arguments(
+        self,
+        mock_fetch_usage_limits,
+        test_client,
+        valid_proxy_api_key,
+    ):
+        """
+        What it does: Verifies route converts ValueError into HTTP 400.
+        Purpose: Return user-friendly validation errors for usage endpoint input.
+        """
+        mock_fetch_usage_limits.side_effect = ValueError("origin must not be empty")
+
+        print("Action: GET /v1/usage with service ValueError...")
+        response = test_client.get(
+            "/v1/usage",
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
+        )
+
+        print(f"Response: {response.status_code} {response.json()}")
+        assert response.status_code == 400
+        assert response.json()["detail"] == "origin must not be empty"
 
 
 # =============================================================================
@@ -813,6 +914,17 @@ class TestRouterIntegration:
         
         print(f"Found routes: {routes}")
         assert "/v1/models" in routes
+
+    def test_router_has_usage_endpoint(self):
+        """
+        What it does: Verifies usage endpoint is registered.
+        Purpose: Ensure endpoint is available.
+        """
+        print("Checking: Router endpoints...")
+        routes = [route.path for route in router.routes]
+
+        print(f"Found routes: {routes}")
+        assert "/v1/usage" in routes
     
     def test_router_has_chat_completions_endpoint(self):
         """
@@ -863,6 +975,19 @@ class TestRouterIntegration:
                 assert "GET" in route.methods
                 return
         pytest.fail("Models endpoint not found")
+
+    def test_usage_endpoint_uses_get_method(self):
+        """
+        What it does: Verifies usage endpoint uses GET method.
+        Purpose: Ensure correct HTTP method.
+        """
+        print("Checking: HTTP methods...")
+        for route in router.routes:
+            if route.path == "/v1/usage":
+                print(f"Route /v1/usage methods: {route.methods}")
+                assert "GET" in route.methods
+                return
+        pytest.fail("Usage endpoint not found")
     
     def test_chat_completions_endpoint_uses_post_method(self):
         """

--- a/tests/unit/test_runtime_usage.py
+++ b/tests/unit/test_runtime_usage.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+
+"""
+Unit tests for runtime usage helpers.
+"""
+
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from kiro.auth import AuthType
+from kiro.runtime_usage import build_usage_limits_params, fetch_usage_limits
+
+
+@pytest.fixture
+def mock_usage_auth_manager():
+    """Create a mocked auth manager for usage helper tests."""
+    manager = Mock()
+    manager.auth_type = AuthType.KIRO_DESKTOP
+    manager.profile_arn = "arn:aws:codewhisperer:us-east-1:123456789012:profile/test"
+    manager.q_host = "https://q.us-east-1.amazonaws.com"
+    return manager
+
+
+class TestBuildUsageLimitsParams:
+    """Tests for usage query parameter construction."""
+
+    def test_includes_profile_arn_for_kiro_desktop(self, mock_usage_auth_manager):
+        """
+        What it does: Verifies desktop auth includes profileArn in query params.
+        Purpose: Ensure GetUsageLimits matches Kiro desktop client behavior.
+        """
+        print("Action: Building params for desktop auth...")
+        params = build_usage_limits_params(mock_usage_auth_manager)
+
+        print(f"Result: {params}")
+        assert params["origin"] == "AI_EDITOR"
+        assert params["resourceType"] == "AGENTIC_REQUEST"
+        assert params["isEmailRequired"] == "true"
+        assert params["profileArn"] == mock_usage_auth_manager.profile_arn
+
+    def test_omits_profile_arn_for_aws_sso(self, mock_usage_auth_manager):
+        """
+        What it does: Verifies AWS SSO auth omits profileArn.
+        Purpose: Avoid sending unsupported profileArn for non-desktop auth.
+        """
+        print("Setup: Switching auth type to AWS SSO OIDC...")
+        mock_usage_auth_manager.auth_type = AuthType.AWS_SSO_OIDC
+
+        print("Action: Building params for AWS SSO auth...")
+        params = build_usage_limits_params(mock_usage_auth_manager)
+
+        print(f"Result: {params}")
+        assert "profileArn" not in params
+
+    def test_empty_origin_raises_value_error(self, mock_usage_auth_manager):
+        """
+        What it does: Verifies empty origin is rejected.
+        Purpose: Ensure invalid query construction fails early.
+        """
+        print("Action: Building params with empty origin...")
+        with pytest.raises(ValueError) as exc_info:
+            build_usage_limits_params(mock_usage_auth_manager, origin="")
+
+        print(f"Error: {exc_info.value}")
+        assert "origin must not be empty" in str(exc_info.value)
+
+
+class TestFetchUsageLimits:
+    """Tests for GetUsageLimits fetching."""
+
+    @pytest.mark.asyncio
+    @patch("kiro.runtime_usage.KiroHttpClient")
+    async def test_returns_usage_payload(self, mock_http_client_class, mock_usage_auth_manager):
+        """
+        What it does: Verifies successful upstream payload is returned unchanged.
+        Purpose: Preserve transparency for usage responses.
+        """
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "subscriptionInfo": {"subscriptionTitle": "KIRO PRO"},
+            "usageBreakdownList": [],
+        }
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.request_with_retry = AsyncMock(return_value=mock_response)
+        mock_http_client_class.return_value = mock_client
+
+        print("Action: Fetching usage limits...")
+        payload = await fetch_usage_limits(
+            auth_manager=mock_usage_auth_manager,
+            shared_client=None,
+        )
+
+        print(f"Result: {payload}")
+        assert payload["subscriptionInfo"]["subscriptionTitle"] == "KIRO PRO"
+        mock_client.request_with_retry.assert_awaited_once_with(
+            "GET",
+            "https://q.us-east-1.amazonaws.com/getUsageLimits",
+            params={
+                "origin": "AI_EDITOR",
+                "resourceType": "AGENTIC_REQUEST",
+                "isEmailRequired": "true",
+                "profileArn": mock_usage_auth_manager.profile_arn,
+            },
+        )
+
+    @pytest.mark.asyncio
+    @patch("kiro.runtime_usage.KiroHttpClient")
+    async def test_upstream_error_raises_http_exception(self, mock_http_client_class, mock_usage_auth_manager):
+        """
+        What it does: Verifies non-200 upstream responses become HTTPException.
+        Purpose: Return actionable route errors to gateway clients.
+        """
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 403
+        mock_response.text = '{"message":"Access denied"}'
+        mock_response.json.return_value = {"message": "Access denied"}
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.request_with_retry = AsyncMock(return_value=mock_response)
+        mock_http_client_class.return_value = mock_client
+
+        print("Action: Fetching usage limits with upstream 403...")
+        with pytest.raises(HTTPException) as exc_info:
+            await fetch_usage_limits(
+                auth_manager=mock_usage_auth_manager,
+                shared_client=None,
+            )
+
+        print(f"Error response: {exc_info.value.detail}")
+        assert exc_info.value.status_code == 403
+        assert "Failed to fetch usage limits" in exc_info.value.detail
+        assert "Access denied" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    @patch("kiro.runtime_usage.KiroHttpClient")
+    async def test_invalid_json_raises_502(self, mock_http_client_class, mock_usage_auth_manager):
+        """
+        What it does: Verifies invalid upstream JSON raises 502.
+        Purpose: Prevent malformed upstream responses from leaking through silently.
+        """
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = json.JSONDecodeError("bad json", "x", 0)
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.request_with_retry = AsyncMock(return_value=mock_response)
+        mock_http_client_class.return_value = mock_client
+
+        print("Action: Fetching usage limits with invalid JSON response...")
+        with pytest.raises(HTTPException) as exc_info:
+            await fetch_usage_limits(
+                auth_manager=mock_usage_auth_manager,
+                shared_client=None,
+            )
+
+        print(f"Error response: {exc_info.value.detail}")
+        assert exc_info.value.status_code == 502
+        assert "invalid JSON" in exc_info.value.detail

--- a/tests/unit/test_runtime_usage.py
+++ b/tests/unit/test_runtime_usage.py
@@ -12,7 +12,11 @@ import pytest
 from fastapi import HTTPException
 
 from kiro.auth import AuthType
-from kiro.runtime_usage import build_usage_limits_params, fetch_usage_limits
+from kiro.runtime_usage import (
+    build_usage_limits_params,
+    build_usage_summary,
+    fetch_usage_limits,
+)
 
 
 @pytest.fixture
@@ -76,14 +80,27 @@ class TestFetchUsageLimits:
     @patch("kiro.runtime_usage.KiroHttpClient")
     async def test_returns_usage_payload(self, mock_http_client_class, mock_usage_auth_manager):
         """
-        What it does: Verifies successful upstream payload is returned unchanged.
-        Purpose: Preserve transparency for usage responses.
+        What it does: Verifies successful upstream payload is returned with a derived summary.
+        Purpose: Preserve transparency while exposing stable usage fields.
         """
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
             "subscriptionInfo": {"subscriptionTitle": "KIRO PRO"},
-            "usageBreakdownList": [],
+            "usageBreakdownList": [
+                {
+                    "resourceType": "CREDIT",
+                    "usageLimit": 1000,
+                    "currentUsageWithPrecision": 0.0,
+                    "unit": "INVOCATIONS",
+                    "nextDateReset": 1775001600.0,
+                    "freeTrialInfo": {
+                        "usageLimit": 500,
+                        "currentUsageWithPrecision": 330.11,
+                        "freeTrialExpiry": 1775916932.34,
+                    },
+                }
+            ],
         }
 
         mock_client = AsyncMock()
@@ -100,6 +117,15 @@ class TestFetchUsageLimits:
 
         print(f"Result: {payload}")
         assert payload["subscriptionInfo"]["subscriptionTitle"] == "KIRO PRO"
+        assert payload["usageSummary"] == {
+            "resetAt": "2026-04-01T00:00:00Z",
+            "primaryLimit": 1000,
+            "primaryUsed": 0.0,
+            "primaryUnit": "INVOCATIONS",
+            "freeTrialLimit": 500,
+            "freeTrialUsed": 330.11,
+            "freeTrialExpiresAt": "2026-04-11T14:15:32.340Z",
+        }
         mock_client.request_with_retry.assert_awaited_once_with(
             "GET",
             "https://q.us-east-1.amazonaws.com/getUsageLimits",
@@ -168,3 +194,63 @@ class TestFetchUsageLimits:
         print(f"Error response: {exc_info.value.detail}")
         assert exc_info.value.status_code == 502
         assert "invalid JSON" in exc_info.value.detail
+
+
+class TestBuildUsageSummary:
+    """Tests for derived usage summary generation."""
+
+    def test_builds_summary_from_usage_breakdown_list(self):
+        """
+        What it does: Verifies the gateway derives stable summary fields.
+        Purpose: Expose the key usage values clients need without losing raw payload data.
+        """
+        payload = {
+            "nextDateReset": 1775001600.0,
+            "usageBreakdownList": [
+                {
+                    "resourceType": "CREDIT",
+                    "usageLimit": 1000,
+                    "currentUsageWithPrecision": 0.0,
+                    "unit": "INVOCATIONS",
+                    "nextDateReset": 1775001600.0,
+                    "freeTrialInfo": {
+                        "usageLimit": 500,
+                        "currentUsageWithPrecision": 330.11,
+                        "freeTrialExpiry": 1775916932.34,
+                    },
+                }
+            ],
+        }
+
+        print("Action: Building usage summary from upstream payload...")
+        summary = build_usage_summary(payload)
+
+        print(f"Summary: {summary}")
+        assert summary == {
+            "resetAt": "2026-04-01T00:00:00Z",
+            "primaryLimit": 1000,
+            "primaryUsed": 0.0,
+            "primaryUnit": "INVOCATIONS",
+            "freeTrialLimit": 500,
+            "freeTrialUsed": 330.11,
+            "freeTrialExpiresAt": "2026-04-11T14:15:32.340Z",
+        }
+
+    def test_handles_missing_breakdown_data(self):
+        """
+        What it does: Verifies missing upstream fields degrade gracefully.
+        Purpose: Keep response shape stable even when upstream omits usage data.
+        """
+        print("Action: Building usage summary from incomplete payload...")
+        summary = build_usage_summary({})
+
+        print(f"Summary: {summary}")
+        assert summary == {
+            "resetAt": None,
+            "primaryLimit": None,
+            "primaryUsed": None,
+            "primaryUnit": None,
+            "freeTrialLimit": None,
+            "freeTrialUsed": None,
+            "freeTrialExpiresAt": None,
+        }


### PR DESCRIPTION
 Description

  ## Summary

  This PR adds a new OpenAI-compatible endpoint, GET /v1/usage, to expose Kiro plan and usage limits through the gateway.

  The route proxies CodeWhisperer Runtime GetUsageLimits and keeps the upstream payload intact. It also adds a derived usageSummary block so clients can read key usage fields
  directly without parsing the nested runtime response shape.

  ## What changed

  - Added GET /v1/usage in kiro/routes_openai.py
  - Added a dedicated runtime usage service in kiro/runtime_usage.py
  - Extended KiroHttpClient.request_with_retry() to support params= for GET requests with query parameters
  - Added a normalized usageSummary block to the usage response
  - Added tests for:
      - query parameter construction
      - upstream request flow
      - route behavior
      - integration flow
  - Updated documentation:
      - README.md
      - docs/en/ARCHITECTURE.md
      - docs/zh/README.md

  ## Endpoint behavior

  GET /v1/usage

  Default query parameters:

  - origin=AI_EDITOR
  - resource_type=AGENTIC_REQUEST
  - is_email_required=true

  For Kiro Desktop auth, the gateway also forwards profileArn when available, matching the desktop client behavior.

  ## Response shape

  The endpoint preserves the upstream JSON and adds:

  {
    "usageSummary": {
      "resetAt": "2026-04-01T00:00:00Z",
      "primaryLimit": 1000,
      "primaryUsed": 0.0,
      "primaryUnit": "INVOCATIONS",
      "freeTrialLimit": 500,
      "freeTrialUsed": 330.11,
      "freeTrialExpiresAt": "2026-04-11T14:15:32.340Z"
    }
  }

  This gives clients stable access to:

  - reset time
  - primary quota limit
  - primary quota used
  - primary unit
  - free trial limit
  - free trial used
  - free trial expiry

  ## Why

  Kiro usage data is available upstream, but the raw payload is nested and awkward for clients to consume directly. This PR keeps the gateway transparent while adding a small,
  explicit summary layer for common usage fields.

  ## Tests

  Validated with:

  pytest tests/unit/test_http_client.py tests/unit/test_runtime_usage.py tests/unit/test_routes_openai.py tests/integration/test_full_flow.py -q

  and later usage-summary-specific coverage with:

  pytest tests/unit/test_runtime_usage.py tests/unit/test_routes_openai.py tests/integration/test_full_flow.py -q

  All passing.

  ## Notes

  - The route is protected by the existing API key authentication
  - Non-200 upstream responses are surfaced as HTTP errors with clearer messages
  - Invalid or unexpected upstream JSON returns a 502