### PR TITLE
fix(converters): apply MODEL_ALIASES in get_model_id_for_kiro()

### DIFF
--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -28,7 +28,7 @@ from typing import Any, Dict, List, Optional
 
 from loguru import logger
 
-from kiro.config import HIDDEN_MODELS
+from kiro.config import HIDDEN_MODELS, MODEL_ALIASES
 from kiro.model_resolver import get_model_id_for_kiro
 from kiro.models_anthropic import (
     AnthropicMessagesRequest,
@@ -405,7 +405,7 @@ def anthropic_to_kiro(
 
     # Get model ID for Kiro API (normalizes + resolves hidden models)
     # Pass-through principle: we normalize and send to Kiro, Kiro decides if valid
-    model_id = get_model_id_for_kiro(request.model, HIDDEN_MODELS)
+    model_id = get_model_id_for_kiro(request.model, HIDDEN_MODELS, aliases=MODEL_ALIASES)
 
     logger.debug(
         f"Converting Anthropic request: model={request.model} -> {model_id}, "

--- a/kiro/converters_openai.py
+++ b/kiro/converters_openai.py
@@ -33,7 +33,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from loguru import logger
 
-from kiro.config import HIDDEN_MODELS
+from kiro.config import HIDDEN_MODELS, MODEL_ALIASES
 from kiro.model_resolver import get_model_id_for_kiro
 from kiro.models_openai import ChatMessage, ChatCompletionRequest, Tool
 
@@ -326,7 +326,7 @@ def build_kiro_payload(
     
     # Get model ID for Kiro API (normalizes + resolves hidden models)
     # Pass-through principle: we normalize and send to Kiro, Kiro decides if valid
-    model_id = get_model_id_for_kiro(request_data.model, HIDDEN_MODELS)
+    model_id = get_model_id_for_kiro(request_data.model, HIDDEN_MODELS, aliases=MODEL_ALIASES)
     
     logger.debug(
         f"Converting OpenAI request: model={request_data.model} -> {model_id}, "

--- a/kiro/model_resolver.py
+++ b/kiro/model_resolver.py
@@ -162,31 +162,36 @@ def normalize_model_name(name: str) -> str:
     return name
 
 
-def get_model_id_for_kiro(model_name: str, hidden_models: Dict[str, str]) -> str:
+def get_model_id_for_kiro(
+    model_name: str,
+    hidden_models: Dict[str, str],
+    aliases: Optional[Dict[str, str]] = None,
+) -> str:
     """
     Get the model ID to send to Kiro API.
-    
+
     This is a simple helper for converters that don't have access to the full
-    ModelResolver. It normalizes the name and checks hidden models.
-    
-    For hidden models (like claude-3.7-sonnet), returns the internal Kiro ID.
-    For regular models, returns the normalized name.
-    
+    ModelResolver. It resolves aliases, normalizes the name, and checks hidden models.
+
     Args:
         model_name: External model name from client
         hidden_models: Dict mapping display names to internal Kiro IDs
-    
+        aliases: Optional dict mapping alias names to real model IDs
+
     Returns:
         Model ID to send to Kiro API
-    
+
     Examples:
         >>> get_model_id_for_kiro("claude-haiku-4-5-20251001", {})
         'claude-haiku-4.5'
         >>> get_model_id_for_kiro("claude-3.7-sonnet", {"claude-3.7-sonnet": "CLAUDE_3_7_SONNET_20250219_V1_0"})
         'CLAUDE_3_7_SONNET_20250219_V1_0'
-        >>> get_model_id_for_kiro("claude-3-7-sonnet", {"claude-3.7-sonnet": "CLAUDE_3_7_SONNET_20250219_V1_0"})
-        'CLAUDE_3_7_SONNET_20250219_V1_0'
+        >>> get_model_id_for_kiro("auto-kiro", {}, aliases={"auto-kiro": "auto"})
+        'auto'
     """
+    # Resolve alias first (same order as ModelResolver.resolve)
+    if aliases:
+        model_name = aliases.get(model_name, model_name)
     normalized = normalize_model_name(model_name)
     return hidden_models.get(normalized, normalized)
 


### PR DESCRIPTION
## Summary

- `get_model_id_for_kiro()` was missing alias resolution, causing model aliases like `auto-kiro` → `auto` to not work during request conversion
- Both OpenAI and Anthropic converters now pass `MODEL_ALIASES` to `get_model_id_for_kiro()`
- Fixes INVALID_MODEL_ID error when using `auto-kiro` with `/v1/messages` or `/v1/chat/completions`

## Test plan

- [x] All 1413 existing tests pass
- [ ] Verify `auto-kiro` resolves to `auto` on both `/v1/chat/completions` and `/v1/messages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)