### PR TITLE
feat(models): add full Anthropic content block type parity

### DIFF
--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -26,7 +26,6 @@ Anthropic's Messages API specification.
 Reference: https://docs.anthropic.com/en/api/messages
 """
 
-import time
 from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, Field
 
@@ -65,6 +64,18 @@ class ThinkingContentBlock(BaseModel):
     signature: str = ""
 
 
+class RedactedThinkingContentBlock(BaseModel):
+    """
+    Redacted thinking content block in Anthropic format.
+
+    Represents redacted/hidden reasoning content when the model's
+    thinking is not fully disclosed.
+    """
+
+    type: Literal["redacted_thinking"] = "redacted_thinking"
+    data: str
+
+
 class ToolUseContentBlock(BaseModel):
     """
     Tool use content block in Anthropic format.
@@ -78,18 +89,71 @@ class ToolUseContentBlock(BaseModel):
     input: Dict[str, Any]
 
 
+class ServerToolUseContentBlock(BaseModel):
+    """
+    Server-side tool use content block in Anthropic format.
+
+    Represents a tool call executed server-side by the API.
+    """
+
+    type: Literal["server_tool_use"] = "server_tool_use"
+    id: str
+    name: str
+    input: Dict[str, Any]
+
+
+class McpToolUseContentBlock(BaseModel):
+    """
+    MCP (Model Context Protocol) tool use content block in Anthropic format.
+
+    Represents a tool call routed through an MCP server.
+    """
+
+    type: Literal["mcp_tool_use"] = "mcp_tool_use"
+    id: str
+    name: str
+    input: Dict[str, Any]
+
+    model_config = {"extra": "allow"}
+
+
+class ToolReferenceContentBlock(BaseModel):
+    """
+    Tool reference content block in Anthropic format.
+
+    Represents a reference to a deferred tool, sent inside tool results
+    by clients like Claude Code when loading tools on demand.
+    """
+
+    type: Literal["tool_reference"] = "tool_reference"
+    tool_name: str
+
+    model_config = {"extra": "allow"}
+
+
 class ToolResultContentBlock(BaseModel):
     """
     Tool result content block in Anthropic format.
 
     Represents the result of a tool call, sent by the user.
-    Tool results can contain text, images, or a mix of both.
+    Tool results can contain text, images, tool references, or a mix.
+    Falls back to Dict[str, Any] for unknown content block types.
     """
 
     type: Literal["tool_result"] = "tool_result"
     tool_use_id: str
     content: Optional[
-        Union[str, List[Union["TextContentBlock", "ImageContentBlock"]]]
+        Union[
+            str,
+            List[
+                Union[
+                    "TextContentBlock",
+                    "ImageContentBlock",
+                    "ToolReferenceContentBlock",
+                    Dict[str, Any],
+                ]
+            ],
+        ]
     ] = None
     is_error: Optional[bool] = None
 
@@ -146,13 +210,54 @@ class ImageContentBlock(BaseModel):
     source: Union[Base64ImageSource, URLImageSource]
 
 
-# Union type for all content blocks (including images and thinking)
+class Base64DocumentSource(BaseModel):
+    """Base64-encoded document source (e.g., PDF)."""
+
+    type: Literal["base64"] = "base64"
+    data: str
+
+
+class DocumentContentBlock(BaseModel):
+    """
+    Document content block in Anthropic format.
+
+    Represents an uploaded document (e.g., PDF) in a message.
+    """
+
+    type: Literal["document"] = "document"
+    source: Base64DocumentSource
+
+    model_config = {"extra": "allow"}
+
+
+class AdvisorToolResultContentBlock(BaseModel):
+    """
+    Advisor tool result content block in Anthropic format.
+
+    Represents results from advisor/agentic tool calls.
+    """
+
+    type: Literal["advisor_tool_result"] = "advisor_tool_result"
+    tool_use_id: str
+    content: Any
+
+    model_config = {"extra": "allow"}
+
+
+# Union type for all content blocks (including images, thinking, and tool references)
 ContentBlock = Union[
     TextContentBlock,
     ThinkingContentBlock,
+    RedactedThinkingContentBlock,
     ImageContentBlock,
+    DocumentContentBlock,
     ToolUseContentBlock,
+    ServerToolUseContentBlock,
+    McpToolUseContentBlock,
     ToolResultContentBlock,
+    ToolReferenceContentBlock,
+    AdvisorToolResultContentBlock,
+    Dict[str, Any],
 ]
 
 
@@ -321,7 +426,15 @@ class AnthropicMessagesResponse(BaseModel):
     id: str
     type: Literal["message"] = "message"
     role: Literal["assistant"] = "assistant"
-    content: List[Union[ThinkingContentBlock, TextContentBlock, ToolUseContentBlock]]
+    content: List[Union[
+        ThinkingContentBlock,
+        RedactedThinkingContentBlock,
+        TextContentBlock,
+        ToolUseContentBlock,
+        ServerToolUseContentBlock,
+        McpToolUseContentBlock,
+        Dict[str, Any],
+    ]]
     model: str
     stop_reason: Optional[
         Literal["end_turn", "max_tokens", "stop_sequence", "tool_use"]


### PR DESCRIPTION
## Summary
- Add missing Anthropic content block types: `RedactedThinkingContentBlock`, `ServerToolUseContentBlock`, `McpToolUseContentBlock`, `ToolReferenceContentBlock`, `DocumentContentBlock`, `AdvisorToolResultContentBlock`
- Add `Dict[str, Any]` fallback in `ContentBlock` and response types for forward compatibility with unknown block types
- Expand `ToolResultContentBlock.content` to accept `ToolReferenceContentBlock` and dict fallback

## Test plan
- [ ] Confirm streaming requests with new content block types (redacted thinking, MCP tool use, server tool use, documents) pass through without errors
- [ ] Validate existing message routing still works for standard text/thinking/tool_use blocks