### PR TITLE
[codex] fix Anthropic tool_reference tool result compatibility

### DIFF
--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -24,6 +24,7 @@ This module is an adapter layer that converts Anthropic-specific formats
 to the unified format used by converters_core.py.
 """
 
+import json
 from typing import Any, Dict, List, Optional
 
 from loguru import logger
@@ -112,6 +113,129 @@ def extract_system_prompt(system: Any) -> str:
     return str(system)
 
 
+def _serialize_tool_result_block(block: Any) -> Dict[str, Any]:
+    """
+    Serialize a nested tool_result content block to a dictionary.
+
+    Args:
+        block: Nested content block in dict or Pydantic format
+
+    Returns:
+        Dictionary representation of the block
+    """
+    if isinstance(block, dict):
+        return block
+
+    if hasattr(block, "model_dump"):
+        return block.model_dump()
+
+    return {}
+
+
+def _summarize_tool_result_block(block: Any) -> str:
+    """
+    Convert nested Anthropic tool_result blocks into a text summary.
+
+    This keeps Kiro-compatible text context for newer Anthropic block types
+    such as tool references and documents while avoiding large binary payloads.
+
+    Args:
+        block: Nested tool_result content block
+
+    Returns:
+        Text summary for the block, or empty string if it should not
+        contribute text context
+    """
+    block_data = _serialize_tool_result_block(block)
+    block_type = block_data.get("type")
+
+    if block_type == "text":
+        return str(block_data.get("text", ""))
+
+    if block_type == "image":
+        return ""
+
+    if block_type == "tool_reference":
+        tool_name = str(block_data.get("tool_name", "")).strip()
+        return f"[Tool Reference] {tool_name}" if tool_name else "[Tool Reference]"
+
+    if block_type == "document":
+        source = block_data.get("source")
+        if isinstance(source, dict):
+            source_type = source.get("type")
+            if source_type == "text":
+                return str(source.get("data", ""))
+
+            media_type = str(source.get("media_type", source_type or "unknown")).strip()
+            title = str(block_data.get("title", "")).strip()
+            return f"[Document] {title}" if title else f"[Document: {media_type}]"
+
+        return "[Document]"
+
+    if block_type == "search_result":
+        title = str(block_data.get("title", "")).strip()
+        url = str(block_data.get("url", "")).strip()
+        snippet = str(
+            block_data.get("text")
+            or block_data.get("content")
+            or block_data.get("snippet")
+            or ""
+        ).strip()
+        parts = [part for part in [title, url, snippet] if part]
+        return "\n".join(parts) if parts else "[Search Result]"
+
+    sanitized: Dict[str, Any] = {}
+    for key, value in block_data.items():
+        if key in {"data", "encrypted_content", "encrypted_index"}:
+            continue
+        if key == "source" and isinstance(value, dict):
+            sanitized_source = {
+                source_key: source_value
+                for source_key, source_value in value.items()
+                if source_key not in {"data", "encrypted_content", "encrypted_index"}
+            }
+            if any(secret_key in value for secret_key in ("data", "encrypted_content", "encrypted_index")):
+                sanitized_source["payload"] = "<omitted>"
+            sanitized[key] = sanitized_source
+        else:
+            sanitized[key] = value
+
+    if not sanitized:
+        return ""
+
+    try:
+        return json.dumps(sanitized, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return f"[{block_type or 'content_block'}]"
+
+
+def normalize_tool_result_content(content: Any) -> str:
+    """
+    Normalize Anthropic tool_result content to Kiro-compatible text.
+
+    Args:
+        content: Tool result content in Anthropic format
+
+    Returns:
+        Text content suitable for Kiro tool results
+    """
+    if isinstance(content, str):
+        return content
+
+    if isinstance(content, list):
+        normalized_parts = []
+        for block in content:
+            part = _summarize_tool_result_block(block).strip()
+            if part:
+                normalized_parts.append(part)
+        return "\n".join(normalized_parts)
+
+    if content is None:
+        return ""
+
+    return str(content)
+
+
 def extract_tool_results_from_anthropic_content(content: Any) -> List[Dict[str, Any]]:
     """
     Extracts tool results from Anthropic message content.
