### PR TITLE
fix(streaming): wire first-token retry and return correct finish_reason on truncation

### DIFF
--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -330,17 +330,26 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
         tools_for_tokenizer = [tool.model_dump() for tool in request_data.tools] if request_data.tools else None
         
         if request_data.stream:
-            # Streaming mode
+            # Streaming mode with first token retry
+            first_attempt = True
+
+            async def make_retry_request():
+                nonlocal first_attempt
+                if first_attempt:
+                    first_attempt = False
+                    return response  # Reuse already-validated 200 response
+                return await http_client.request_with_retry("POST", url, kiro_payload, stream=True)
+
             async def stream_wrapper():
                 streaming_error = None
                 client_disconnected = False
                 try:
-                    async for chunk in stream_kiro_to_openai(
-                        http_client.client,
-                        response,
-                        request_data.model,
-                        model_cache,
-                        auth_manager,
+                    async for chunk in stream_with_first_token_retry(
+                        make_request=make_retry_request,
+                        client=http_client.client,
+                        model=request_data.model,
+                        model_cache=model_cache,
+                        auth_manager=auth_manager,
                         request_messages=messages_for_tokenizer,
                         request_tools=tools_for_tokenizer
                     ):

--- a/kiro/streaming_anthropic.py
+++ b/kiro/streaming_anthropic.py
@@ -465,7 +465,12 @@ async def stream_kiro_to_anthropic(
             input_tokens = prompt_tokens
         
         # Determine stop reason
-        stop_reason = "tool_use" if tool_blocks else "end_turn"
+        if tool_blocks:
+            stop_reason = "tool_use"
+        elif content_was_truncated:
+            stop_reason = "max_tokens"
+        else:
+            stop_reason = "end_turn"
         
         # Send message_delta with stop_reason and usage
         yield format_sse_event("message_delta", {

--- a/kiro/streaming_openai.py
+++ b/kiro/streaming_openai.py
@@ -220,7 +220,12 @@ async def stream_kiro_to_openai_internal(
             )
         
         # Determine finish_reason
-        finish_reason = "tool_calls" if all_tool_calls else "stop"
+        if all_tool_calls:
+            finish_reason = "tool_calls"
+        elif content_was_truncated:
+            finish_reason = "length"
+        else:
+            finish_reason = "stop"
         
         # Count completion_tokens (output) using tiktoken
         completion_tokens = count_tokens(full_content + full_thinking_content)

--- a/tests/unit/test_streaming_anthropic.py
+++ b/tests/unit/test_streaming_anthropic.py
@@ -360,6 +360,7 @@ class TestStreamKiroToAnthropic:
         
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
+            yield KiroEvent(type="context_usage", context_usage_percentage=5.0)
         
         print("Action: Streaming to Anthropic format...")
         events = []

--- a/tests/unit/test_streaming_openai.py
+++ b/tests/unit/test_streaming_openai.py
@@ -313,6 +313,7 @@ class TestStreamKiroToOpenai:
         
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
+            yield KiroEvent(type="usage", usage={"inputTokenCount": 10, "outputTokenCount": 1})
         
         print("Action: Streaming to OpenAI format...")
         chunks = []


### PR DESCRIPTION
## Summary

Fixes #113 — Two streaming reliability fixes:

1. **Wire `stream_with_first_token_retry` into OpenAI streaming path** — The retry mechanism was implemented but never connected. Now `routes_openai.py` uses it with a closure that reuses the initial validated response on first attempt, only creating new requests on retry.

2. **Return correct finish_reason/stop_reason on truncation** — When Kiro API truncates mid-stream (no completion signals), now returns `finish_reason: "length"` (OpenAI) / `stop_reason: "max_tokens"` (Anthropic) instead of `"stop"` / `"end_turn"`.

## Changes

- **`routes_openai.py`**: Replace `stream_kiro_to_openai` with `stream_with_first_token_retry` in streaming handler. Uses `make_retry_request` closure that reuses the initial 200 response on first attempt.
- **`streaming_openai.py`**: When `content_was_truncated` is true, set `finish_reason = "length"` instead of `"stop"`
- **`streaming_anthropic.py`**: When `content_was_truncated` is true, set `stop_reason = "max_tokens"` instead of `"end_turn"`

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| First token timeout (OpenAI) | Immediate failure, no retry | Up to 3 retries (FIRST_TOKEN_MAX_RETRIES) |
| Kiro API truncation (OpenAI) | `finish_reason: "stop"` | `finish_reason: "length"` |
| Kiro API truncation (Anthropic) | `stop_reason: "end_turn"` | `stop_reason: "max_tokens"` |
| Normal completion | `finish_reason: "stop"` | `finish_reason: "stop"` (unchanged) |

## Testing

Verified locally via Docker:
- Streaming responses complete normally with `finish_reason: "stop"`
- First-token retry mechanism is wired (confirmed via log path `routes_openai:stream_wrapper`)
- Truncation detection logic unchanged — only the reported finish_reason differs