### PR TITLE
fix: credentials file region must not override Kiro API host

### DIFF
--- a/kiro/auth.py
+++ b/kiro/auth.py
@@ -310,7 +310,11 @@ class KiroAuthManager:
         - refreshToken: Refresh token
         - accessToken: Access token (if already available)
         - profileArn: Profile ARN
-        - region: AWS region
+        - region: Auth/SSO region — stored as _sso_region and used only for the auth refresh
+          URL (e.g., https://prod.{region}.auth.desktop.kiro.dev/refreshToken). The Kiro API
+          endpoints (_api_host, _q_host) are controlled exclusively by the KIRO_REGION env var
+          (default: us-east-1) and are NOT updated from this field. This prevents invalid
+          organization login regions (e.g., us-east-2) from breaking API calls.
         - expiresAt: Token expiration time (ISO 8601)
         
         Additional fields for AWS SSO OIDC (kiro-cli):
@@ -342,12 +346,14 @@ class KiroAuthManager:
             if 'profileArn' in data:
                 self._profile_arn = data['profileArn']
             if 'region' in data:
-                self._region = data['region']
-                # Update URLs for new region
-                self._refresh_url = get_kiro_refresh_url(self._region)
-                self._api_host = get_kiro_api_host(self._region)
-                self._q_host = get_kiro_q_host(self._region)
-                logger.info(f"Region updated from credentials file: region={self._region}, api_host={self._api_host}, q_host={self._q_host}")
+                # Store as SSO/auth region only — does NOT override _api_host/_q_host.
+                # See docstring for details on why API host is kept separate.
+                self._sso_region = data['region']
+                self._refresh_url = get_kiro_refresh_url(self._sso_region)
+                logger.info(
+                    f"Auth region from credentials file: sso_region={self._sso_region} "
+                    f"(API stays at region={self._region}, api_host={self._api_host})"
+                )
             
             # Load clientIdHash and device registration for Enterprise Kiro IDE
             if 'clientIdHash' in data:

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -122,6 +122,91 @@ class TestKiroAuthManagerCredentialsFile:
         print(f"Comparing refresh_token: Expected 'fallback_token', Got '{manager._refresh_token}'")
         assert manager._refresh_token == "fallback_token"
 
+    def test_api_host_not_overridden_by_credentials_file_region(self, tmp_path):
+        """
+        What it does: Verifies API host stays at configured region when credentials contain a different region.
+        Purpose: Prevent invalid regions (e.g., us-east-2 from org login) from breaking API calls.
+
+        Regression test for: credentials file with us-east-2 (org login region) causing gateway
+        to send API requests to https://q.us-east-2.amazonaws.com which does not exist.
+        """
+        print("Setup: Creating credentials file with us-east-2 region (org login scenario)...")
+        creds_file = tmp_path / "kiro-auth-token.json"
+        creds_data = {
+            "accessToken": "test_access_token",
+            "refreshToken": "test_refresh_token",
+            "expiresAt": "2099-01-01T00:00:00.000Z",
+            "region": "us-east-2"
+        }
+        creds_file.write_text(json.dumps(creds_data))
+
+        manager = KiroAuthManager(creds_file=str(creds_file), region="us-east-1")
+
+        print("Verification: API region stays at us-east-1...")
+        print(f"Comparing _region: Expected 'us-east-1', Got '{manager._region}'")
+        assert manager._region == "us-east-1"
+
+        print("Verification: api_host points to us-east-1, not us-east-2...")
+        print(f"api_host: {manager._api_host}")
+        assert "us-east-1" in manager._api_host
+        assert "us-east-2" not in manager._api_host
+
+        print("Verification: q_host points to us-east-1, not us-east-2...")
+        print(f"q_host: {manager._q_host}")
+        assert "us-east-1" in manager._q_host
+        assert "us-east-2" not in manager._q_host
+
+        print("Verification: sso_region stores the credentials region...")
+        print(f"Comparing _sso_region: Expected 'us-east-2', Got '{manager._sso_region}'")
+        assert manager._sso_region == "us-east-2"
+
+        print("Verification: refresh_url uses sso_region (us-east-2) with correct format...")
+        print(f"refresh_url: {manager._refresh_url}")
+        expected_refresh_url = "https://prod.us-east-2.auth.desktop.kiro.dev/refreshToken"
+        print(f"Comparing _refresh_url: Expected '{expected_refresh_url}', Got '{manager._refresh_url}'")
+        assert manager._refresh_url == expected_refresh_url
+
+    def test_sso_region_set_from_credentials_file(self, tmp_path):
+        """
+        What it does: Verifies _sso_region is populated from credentials file region field.
+        Purpose: Ensure auth/refresh requests use the correct regional endpoint.
+        """
+        print("Setup: Creating credentials file with eu-central-1 region...")
+        creds_file = tmp_path / "kiro-auth-token.json"
+        creds_data = {
+            "refreshToken": "test_refresh_token",
+            "region": "eu-central-1"
+        }
+        creds_file.write_text(json.dumps(creds_data))
+
+        manager = KiroAuthManager(creds_file=str(creds_file), region="us-east-1")
+
+        print("Verification: _sso_region set to eu-central-1...")
+        print(f"Comparing _sso_region: Expected 'eu-central-1', Got '{manager._sso_region}'")
+        assert manager._sso_region == "eu-central-1"
+
+        print("Verification: API region unchanged...")
+        assert manager._region == "us-east-1"
+
+    def test_sso_region_none_when_credentials_file_has_no_region(self, tmp_path):
+        """
+        What it does: Verifies _sso_region is None when credentials file has no region field.
+        Purpose: Ensure backward compatibility with credentials files that omit region.
+        """
+        print("Setup: Creating credentials file without region field...")
+        creds_file = tmp_path / "kiro-auth-token.json"
+        creds_data = {
+            "refreshToken": "test_refresh_token",
+            "accessToken": "test_access_token"
+        }
+        creds_file.write_text(json.dumps(creds_data))
+
+        manager = KiroAuthManager(creds_file=str(creds_file), region="us-east-1")
+
+        print("Verification: _sso_region is None...")
+        print(f"Comparing _sso_region: Expected None, Got '{manager._sso_region}'")
+        assert manager._sso_region is None
+
 
 class TestKiroAuthManagerTokenExpiration:
     """Tests for token expiration checking."""


### PR DESCRIPTION
When logging into Kiro via an organization (e.g. `us-east-2`), that region is written into the credentials file. `_load_credentials_from_file` was using it to overwrite `_api_host` and `_q_host`, routing all API traffic to `https://q.us-east-2.amazonaws.com` — an endpoint that does not exist.

## Changes

- **`kiro/auth.py` — `_load_credentials_from_file`**: Store the credentials `region` field as `_sso_region` (auth/refresh URL only) instead of overriding `_region`/`_api_host`/`_q_host`. This mirrors the already-correct behaviour in `_load_credentials_from_sqlite`, which has a long-standing comment to the same effect.

```python
# Before — breaks API calls when credentials contain a non-existent region
self._region = data['region']
self._refresh_url = get_kiro_refresh_url(self._region)
self._api_host = get_kiro_api_host(self._region)   # ← sends traffic to q.us-east-2.amazonaws.com
self._q_host   = get_kiro_q_host(self._region)

# After — auth uses credentials region; API host stays on KIRO_REGION (default: us-east-1)
self._sso_region   = data['region']
self._refresh_url  = get_kiro_refresh_url(self._sso_region)
# _api_host / _q_host untouched
```

- **`_load_credentials_from_file` docstring**: Documents that `region` is an SSO/auth region and explicitly states API hosts are governed by `KIRO_REGION` env var.

- **`tests/unit/test_auth_manager.py`**: Three new tests in `TestKiroAuthManagerCredentialsFile` covering the regression scenario (`us-east-2` creds → API stays `us-east-1`), `_sso_region` population, and backward-compat when the `region` field is absent.

