### PR TITLE
feat: add install script and full Anthropic content block type parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ build/
 debug_logs*/
 debug*.json
 
+# Claude Code
+.claude/
+
 # Project-specific
 _notes/
 requests/

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ debug_logs*/
 debug*.json
 
 # Claude Code
-.claude/
+.claude/scheduled_tasks.lock
 
 # Project-specific
 _notes/

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ requests/
 # Testing
 .pytest_cache/
 .coverage
-htmlcov/
+htmlcov/.venv/

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Kiro Gateway - Install/Reinstall Script
+# Installs as a user systemd service and (re)starts it.
+# Requires: uv (https://docs.astral.sh/uv/)
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+SERVICE_NAME="kiro-gateway"
+SERVICE_FILE="$HOME/.config/systemd/user/${SERVICE_NAME}.service"
+VENV_DIR="${REPO_DIR}/.venv"
+
+echo "==> Kiro Gateway installer"
+echo "    Repo: ${REPO_DIR}"
+
+# Ensure systemd user directory exists
+mkdir -p "$HOME/.config/systemd/user"
+
+# Create/update virtualenv and install dependencies
+echo "==> Installing dependencies with uv..."
+uv venv "$VENV_DIR" --quiet
+uv pip install --quiet -r "${REPO_DIR}/requirements.txt" -p "${VENV_DIR}/bin/python"
+
+# Write systemd service unit
+echo "==> Writing systemd service to ${SERVICE_FILE}"
+cat > "$SERVICE_FILE" <<EOF
+[Unit]
+Description=Kiro Gateway
+After=network.target
+
+[Service]
+WorkingDirectory=${REPO_DIR}
+ExecStart=${VENV_DIR}/bin/python main.py
+Restart=on-failure
+RestartSec=5
+Environment=PATH=${VENV_DIR}/bin:/usr/local/bin:/usr/bin:/bin
+
+[Install]
+WantedBy=default.target
+EOF
+
+# Reload, enable, and restart
+echo "==> Reloading systemd and restarting ${SERVICE_NAME}..."
+systemctl --user daemon-reload
+systemctl --user enable "${SERVICE_NAME}.service"
+systemctl --user restart "${SERVICE_NAME}.service"
+
+# Show status
+echo "==> Done. Service status:"
+systemctl --user status "${SERVICE_NAME}.service" --no-pager

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -26,7 +26,6 @@ Anthropic's Messages API specification.
 Reference: https://docs.anthropic.com/en/api/messages
 """
 
-import time
 from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, Field
 
@@ -65,6 +64,18 @@ class ThinkingContentBlock(BaseModel):
     signature: str = ""
 
 
+class RedactedThinkingContentBlock(BaseModel):
+    """
+    Redacted thinking content block in Anthropic format.
+
+    Represents redacted/hidden reasoning content when the model's
+    thinking is not fully disclosed.
+    """
+
+    type: Literal["redacted_thinking"] = "redacted_thinking"
+    data: str
+
+
 class ToolUseContentBlock(BaseModel):
     """
     Tool use content block in Anthropic format.
@@ -78,18 +89,71 @@ class ToolUseContentBlock(BaseModel):
     input: Dict[str, Any]
 
 