@@ -144,11 +268,7 @@ def extract_tool_results_from_anthropic_content(content: Any) -> List[Dict[str, 
             result_content = getattr(block, "content", "")
 
         if block_type == "tool_result" and tool_use_id:
-            # Convert content to text if it's a list
-            if isinstance(result_content, list):
-                result_content = extract_text_content(result_content)
-            elif not isinstance(result_content, str):
-                result_content = str(result_content) if result_content else ""
+            result_content = normalize_tool_result_content(result_content)
 
             tool_results.append(
                 {

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -83,13 +83,22 @@ class ToolResultContentBlock(BaseModel):
     Tool result content block in Anthropic format.
 
     Represents the result of a tool call, sent by the user.
-    Tool results can contain text, images, or a mix of both.
+    Tool results can contain text, images, or newer nested Anthropic
+    content blocks such as tool references and document/search payloads.
+
+    Anthropic has expanded the set of nested block types over time.
+    As a transparent gateway, we accept forward-compatible dict blocks
+    here and normalize them later in the conversion layer instead of
+    rejecting newer official payloads at validation time.
     """
 
     type: Literal["tool_result"] = "tool_result"
     tool_use_id: str
     content: Optional[
-        Union[str, List[Union["TextContentBlock", "ImageContentBlock"]]]
+        Union[
+            str,
+            List[Union["TextContentBlock", "ImageContentBlock", Dict[str, Any]]],
+        ]
     ] = None
     is_error: Optional[bool] = None
 

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -597,6 +597,33 @@ class TestExtractToolResultsFromAnthropicContent:
         # Text is preserved, images are extracted separately
         assert result[0]["content"] == "Screenshot captured"
 
+    def test_handles_tool_reference_in_tool_result(self):
+        """
+        What it does: Verifies handling of tool_reference blocks in tool_result content.
+        Purpose: Ensure deferred tool loading payloads are converted to stable text.
+        """
+        print("Setup: Tool result with tool_reference content...")
+        content = [
+            {
+                "type": "tool_result",
+                "tool_use_id": "call_999",
+                "content": [
+                    {
+                        "type": "tool_reference",
+                        "tool_name": "mcp__github__get_file_contents",
+                    }
+                ],
+            }
+        ]
+
+        print("Action: Extracting tool results...")
+        result = extract_tool_results_from_anthropic_content(content)
+
+        print(f"Result: {result}")
+        assert len(result) == 1
+        assert result[0]["tool_use_id"] == "call_999"
+        assert result[0]["content"] == "[Tool Reference] mcp__github__get_file_contents"
+
 
 # ==================================================================================================
 # Tests for extract_images_from_tool_results

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -949,6 +949,27 @@ class TestToolResultContentBlock:
         print(f"Comparing content type: Expected list, Got {type(block.content)}")
         assert isinstance(block.content, list)
         assert len(block.content) == 2
+
+    def test_accepts_tool_reference_list_content(self):
+        """
+        What it does: Verifies that tool_reference nested blocks are accepted.
+        Purpose: Ensure newer Anthropic tool_result payloads do not fail validation.
+        """
+        print("Setup: Creating ToolResultContentBlock with tool_reference content...")
+        block = ToolResultContentBlock(
+            tool_use_id="call_1",
+            content=[
+                {
+                    "type": "tool_reference",
+                    "tool_name": "mcp__github__get_file_contents",
+                }
+            ],
+        )
+
+        print(f"Result: {block}")
+        assert isinstance(block.content, list)
+        assert block.content[0]["type"] == "tool_reference"
+        assert block.content[0]["tool_name"] == "mcp__github__get_file_contents"
     
     def test_is_error_field(self):
         """

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -640,6 +640,54 @@ class TestMessagesToolUse:
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
+    def test_accepts_tool_reference_tool_result_message(self, test_client, valid_proxy_api_key):
+        """
+        What it does: Verifies tool_result content with tool_reference is accepted.
+        Purpose: Ensure newer Anthropic deferred-tool payloads do not fail validation.
+        """
+        print("Action: POST /v1/messages with tool_reference tool result...")
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-4-6",
+                "max_tokens": 1024,
+                "messages": [
+                    {"role": "user", "content": "Load the GitHub file tool."},
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "tooluse_123",
+                                "name": "ToolSearch",
+                                "input": {"query": "GitHub file contents"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "tooluse_123",
+                                "content": [
+                                    {
+                                        "type": "tool_reference",
+                                        "tool_name": "mcp__github__get_file_contents",
+                                    }
+                                ],
+                            },
+                            {"type": "text", "text": "Tool loaded."},
+                        ],
+                    },
+                ],
+            },
+        )
+
+        print(f"Status: {response.status_code}")
+        assert response.status_code != 422
+
 
 # =============================================================================
 # Tests for /v1/messages optional parameters


### PR DESCRIPTION
## Summary

- accept newer Anthropic `tool_result` nested content blocks instead of rejecting them at request validation time
- normalize `tool_reference`, `document`, and `search_result` style blocks into stable Kiro-compatible text summaries
- add model, converter, and route coverage for `tool_reference` payloads

## Root cause

`kiro-gateway` only allowed `tool_result.content` to contain text or image blocks. Anthropic's current Messages API and official SDKs also allow newer nested blocks such as `tool_reference`, which caused `/v1/messages` requests to fail locally with HTTP 422 before the gateway could process them.

## User impact

Clients that send Anthropic deferred-tool / tool-search style payloads with `tool_reference` blocks no longer get rejected by `kiro-gateway` during request validation.

## Validation

- `.venv/bin/pytest -v tests/unit/test_models_anthropic.py tests/unit/test_converters_anthropic.py tests/unit/test_routes_anthropic.py`
- `.venv/bin/pytest -v`
- rebuilt `kiro-gateway` Docker image and replayed a real `tool_reference` request against `/v1/messages` with HTTP 200

## Notes

Full test suite result in this environment: `1414 passed, 2 failed`.
The two failures are existing config-environment assertions unrelated to this Anthropic compatibility fix:
- `tests/unit/test_config.py::TestServerPortConfig::test_default_server_port_is_8000`
- `tests/unit/test_config.py::TestKiroCliDbFileConfig::test_kiro_cli_db_file_from_environment`
