### PR TITLE
feat(models): add tool_reference, server_tool_use, and tool_search_tool_result content blocks

### DIFF
--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -78,20 +78,44 @@ class ToolUseContentBlock(BaseModel):
     input: Dict[str, Any]
 
 
+class ToolReferenceContentBlock(BaseModel):
+    """Tool reference block used by Anthropic's tool search / defer_loading feature."""
+
+    type: Literal["tool_reference"] = "tool_reference"
+    tool_name: str
+    model_config = {"extra": "allow"}
+
+
+class ServerToolUseContentBlock(BaseModel):
+    """Server-side tool use block (e.g., tool_search invocations handled by Anthropic API)."""
+
+    type: Literal["server_tool_use"] = "server_tool_use"
+    model_config = {"extra": "allow"}
+
+
+class ToolSearchResultContentBlock(BaseModel):
+    """Tool search result block returned by Anthropic's tool search feature."""
+
+    type: Literal["tool_search_tool_result"] = "tool_search_tool_result"
+    model_config = {"extra": "allow"}
+
+
 class ToolResultContentBlock(BaseModel):
     """
     Tool result content block in Anthropic format.
 
     Represents the result of a tool call, sent by the user.
-    Tool results can contain text, images, or a mix of both.
+    Tool results can contain text, images, tool references, or a mix.
     """
 
     type: Literal["tool_result"] = "tool_result"
     tool_use_id: str
     content: Optional[
-        Union[str, List[Union["TextContentBlock", "ImageContentBlock"]]]
+        Union[str, List[Union["TextContentBlock", "ImageContentBlock", "ToolReferenceContentBlock"]]]
     ] = None
     is_error: Optional[bool] = None
+
+    model_config = {"extra": "allow"}
 
 
 # ==================================================================================================
@@ -146,13 +170,16 @@ class ImageContentBlock(BaseModel):
     source: Union[Base64ImageSource, URLImageSource]
 
 
-# Union type for all content blocks (including images and thinking)
+# Union type for all content blocks (including images, thinking, and tool search)
 ContentBlock = Union[
     TextContentBlock,
     ThinkingContentBlock,
     ImageContentBlock,
     ToolUseContentBlock,
     ToolResultContentBlock,
+    ToolReferenceContentBlock,
+    ServerToolUseContentBlock,
+    ToolSearchResultContentBlock,
 ]
 
 


### PR DESCRIPTION
## What

Adds Pydantic models for three content block types used by Anthropic's tool search feature, preventing 422 validation errors.

## Why

Claude Code v2.1.69+ with `ENABLE_TOOL_SEARCH=true` sends `tool_reference` blocks inside `tool_result` content. The Anthropic API also returns `server_tool_use` and `tool_search_tool_result` blocks for server-side tool search invocations. Without these models, Pydantic rejects requests with 422 errors.

## Changes

- Add `ToolReferenceContentBlock` model (`type='tool_reference'`)
- Add `ServerToolUseContentBlock` model (`type='server_tool_use'`)
- Add `ToolSearchResultContentBlock` model (`type='tool_search_tool_result'`)
- Add `ToolReferenceContentBlock` to `ToolResultContentBlock.content` union
- Add all three to `ContentBlock` union
- Add `model_config = {"extra": "allow"}` to `ToolResultContentBlock` (for `cache_control` and future fields)

All models use `extra="allow"` for forward compatibility with new fields.

## Related

Overlaps with #90, #96, #82 which address the same 422 issue with different approaches:
- **#90**: Adds `ToolReferenceContentBlock` only (subset of this PR)
- **#96**: Converts `tool_reference` to text markers in `extract_text_content`
- **#82**: Uses `model_validator` to sanitize all unknown blocks to text

This PR takes a typed-model approach covering all three tool search block types, preserving type information for downstream processing.

## Testing

All 1413 existing tests pass. No behavioral changes — only model acceptance is expanded.