+class ServerToolUseContentBlock(BaseModel):
+    """
+    Server-side tool use content block in Anthropic format.
+
+    Represents a tool call executed server-side by the API.
+    """
+
+    type: Literal["server_tool_use"] = "server_tool_use"
+    id: str
+    name: str
+    input: Dict[str, Any]
+
+
+class McpToolUseContentBlock(BaseModel):
+    """
+    MCP (Model Context Protocol) tool use content block in Anthropic format.
+
+    Represents a tool call routed through an MCP server.
+    """
+
+    type: Literal["mcp_tool_use"] = "mcp_tool_use"
+    id: str
+    name: str
+    input: Dict[str, Any]
+
+    model_config = {"extra": "allow"}
+
+
+class ToolReferenceContentBlock(BaseModel):
+    """
+    Tool reference content block in Anthropic format.
+
+    Represents a reference to a deferred tool, sent inside tool results
+    by clients like Claude Code when loading tools on demand.
+    """
+
+    type: Literal["tool_reference"] = "tool_reference"
+    tool_name: str
+
+    model_config = {"extra": "allow"}
+
+
 class ToolResultContentBlock(BaseModel):
     """
     Tool result content block in Anthropic format.
 
     Represents the result of a tool call, sent by the user.
-    Tool results can contain text, images, or a mix of both.
+    Tool results can contain text, images, tool references, or a mix.
+    Falls back to Dict[str, Any] for unknown content block types.
     """
 
     type: Literal["tool_result"] = "tool_result"
     tool_use_id: str
     content: Optional[
-        Union[str, List[Union["TextContentBlock", "ImageContentBlock"]]]
+        Union[
+            str,
+            List[
+                Union[
+                    "TextContentBlock",
+                    "ImageContentBlock",
+                    "ToolReferenceContentBlock",
+                    Dict[str, Any],
+                ]
+            ],
+        ]
     ] = None
     is_error: Optional[bool] = None
 
@@ -146,13 +210,54 @@ class ImageContentBlock(BaseModel):
     source: Union[Base64ImageSource, URLImageSource]
 
 
-# Union type for all content blocks (including images and thinking)
+class Base64DocumentSource(BaseModel):
+    """Base64-encoded document source (e.g., PDF)."""
+
+    type: Literal["base64"] = "base64"
+    data: str
+
+
+class DocumentContentBlock(BaseModel):
+    """
+    Document content block in Anthropic format.
+
+    Represents an uploaded document (e.g., PDF) in a message.
+    """
+
+    type: Literal["document"] = "document"
+    source: Base64DocumentSource
+
+    model_config = {"extra": "allow"}
+
+
+class AdvisorToolResultContentBlock(BaseModel):
+    """
+    Advisor tool result content block in Anthropic format.
+
+    Represents results from advisor/agentic tool calls.
+    """
+
+    type: Literal["advisor_tool_result"] = "advisor_tool_result"
+    tool_use_id: str
+    content: Any
+
+    model_config = {"extra": "allow"}
+
+
+# Union type for all content blocks (including images, thinking, and tool references)
 ContentBlock = Union[
     TextContentBlock,
     ThinkingContentBlock,
+    RedactedThinkingContentBlock,
     ImageContentBlock,
+    DocumentContentBlock,
     ToolUseContentBlock,
+    ServerToolUseContentBlock,
+    McpToolUseContentBlock,
     ToolResultContentBlock,
+    ToolReferenceContentBlock,
+    AdvisorToolResultContentBlock,
+    Dict[str, Any],
 ]
 
 
@@ -321,7 +426,15 @@ class AnthropicMessagesResponse(BaseModel):
     id: str
     type: Literal["message"] = "message"
     role: Literal["assistant"] = "assistant"
-    content: List[Union[ThinkingContentBlock, TextContentBlock, ToolUseContentBlock]]
+    content: List[Union[
+        ThinkingContentBlock,
+        RedactedThinkingContentBlock,
+        TextContentBlock,
+        ToolUseContentBlock,
+        ServerToolUseContentBlock,
+        McpToolUseContentBlock,
+        Dict[str, Any],
+    ]]
     model: str
     stop_reason: Optional[
         Literal["end_turn", "max_tokens", "stop_sequence", "tool_use"]


### PR DESCRIPTION
## Summary
- Add `install.sh` for one-command setup as a user systemd service (requires `uv`)
- Add full Anthropic content block type parity: `RedactedThinkingContentBlock`, `ServerToolUseContentBlock`, `McpToolUseContentBlock`, `ToolReferenceContentBlock`, `DocumentContentBlock`, `AdvisorToolResultContentBlock`, and `Dict[str, Any]` fallback for unknown types
- Minor `.gitignore` updates (Claude Code lock file, `.venv` path fix)

## Test plan
- [x] Verify `bash install.sh` creates and starts the systemd service
- [x] Confirm streaming requests with new content block types (redacted thinking, MCP tool use, server tool use, documents) pass through without errors
- [x] Validate existing message routing still works for standard text/thinking/tool_use blocks