### PR TITLE
feat(auth): add External IdP authentication support (Microsoft Azure AD / Entra ID)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,3 +14,4 @@ Thank you to all the contributors who have helped improve this project!
 - [@PAzter1101](https://github.com/PAzter1101) — Docker containerization with CI/CD (#55)
 - [@Ry-DS](https://github.com/Ry-DS) — Images in tool results support for Anthropic MCP servers (#57)
 - [@saaj](https://github.com/saaj) — Regional endpoint fix for eu-central-1 and other non-us-east-1 regions (#58)
+- [@lombax85](https://github.com/lombax85) — External IdP (Microsoft Azure AD / Entra ID) authentication support (#126)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Specify the path to the credentials file:
 
 Works with:
 - **Kiro IDE** (standard) - for personal accounts
-- **Enterprise** - for corporate accounts with SSO
+- **Enterprise** - for corporate accounts with SSO (including External IdP such as Microsoft Azure AD / Entra ID)
 
 ```env
 KIRO_CREDS_FILE="~/.aws/sso/cache/kiro-auth-token.json"
@@ -124,6 +124,7 @@ PROXY_API_KEY="my-super-secret-password-123"
 <details>
 <summary>📄 JSON file format</summary>
 
+**Standard / Enterprise (IdC):**
 ```json
 {
   "accessToken": "eyJ...",
@@ -132,6 +133,20 @@ PROXY_API_KEY="my-super-secret-password-123"
   "profileArn": "arn:aws:codewhisperer:us-east-1:...",
   "region": "us-east-1",
   "clientIdHash": "abc123..."  // Optional: for corporate SSO setups
+}
+```
+
+**External IdP (Microsoft Azure AD / Entra ID):**
+```json
+{
+  "accessToken": "eyJ...",
+  "refreshToken": "eyJ...",
+  "expiresAt": "2025-01-12T23:00:00.000Z",
+  "authMethod": "external_idp",
+  "provider": "ExternalIdp",
+  "tokenEndpoint": "https://login.microsoftonline.com/{tenant-id}/oauth2/v2.0/token",
+  "clientId": "your-client-id",
+  "scopes": "api://your-client-id/codewhisperer:conversations ..."
 }
 ```
 
@@ -196,11 +211,15 @@ AWS SSO credentials files (from `~/.aws/sso/cache/`) contain:
 
 The gateway automatically detects the authentication type based on the credentials file:
 
-- **Kiro Desktop Auth** (default): Used when `clientId` and `clientSecret` are NOT present
-  - Endpoint: `https://prod.{region}.auth.desktop.kiro.dev/refreshToken`
+- **External IdP** (e.g., Microsoft Azure AD / Entra ID): Used when `authMethod` is `"external_idp"` and `tokenEndpoint` is present
+  - Token refresh: via the IdP's OAuth2 token endpoint (e.g., `login.microsoftonline.com`)
+  - The IdP JWT is used directly with a `TokenType: EXTERNAL_IDP` header
   
 - **AWS SSO (OIDC)**: Used when `clientId` and `clientSecret` ARE present
   - Endpoint: `https://oidc.{region}.amazonaws.com/token`
+
+- **Kiro Desktop Auth** (default): Used when none of the above conditions are met
+  - Endpoint: `https://prod.{region}.auth.desktop.kiro.dev/refreshToken`
 
 No additional configuration is needed — just point to your credentials file!
 
@@ -226,13 +245,16 @@ PROXY_API_KEY="my-super-secret-password-123"
 | CLI Tool | Database Path |
 |----------|---------------|
 | kiro-cli | `~/.local/share/kiro-cli/data.sqlite3` |
+| kiro-cli (macOS) | `~/Library/Application Support/kiro-cli/data.sqlite3` |
 | amazon-q-developer-cli | `~/.local/share/amazon-q/data.sqlite3` |
 
 The gateway reads credentials from the `auth_kv` table which stores:
-- `kirocli:odic:token` or `codewhisperer:odic:token` — access token, refresh token, expiration
+- `kirocli:external-idp:token` — External IdP credentials (Microsoft Azure AD, etc.)
+- `kirocli:social:token` — Social login (Google, GitHub, Microsoft, etc.)
+- `kirocli:odic:token` or `codewhisperer:odic:token` — AWS SSO OIDC credentials
 - `kirocli:odic:device-registration` or `codewhisperer:odic:device-registration` — client ID and secret
 
-Both key formats are supported for compatibility with different kiro-cli versions.
+All key formats are supported for compatibility with different kiro-cli versions and auth methods.
 
 </details>
 

--- a/kiro/auth.py
+++ b/kiro/auth.py
@@ -50,9 +50,10 @@ from kiro.utils import get_machine_fingerprint
 
 # Supported SQLite token keys (searched in priority order)
 SQLITE_TOKEN_KEYS = [
-    "kirocli:social:token",      # Social login (Google, GitHub, Microsoft, etc.)
-    "kirocli:odic:token",        # AWS SSO OIDC (kiro-cli corporate)
-    "codewhisperer:odic:token",  # Legacy AWS SSO OIDC
+    "kirocli:external-idp:token",  # External IdP (Microsoft Azure AD, etc.)
+    "kirocli:social:token",        # Social login (Google, GitHub, Microsoft, etc.)
+    "kirocli:odic:token",          # AWS SSO OIDC (kiro-cli corporate)
+    "codewhisperer:odic:token",    # Legacy AWS SSO OIDC
 ]
 
 # Device registration keys (for AWS SSO OIDC only)
@@ -65,18 +66,24 @@ SQLITE_REGISTRATION_KEYS = [
 class AuthType(Enum):
     """
     Type of authentication mechanism.
-    
+
     KIRO_DESKTOP: Kiro IDE credentials (default)
         - Uses https://prod.{region}.auth.desktop.kiro.dev/refreshToken
         - JSON body: {"refreshToken": "..."}
-    
+
     AWS_SSO_OIDC: AWS SSO credentials from kiro-cli
         - Uses https://oidc.{region}.amazonaws.com/token
         - Form body: grant_type=refresh_token&client_id=...&client_secret=...&refresh_token=...
         - Requires clientId and clientSecret from credentials file
+
+    EXTERNAL_IDP: External Identity Provider (e.g., Microsoft Azure AD / Entra ID)
+        - Uses the tokenEndpoint from the credentials file (e.g., login.microsoftonline.com)
+        - OAuth2 public client refresh (no client_secret required)
+        - Detected when authMethod is "external_idp" in credentials file
     """
     KIRO_DESKTOP = "kiro_desktop"
     AWS_SSO_OIDC = "aws_sso_oidc"
+    EXTERNAL_IDP = "external_idp"
 
 
 class KiroAuthManager:
@@ -150,6 +157,11 @@ class KiroAuthManager:
         
         # Enterprise Kiro IDE specific fields
         self._client_id_hash: Optional[str] = None  # clientIdHash from Enterprise Kiro IDE
+
+        # External IdP specific fields (e.g., Microsoft Azure AD / Entra ID)
+        self._auth_method: Optional[str] = None  # authMethod from credentials file
+        self._token_endpoint: Optional[str] = None  # OAuth2 token endpoint URL
+        self._idp_scopes: Optional[str] = None  # OAuth2 scopes string for external IdP
         
         # Track which SQLite key we loaded credentials from (for saving back to correct location)
         self._sqlite_token_key: Optional[str] = None
@@ -185,11 +197,16 @@ class KiroAuthManager:
     def _detect_auth_type(self) -> None:
         """
         Detects authentication type based on available credentials.
-        
-        AWS SSO OIDC credentials contain clientId and clientSecret.
-        Kiro Desktop credentials do not contain these fields.
+
+        Priority:
+        1. External IdP: authMethod is "external_idp" and tokenEndpoint is set
+        2. AWS SSO OIDC: clientId and clientSecret are both present
+        3. Kiro Desktop: fallback (default)
         """
-        if self._client_id and self._client_secret:
+        if self._auth_method == "external_idp" and self._token_endpoint:
+            self._auth_type = AuthType.EXTERNAL_IDP
+            logger.info(f"Detected auth type: External IdP (endpoint: {self._token_endpoint})")
+        elif self._client_id and self._client_secret:
             self._auth_type = AuthType.AWS_SSO_OIDC
             logger.info("Detected auth type: AWS SSO OIDC (kiro-cli)")
         else:
@@ -258,6 +275,14 @@ class KiroAuthManager:
                     # Load scopes if available
                     if 'scopes' in token_data:
                         self._scopes = token_data['scopes']
+
+                    # Load external IdP specific fields (snake_case in SQLite)
+                    if 'token_endpoint' in token_data:
+                        self._token_endpoint = token_data['token_endpoint']
+                    if 'issuer_url' in token_data:
+                        self._auth_method = "external_idp"
+                    if 'client_id' in token_data:
+                        self._client_id = token_data['client_id']
                     
                     # Parse expires_at (RFC3339 format)
                     if 'expires_at' in token_data:
@@ -354,6 +379,14 @@ class KiroAuthManager:
                 self._client_id_hash = data['clientIdHash']
                 self._load_enterprise_device_registration(self._client_id_hash)
             
+            # Load external IdP specific fields
+            if 'authMethod' in data:
+                self._auth_method = data['authMethod']
+            if 'tokenEndpoint' in data:
+                self._token_endpoint = data['tokenEndpoint']
+            if 'scopes' in data:
+                self._idp_scopes = data['scopes']
+
             # Load AWS SSO OIDC specific fields (if directly in credentials file)
             if 'clientId' in data:
                 self._client_id = data['clientId']
@@ -566,7 +599,9 @@ class KiroAuthManager:
             ValueError: If refresh token is not set or response doesn't contain accessToken
             httpx.HTTPError: On HTTP request error
         """
-        if self._auth_type == AuthType.AWS_SSO_OIDC:
+        if self._auth_type == AuthType.EXTERNAL_IDP:
+            await self._refresh_token_external_idp()
+        elif self._auth_type == AuthType.AWS_SSO_OIDC:
             await self._refresh_token_aws_sso_oidc()
         else:
             await self._refresh_token_kiro_desktop()
@@ -630,6 +665,66 @@ class KiroAuthManager:
         else:
             self._save_credentials_to_file()
     
+    async def _refresh_token_external_idp(self) -> None:
+        """
+        Refreshes token using an external Identity Provider (e.g., Microsoft Azure AD / Entra ID).
+
+        Uses the tokenEndpoint from the credentials file with a standard OAuth2
+        refresh_token grant. The resulting IdP JWT is used directly with the Kiro API
+        (the API recognizes it via the TokenType: EXTERNAL_IDP header).
+
+        Raises:
+            ValueError: If required credentials are not set
+            httpx.HTTPError: On HTTP request error
+        """
+        if not self._refresh_token:
+            raise ValueError("Refresh token is not set")
+        if not self._token_endpoint:
+            raise ValueError("Token endpoint is not set (required for External IdP)")
+        if not self._client_id:
+            raise ValueError("Client ID is not set (required for External IdP)")
+
+        logger.info(f"Refreshing token via External IdP: {self._token_endpoint}")
+
+        payload = {
+            "grant_type": "refresh_token",
+            "client_id": self._client_id,
+            "refresh_token": self._refresh_token,
+        }
+        if self._idp_scopes:
+            payload["scope"] = self._idp_scopes
+
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+
+        async with httpx.AsyncClient(timeout=30) as client:
+            response = await client.post(self._token_endpoint, data=payload, headers=headers)
+
+            if response.status_code != 200:
+                error_body = response.text
+                logger.error(f"External IdP refresh failed: status={response.status_code}, body={error_body}")
+                response.raise_for_status()
+
+            result = response.json()
+
+        new_access_token = result.get("access_token")
+        new_refresh_token = result.get("refresh_token")
+        expires_in = result.get("expires_in", 3600)
+
+        if not new_access_token:
+            raise ValueError(f"External IdP response does not contain access_token: {result}")
+
+        self._access_token = new_access_token
+        if new_refresh_token:
+            self._refresh_token = new_refresh_token
+
+        self._expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in - 60)
+
+        logger.info(f"Token refreshed via External IdP, expires: {self._expires_at.isoformat()}")
+
+        self._save_credentials_to_file()
+
     async def _refresh_token_aws_sso_oidc(self) -> None:
         """
         Refreshes token using AWS SSO OIDC endpoint.
@@ -863,5 +958,5 @@ class KiroAuthManager:
     
     @property
     def auth_type(self) -> AuthType:
-        """Authentication type (KIRO_DESKTOP or AWS_SSO_OIDC)."""
+        """Authentication type (KIRO_DESKTOP, AWS_SSO_OIDC, or EXTERNAL_IDP)."""
         return self._auth_type

--- a/kiro/utils.py
+++ b/kiro/utils.py
@@ -61,22 +61,24 @@ def get_machine_fingerprint() -> str:
 def get_kiro_headers(auth_manager: "KiroAuthManager", token: str) -> dict:
     """
     Builds headers for Kiro API requests.
-    
+
     Includes all necessary headers for authentication and identification:
     - Authorization with Bearer token
     - User-Agent with fingerprint
     - AWS CodeWhisperer specific headers
-    
+    - TokenType header for External IdP authentication
+
     Args:
         auth_manager: Authentication manager for obtaining fingerprint
         token: Access token for authorization
-    
+
     Returns:
         Dictionary with headers for HTTP request
     """
+    from kiro.auth import AuthType
     fingerprint = auth_manager.fingerprint
-    
-    return {
+
+    headers = {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
         "User-Agent": f"aws-sdk-js/1.0.27 ua/2.1 os/win32#10.0.19044 lang/js md/nodejs#22.21.1 api/codewhispererstreaming#1.0.27 m/E KiroIDE-0.7.45-{fingerprint}",
@@ -86,6 +88,11 @@ def get_kiro_headers(auth_manager: "KiroAuthManager", token: str) -> dict:
         "amz-sdk-invocation-id": str(uuid.uuid4()),
         "amz-sdk-request": "attempt=1; max=3",
     }
+
+    if auth_manager.auth_type == AuthType.EXTERNAL_IDP:
+        headers["TokenType"] = "EXTERNAL_IDP"
+
+    return headers
 
 
 def generate_completion_id() -> str:


### PR DESCRIPTION
## Summary

- Add support for **External Identity Provider (IdP)** authentication, enabling enterprise users with Microsoft Azure AD / Entra ID SSO to use the gateway
- Previously, external_idp credentials were misdetected as "Kiro Desktop" auth, causing 403 errors ("The bearer token included in the request is invalid")
- Adds the critical `TokenType: EXTERNAL_IDP` header that the Kiro API requires to accept external IdP JWTs
- Supports loading external-idp credentials from both JSON file (`KIRO_CREDS_FILE`) and kiro-cli SQLite database (`kirocli:external-idp:token` key)

## How it works

1. **Detection**: When the credentials file contains `authMethod: "external_idp"` and `tokenEndpoint`, the gateway auto-detects the new `EXTERNAL_IDP` auth type
2. **Token refresh**: Uses standard OAuth2 `refresh_token` grant against the IdP's token endpoint (e.g., `login.microsoftonline.com`)
3. **API calls**: Adds `TokenType: EXTERNAL_IDP` header so the Kiro API accepts the external IdP JWT directly (no token exchange needed)

## Configuration

No new configuration required — existing `KIRO_CREDS_FILE` setup works automatically:

```env
KIRO_CREDS_FILE="~/.aws/sso/cache/kiro-auth-token.json"
PROXY_API_KEY="your-key"
```

The gateway reads `authMethod`, `tokenEndpoint`, `clientId`, and `scopes` from the credentials file.

## Files changed

| File | Change |
|------|--------|
| `kiro/auth.py` | New `EXTERNAL_IDP` auth type, detection logic, token refresh method, SQLite key support |
| `kiro/utils.py` | Add `TokenType: EXTERNAL_IDP` header for external IdP requests |

## Test plan

- [x] Tested with Microsoft Azure AD (Entra ID) enterprise SSO credentials
- [x] Verified token refresh via Microsoft's OAuth2 endpoint
- [x] Verified both streaming and non-streaming API calls work
- [x] Verified both OpenAI and Anthropic compatible endpoints work
- [x] Existing Kiro Desktop and AWS SSO OIDC auth types unaffected (detection priority preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
