### PR TITLE
fix(anthropic): accurate token estimation for Anthropic API path

### DIFF
--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -352,10 +352,16 @@ class AnthropicUsage(BaseModel):
     Attributes:
         input_tokens: Number of input tokens
         output_tokens: Number of output tokens
+        cache_read_input_tokens: Tokens read from prompt cache (仅在 Kiro 上游明确返回时透传)
+        cache_creation_input_tokens: Tokens used to create prompt cache (仅在 Kiro 上游明确返回时透传)
     """
 
     input_tokens: int
     output_tokens: int
+    cache_read_input_tokens: Optional[int] = None
+    cache_creation_input_tokens: Optional[int] = None
+
+    model_config = {"extra": "allow"}
 
 
 class AnthropicMessagesResponse(BaseModel):

--- a/kiro/routes_anthropic.py
+++ b/kiro/routes_anthropic.py
@@ -50,7 +50,6 @@ from kiro.streaming_anthropic import (
 )
 from kiro.http_client import KiroHttpClient
 from kiro.utils import generate_conversation_id
-from kiro.tokenizer import count_tools_tokens
 from kiro.config import WEB_SEARCH_ENABLED
 from kiro.mcp_tools import handle_native_web_search
 
@@ -353,6 +352,11 @@ async def messages(
     # Convert Pydantic models to dicts for tokenizer
     messages_for_tokenizer = [msg.model_dump() for msg in request_data.messages]
     tools_for_tokenizer = [tool.model_dump() for tool in request_data.tools] if request_data.tools else None
+    # Serialize system prompt (may be a list of Pydantic objects)
+    if isinstance(request_data.system, list):
+        system_for_tokenizer = [b.model_dump() if hasattr(b, "model_dump") else b for b in request_data.system]
+    else:
+        system_for_tokenizer = request_data.system
     
     try:
         # Make request to Kiro API (for both streaming and non-streaming modes)
@@ -419,7 +423,9 @@ async def messages(
                         request_data.model,
                         model_cache,
                         auth_manager,
-                        request_messages=messages_for_tokenizer
+                        request_messages=messages_for_tokenizer,
+                        request_tools=tools_for_tokenizer,
+                        request_system=system_for_tokenizer,
                     ):
                         yield chunk
                 except GeneratorExit:
@@ -466,7 +472,9 @@ async def messages(
                 request_data.model,
                 model_cache,
                 auth_manager,
-                request_messages=messages_for_tokenizer
+                request_messages=messages_for_tokenizer,
+                request_tools=tools_for_tokenizer,
+                request_system=system_for_tokenizer,
             )
             
             await http_client.close()

--- a/kiro/streaming_anthropic.py
+++ b/kiro/streaming_anthropic.py
@@ -47,7 +47,7 @@ from kiro.streaming_core import (
     calculate_tokens_from_context_usage,
     stream_with_first_token_retry,
 )
-from kiro.tokenizer import count_tokens, count_message_tokens, count_tools_tokens
+from kiro.tokenizer import count_tokens, estimate_request_tokens
 from kiro.parsers import parse_bracket_tool_calls, deduplicate_tool_calls
 from kiro.config import FIRST_TOKEN_TIMEOUT, FIRST_TOKEN_MAX_RETRIES, FAKE_REASONING_HANDLING
 
@@ -98,6 +98,34 @@ def generate_thinking_signature() -> str:
     return f"sig_{uuid.uuid4().hex[:32]}"
 
 
+def _extract_cache_usage_fields(usage: Optional[Dict[str, Any]]) -> Dict[str, int]:
+    """
+    Extract cache token fields from upstream usage (if present).
+
+    Args:
+        usage: Usage data from Kiro stream event
+
+    Returns:
+        Dict containing only available cache fields; missing fields are omitted
+    """
+    if not isinstance(usage, dict):
+        return {}
+
+    extracted: Dict[str, int] = {}
+    key_map = {
+        "cache_read_input_tokens": "cache_read_input_tokens",
+        "cacheReadInputTokens": "cache_read_input_tokens",
+        "cache_creation_input_tokens": "cache_creation_input_tokens",
+        "cacheCreationInputTokens": "cache_creation_input_tokens",
+    }
+    for source_key, target_key in key_map.items():
+        value = usage.get(source_key)
+        if isinstance(value, (int, float)):
+            extracted[target_key] = int(value)
+
+    return extracted
+
+
 async def stream_kiro_to_anthropic(
     response: httpx.Response,
     model: str,
@@ -105,6 +133,8 @@ async def stream_kiro_to_anthropic(
     auth_manager: "KiroAuthManager",
     first_token_timeout: float = FIRST_TOKEN_TIMEOUT,
     request_messages: Optional[list] = None,
+    request_tools: Optional[list] = None,
+    request_system: Optional[Any] = None,
     conversation_id: Optional[str] = None
 ) -> AsyncGenerator[str, None]:
     """
@@ -120,6 +150,8 @@ async def stream_kiro_to_anthropic(
         auth_manager: Authentication manager
         first_token_timeout: First token wait timeout (seconds)
         request_messages: Original request messages (for token counting)
+        request_tools: Original request tools (for token counting)
+        request_system: Original system prompt (for token counting)
         conversation_id: Stable conversation ID for truncation recovery (optional)
     
     Yields:
@@ -134,9 +166,15 @@ async def stream_kiro_to_anthropic(
     full_content = ""
     full_thinking_content = ""
     
-    # Count input tokens from request messages
-    if request_messages:
-        input_tokens = count_message_tokens(request_messages, apply_claude_correction=False)
+    # Fallback estimation must cover messages/tools/system to avoid significant undercount
+    if request_messages or request_tools or request_system:
+        request_token_stats = estimate_request_tokens(
+            messages=request_messages or [],
+            tools=request_tools,
+            system_prompt=request_system,
+            apply_claude_correction=False
+        )
+        input_tokens = request_token_stats["total_tokens"]
     
     # Track content blocks - thinking block is index 0, text block is index 1 (when thinking enabled)
     current_block_index = 0
@@ -152,6 +190,7 @@ async def stream_kiro_to_anthropic(
     
     # Track context usage for token calculation
     context_usage_percentage: Optional[float] = None
+    upstream_cache_usage: Dict[str, int] = {}
     
     # Track truncated tool calls for recovery
     truncated_tools: List[Dict[str, Any]] = []
@@ -475,6 +514,8 @@ async def stream_kiro_to_anthropic(
             
             elif event.type == "context_usage" and event.context_usage_percentage is not None:
                 context_usage_percentage = event.context_usage_percentage
+            elif event.type == "usage" and event.usage:
+                upstream_cache_usage.update(_extract_cache_usage_fields(event.usage))
         
         # Track completion signals for truncation detection
         stream_completed_normally = context_usage_percentage is not None
@@ -579,24 +620,29 @@ async def stream_kiro_to_anthropic(
         
         # Calculate total tokens from context usage if available
         if context_usage_percentage is not None:
-            prompt_tokens, total_tokens, _, _ = calculate_tokens_from_context_usage(
+            prompt_tokens, _, prompt_source, _ = calculate_tokens_from_context_usage(
                 context_usage_percentage, output_tokens, model_cache, model
             )
-            input_tokens = prompt_tokens
+            # Only override local estimate when upstream context usage is available, avoid 0% zeroing out
+            if prompt_source != "unknown":
+                input_tokens = prompt_tokens
         
         # Determine stop reason
         stop_reason = "tool_use" if tool_blocks else "end_turn"
         
         # Send message_delta with stop_reason and usage
+        usage_payload = {
+            "output_tokens": output_tokens
+        }
+        usage_payload.update(upstream_cache_usage)
+
         yield format_sse_event("message_delta", {
             "type": "message_delta",
             "delta": {
                 "stop_reason": stop_reason,
                 "stop_sequence": None
             },
-            "usage": {
-                "output_tokens": output_tokens
-            }
+            "usage": usage_payload
         })
         
         # Send message_stop
@@ -665,7 +711,9 @@ async def collect_anthropic_response(
     model: str,
     model_cache: "ModelInfoCache",
     auth_manager: "KiroAuthManager",
-    request_messages: Optional[list] = None
+    request_messages: Optional[list] = None,
+    request_tools: Optional[list] = None,
+    request_system: Optional[Any] = None
 ) -> dict:
     """
     Collect full response from Kiro stream in Anthropic format.
@@ -678,19 +726,28 @@ async def collect_anthropic_response(
         model_cache: Model cache
         auth_manager: Authentication manager
         request_messages: Original request messages (for token counting)
+        request_tools: Original request tools (for token counting)
+        request_system: Original system prompt (for token counting)
     
     Returns:
         Dictionary with full response in Anthropic Messages format
     """
     message_id = generate_message_id()
     
-    # Count input tokens
+    # Non-streaming uses the same full-request estimation as streaming
     input_tokens = 0
-    if request_messages:
-        input_tokens = count_message_tokens(request_messages, apply_claude_correction=False)
+    if request_messages or request_tools or request_system:
+        request_token_stats = estimate_request_tokens(
+            messages=request_messages or [],
+            tools=request_tools,
+            system_prompt=request_system,
+            apply_claude_correction=False
+        )
+        input_tokens = request_token_stats["total_tokens"]
     
     # Collect stream result
     result = await collect_stream_to_result(response)
+    upstream_cache_usage = _extract_cache_usage_fields(result.usage)
     
     # Build content blocks
     content_blocks = []
@@ -739,10 +796,11 @@ async def collect_anthropic_response(
     
     # Calculate from context usage if available
     if result.context_usage_percentage is not None:
-        prompt_tokens, _, _, _ = calculate_tokens_from_context_usage(
+        prompt_tokens, _, prompt_source, _ = calculate_tokens_from_context_usage(
             result.context_usage_percentage, output_tokens, model_cache, model
         )
-        input_tokens = prompt_tokens
+        if prompt_source != "unknown":
+            input_tokens = prompt_tokens
     
     # Determine stop reason
     stop_reason = "tool_use" if result.tool_calls else "end_turn"
@@ -753,6 +811,12 @@ async def collect_anthropic_response(
         f"tool_calls={len(result.tool_calls)}, stop_reason={stop_reason}"
     )
     
+    usage_payload: Dict[str, Any] = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens
+    }
+    usage_payload.update(upstream_cache_usage)
+
     return {
         "id": message_id,
         "type": "message",
@@ -761,10 +825,7 @@ async def collect_anthropic_response(
         "model": model,
         "stop_reason": stop_reason,
         "stop_sequence": None,
-        "usage": {
-            "input_tokens": input_tokens,
-            "output_tokens": output_tokens
-        }
+        "usage": usage_payload
     }
 
 
@@ -776,7 +837,8 @@ async def stream_with_first_token_retry_anthropic(
     max_retries: int = FIRST_TOKEN_MAX_RETRIES,
     first_token_timeout: float = FIRST_TOKEN_TIMEOUT,
     request_messages: Optional[list] = None,
-    request_tools: Optional[list] = None
+    request_tools: Optional[list] = None,
+    request_system: Optional[Any] = None
 ) -> AsyncGenerator[str, None]:
     """
     Streaming with automatic retry on first token timeout for Anthropic API.
@@ -796,6 +858,7 @@ async def stream_with_first_token_retry_anthropic(
         first_token_timeout: First token wait timeout (seconds)
         request_messages: Original request messages (for fallback token counting)
         request_tools: Original request tools (for fallback token counting)
+        request_system: Original system prompt (for fallback token counting)
     
     Yields:
         Strings in Anthropic SSE format
@@ -831,7 +894,9 @@ async def stream_with_first_token_retry_anthropic(
             model_cache,
             auth_manager,
             first_token_timeout=first_token_timeout,
-            request_messages=request_messages
+            request_messages=request_messages,
+            request_tools=request_tools,
+            request_system=request_system,
         ):
             yield chunk
     

--- a/kiro/tokenizer.py
+++ b/kiro/tokenizer.py
@@ -32,6 +32,7 @@ empirical observations: Claude tokenizes text approximately 15%
 more than GPT-4 (cl100k_base). This is due to differences in BPE vocabularies.
 """
 
+import json
 from typing import List, Dict, Any, Optional
 from loguru import logger
 
@@ -141,14 +142,51 @@ def count_message_tokens(messages: List[Dict[str, Any]], apply_claude_correction
             if isinstance(content, str):
                 total_tokens += count_tokens(content, apply_claude_correction=False)
             elif isinstance(content, list):
-                # Multimodal content (text + images)
+                # Support OpenAI/Anthropic multi-type content blocks
                 for item in content:
                     if isinstance(item, dict):
-                        if item.get("type") == "text":
+                        item_type = item.get("type")
+                        if item_type == "text":
                             total_tokens += count_tokens(item.get("text", ""), apply_claude_correction=False)
-                        elif item.get("type") == "image_url":
-                            # Images take ~85-170 tokens depending on size
-                            total_tokens += 100  # Average estimate
+                        elif item_type in {"image_url", "image"}:
+                            # Estimate image as fixed cost to avoid significant undercount
+                            total_tokens += 100
+                        elif item_type == "tool_use":
+                            total_tokens += count_tokens(item.get("id", ""), apply_claude_correction=False)
+                            total_tokens += count_tokens(item.get("name", ""), apply_claude_correction=False)
+                            tool_input_str = json.dumps(item.get("input", {}), ensure_ascii=False)
+                            total_tokens += count_tokens(tool_input_str, apply_claude_correction=False)
+                        elif item_type == "tool_result":
+                            total_tokens += count_tokens(item.get("tool_use_id", ""), apply_claude_correction=False)
+                            if item.get("is_error") is not None:
+                                total_tokens += count_tokens(str(item.get("is_error")), apply_claude_correction=False)
+
+                            tool_result_content = item.get("content")
+                            if isinstance(tool_result_content, str):
+                                total_tokens += count_tokens(tool_result_content, apply_claude_correction=False)
+                            elif isinstance(tool_result_content, list):
+                                for result_block in tool_result_content:
+                                    if isinstance(result_block, dict):
+                                        result_type = result_block.get("type")
+                                        if result_type == "text":
+                                            total_tokens += count_tokens(
+                                                result_block.get("text", ""),
+                                                apply_claude_correction=False
+                                            )
+                                        elif result_type in {"image_url", "image"}:
+                                            total_tokens += 100
+                                    else:
+                                        total_tokens += count_tokens(str(result_block), apply_claude_correction=False)
+                            elif tool_result_content is not None:
+                                total_tokens += count_tokens(str(tool_result_content), apply_claude_correction=False)
+                        else:
+                            # Unknown block fallback: estimate via JSON to avoid undercount
+                            total_tokens += count_tokens(
+                                json.dumps(item, ensure_ascii=False),
+                                apply_claude_correction=False
+                            )
+                    else:
+                        total_tokens += count_tokens(str(item), apply_claude_correction=False)
         
         # tool_calls tokens (if present)
         tool_calls = message.get("tool_calls")
@@ -190,24 +228,67 @@ def count_tools_tokens(tools: Optional[List[Dict[str, Any]]], apply_claude_corre
     
     for tool in tools:
         total_tokens += 4  # Service tokens
-        
-        if tool.get("type") == "function":
-            func = tool.get("function", {})
-            
-            # Function name
-            total_tokens += count_tokens(func.get("name", ""), apply_claude_correction=False)
-            
-            # Function description
-            total_tokens += count_tokens(func.get("description", ""), apply_claude_correction=False)
-            
-            # Parameters (JSON schema)
-            params = func.get("parameters")
-            if params:
-                import json
-                params_str = json.dumps(params, ensure_ascii=False)
-                total_tokens += count_tokens(params_str, apply_claude_correction=False)
+
+        # Support both OpenAI standard tools and Anthropic/OpenAI flat tools
+        if tool.get("type") == "function" and isinstance(tool.get("function"), dict):
+            tool_payload = tool.get("function", {})
+        else:
+            tool_payload = tool
+
+        # Name / description
+        total_tokens += count_tokens(tool_payload.get("name", ""), apply_claude_correction=False)
+        total_tokens += count_tokens(tool_payload.get("description", ""), apply_claude_correction=False)
+
+        # JSON schema（Anthropic: input_schema, OpenAI: parameters）
+        params = tool_payload.get("input_schema")
+        if params is None:
+            params = tool_payload.get("parameters")
+        if params is not None:
+            params_str = json.dumps(params, ensure_ascii=False)
+            total_tokens += count_tokens(params_str, apply_claude_correction=False)
     
     # Apply correction to total count
+    if apply_claude_correction:
+        return int(total_tokens * CLAUDE_CORRECTION_FACTOR)
+    return total_tokens
+
+
+def count_system_tokens(system_prompt: Optional[Any], apply_claude_correction: bool = True) -> int:
+    """
+    Counts tokens in system prompt.
+
+    Supports both plain string and Anthropic block list.
+
+    Args:
+        system_prompt: System prompt (str / list of blocks)
+        apply_claude_correction: Apply correction coefficient for Claude
+
+    Returns:
+        Approximate number of tokens
+    """
+    if not system_prompt:
+        return 0
+
+    total_tokens = 0
+
+    if isinstance(system_prompt, str):
+        total_tokens += count_tokens(system_prompt, apply_claude_correction=False)
+    elif isinstance(system_prompt, list):
+        for block in system_prompt:
+            if isinstance(block, dict):
+                # Count text content, support prompt caching structure
+                total_tokens += count_tokens(block.get("type", ""), apply_claude_correction=False)
+                total_tokens += count_tokens(block.get("text", ""), apply_claude_correction=False)
+                if block.get("cache_control") is not None:
+                    total_tokens += count_tokens(
+                        json.dumps(block.get("cache_control"), ensure_ascii=False),
+                        apply_claude_correction=False
+                    )
+            else:
+                total_tokens += count_tokens(str(block), apply_claude_correction=False)
+    else:
+        total_tokens += count_tokens(str(system_prompt), apply_claude_correction=False)
+
     if apply_claude_correction:
         return int(total_tokens * CLAUDE_CORRECTION_FACTOR)
     return total_tokens
@@ -216,7 +297,8 @@ def count_tools_tokens(tools: Optional[List[Dict[str, Any]]], apply_claude_corre
 def estimate_request_tokens(
     messages: List[Dict[str, Any]],
     tools: Optional[List[Dict[str, Any]]] = None,
-    system_prompt: Optional[str] = None
+    system_prompt: Optional[Any] = None,
+    apply_claude_correction: bool = True
 ) -> Dict[str, int]:
     """
     Estimates total number of tokens in request.
@@ -224,7 +306,8 @@ def estimate_request_tokens(
     Args:
         messages: List of messages
         tools: List of tools (optional)
-        system_prompt: System prompt (optional, if not in messages)
+        system_prompt: System prompt (optional, string or Anthropic content blocks)
+        apply_claude_correction: Apply correction coefficient for Claude
     
     Returns:
         Dictionary with token breakdown:
@@ -233,9 +316,9 @@ def estimate_request_tokens(
         - system_tokens: system prompt tokens
         - total_tokens: total count
     """
-    messages_tokens = count_message_tokens(messages)
-    tools_tokens = count_tools_tokens(tools)
-    system_tokens = count_tokens(system_prompt) if system_prompt else 0
+    messages_tokens = count_message_tokens(messages, apply_claude_correction=apply_claude_correction)
+    tools_tokens = count_tools_tokens(tools, apply_claude_correction=apply_claude_correction)
+    system_tokens = count_system_tokens(system_prompt, apply_claude_correction=apply_claude_correction)
     
     return {
         "messages_tokens": messages_tokens,

--- a/tests/unit/test_streaming_anthropic.py
+++ b/tests/unit/test_streaming_anthropic.py
@@ -682,7 +682,7 @@ class TestCollectAnthropicResponse:
         print("Action: Collecting Anthropic response...")
         
         with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
-            with patch('kiro.streaming_anthropic.count_message_tokens', return_value=10):
+            with patch('kiro.streaming_anthropic.estimate_request_tokens', return_value={"total_tokens": 10}):
                 with patch('kiro.streaming_anthropic.count_tokens', return_value=5):
                     result = await collect_anthropic_response(
                         mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager,
@@ -1101,17 +1101,105 @@ class TestStreamingAnthropicContextUsage:
         
         with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
             with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
-                with patch('kiro.streaming_anthropic.count_message_tokens', return_value=10) as mock_count:
+                with patch('kiro.streaming_anthropic.estimate_request_tokens', return_value={"total_tokens": 10}) as mock_estimate:
                     async for event in stream_kiro_to_anthropic(
                         mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager,
                         request_messages=request_messages
                     ):
                         events.append(event)
                     
-                    # Verify count_message_tokens was called
-                    mock_count.assert_called_once_with(request_messages, apply_claude_correction=False)
+                    # Verify estimate_request_tokens was called
+                    mock_estimate.assert_called_once_with(
+                        messages=request_messages,
+                        tools=None,
+                        system_prompt=None,
+                        apply_claude_correction=False
+                    )
         
         print("✓ Request messages used for input token count")
+
+    @pytest.mark.asyncio
+    async def test_uses_tools_and_system_for_input_tokens(self, mock_response, mock_model_cache, mock_auth_manager):
+        """
+        What it does: Includes request tools and system in input token estimation.
+        Goal: Verify Anthropic fallback token counting uses full request.
+        """
+        print("Setup: Mock stream...")
+
+        async def mock_parse_kiro_stream(*args, **kwargs):
+            yield KiroEvent(type="content", content="Hello")
+
+        request_messages = [{"role": "user", "content": "Hi"}]
+        request_tools = [{"name": "get_weather", "input_schema": {"type": "object"}}]
+        request_system = [{"type": "text", "text": "你是助手"}]
+
+        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
+            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+                with patch('kiro.streaming_anthropic.estimate_request_tokens', return_value={"total_tokens": 12}) as mock_estimate:
+                    events = []
+                    async for event in stream_kiro_to_anthropic(
+                        mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager,
+                        request_messages=request_messages,
+                        request_tools=request_tools,
+                        request_system=request_system,
+                    ):
+                        events.append(event)
+
+                    assert events, "Should produce streaming events"
+                    mock_estimate.assert_called_once_with(
+                        messages=request_messages,
+                        tools=request_tools,
+                        system_prompt=request_system,
+                        apply_claude_correction=False
+                    )
+        print("✓ Request tools and system included in token count")
+
+    @pytest.mark.asyncio
+    async def test_context_usage_zero_keeps_fallback_estimate(self, mock_response, mock_model_cache, mock_auth_manager):
+        """
+        What it does: Keeps fallback estimate when context usage is 0.
+        Goal: Prevent overriding with zero prompt tokens.
+        """
+        async def mock_parse_kiro_stream(*args, **kwargs):
+            yield KiroEvent(type="content", content="Hello")
+            yield KiroEvent(type="context_usage", context_usage_percentage=0.0)
+
+        events = []
+        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
+            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+                with patch('kiro.streaming_anthropic.estimate_request_tokens', return_value={"total_tokens": 99}):
+                    async for event in stream_kiro_to_anthropic(
+                        mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager,
+                        request_messages=[{"role": "user", "content": "hi"}]
+                    ):
+                        events.append(event)
+
+        message_start_event = next(e for e in events if "event: message_start" in e)
+        assert '"input_tokens": 99' in message_start_event
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_passes_upstream_cache_usage_fields(self, mock_response, mock_model_cache, mock_auth_manager):
+        """
+        What it does: Passes through upstream cache usage fields when available.
+        Goal: Ensure no fake values, only real upstream usage keys.
+        """
+        mock_result = MagicMock(
+            content="done",
+            thinking_content="",
+            tool_calls=[],
+            context_usage_percentage=None,
+            usage={"cacheReadInputTokens": 12, "cacheCreationInputTokens": 34},
+        )
+
+        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+            with patch('kiro.streaming_anthropic.generate_message_id', return_value="msg_test"):
+                response_data = await collect_anthropic_response(
+                    mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                )
+
+        usage = response_data["usage"]
+        assert usage["cache_read_input_tokens"] == 12
+        assert usage["cache_creation_input_tokens"] == 34
 
 
 # ==================================================================================================

--- a/tests/unit/test_tokenizer.py
+++ b/tests/unit/test_tokenizer.py
@@ -19,6 +19,7 @@ from kiro.tokenizer import (
     count_tokens,
     count_message_tokens,
     count_tools_tokens,
+    count_system_tokens,
     estimate_request_tokens,
     CLAUDE_CORRECTION_FACTOR,
     _get_encoding
@@ -356,6 +357,41 @@ class TestCountMessageTokens:
         
         assert result > 0, "Сообщение с None content должно иметь служебные токены"
 
+    def test_anthropic_tool_use_and_tool_result_blocks(self):
+        """
+        Что он делает: Проверяет подсчёт Anthropic блоков tool_use/tool_result.
+        Цель: Убедиться, что ключевые блоки Claude Code не теряются в подсчёте.
+        """
+        print("Тест: Anthropic tool_use/tool_result блоки...")
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_123",
+                        "name": "get_weather",
+                        "input": {"city": "Tokyo"}
+                    }
+                ]
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_123",
+                        "content": [{"type": "text", "text": "晴天 26C"}],
+                        "is_error": False
+                    }
+                ]
+            }
+        ]
+
+        result = count_message_tokens(messages, apply_claude_correction=False)
+        print(f"Результат: {result}")
+        assert result > 0
+
 
 class TestCountToolsTokens:
     """Тесты для функции count_tools_tokens."""
@@ -569,6 +605,115 @@ class TestCountToolsTokens:
         
         assert with_correction > without_correction, "С коррекцией должно быть больше"
 
+    def test_openai_flat_tool_format(self):
+        """
+        Что он делает: Проверяет подсчёт токенов для flat/Cursor-style инструмента.
+        Цель: Убедиться, что формат без type=function тоже учитывается.
+        """
+        tools = [
+            {
+                "name": "search_docs",
+                "description": "Search docs by keyword",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"]
+                }
+            }
+        ]
+
+        result = count_tools_tokens(tools, apply_claude_correction=False)
+        assert result > 4  # Must exceed base service overhead, proving name/description/schema are counted
+
+    def test_anthropic_flat_and_openai_function_are_close(self):
+        """
+        Что он делает: Сравнивает Anthropic flat и OpenAI function форматы.
+        Цель: Prevent Anthropic tools from regressing to base-overhead-only counting.
+        """
+        shared_schema = {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "recursive": {"type": "boolean", "description": "Recursive search"}
+            },
+            "required": ["path"]
+        }
+        openai_tools = [{
+            "type": "function",
+            "function": {
+                "name": "search_files",
+                "description": "Search files",
+                "parameters": shared_schema
+            }
+        }]
+        anthropic_tools = [{
+            "name": "search_files",
+            "description": "Search files",
+            "input_schema": shared_schema
+        }]
+
+        openai_tokens = count_tools_tokens(openai_tools, apply_claude_correction=False)
+        anthropic_tokens = count_tools_tokens(anthropic_tools, apply_claude_correction=False)
+
+        assert openai_tokens > 4
+        assert anthropic_tokens > 4
+        diff_ratio = abs(openai_tokens - anthropic_tokens) / max(openai_tokens, anthropic_tokens)
+        assert diff_ratio < 0.15
+
+
+class TestCountSystemTokens:
+    """Tests for count_system_tokens function."""
+
+    def test_none_returns_zero(self):
+        """Checks that None returns 0."""
+        assert count_system_tokens(None) == 0
+
+    def test_empty_string_returns_zero(self):
+        """Checks that empty string returns 0."""
+        assert count_system_tokens("") == 0
+
+    def test_plain_string(self):
+        """Checks that plain string is counted correctly."""
+        result = count_system_tokens("You are a helpful assistant.", apply_claude_correction=False)
+        assert result > 0
+
+    def test_dict_block_list(self):
+        """Checks that Anthropic dict block list is counted correctly."""
+        blocks = [
+            {"type": "text", "text": "You are a helpful assistant."},
+            {"type": "text", "text": "Be concise.", "cache_control": {"type": "ephemeral"}},
+        ]
+        result = count_system_tokens(blocks, apply_claude_correction=False)
+        assert result > 0
+        # Should be greater than single block result
+        single = count_system_tokens([blocks[0]], apply_claude_correction=False)
+        assert result > single
+
+    def test_dict_block_with_cache_control(self):
+        """Checks that cache_control field is counted in tokens."""
+        without_cache = [{"type": "text", "text": "Hello"}]
+        with_cache = [{"type": "text", "text": "Hello", "cache_control": {"type": "ephemeral"}}]
+        r1 = count_system_tokens(without_cache, apply_claude_correction=False)
+        r2 = count_system_tokens(with_cache, apply_claude_correction=False)
+        assert r2 > r1
+
+    def test_non_dict_block_fallback(self):
+        """Checks that non-dict elements fall back to str()."""
+        result = count_system_tokens([42, "text"], apply_claude_correction=False)
+        assert result > 0
+
+    def test_unknown_type_fallback(self):
+        """Checks that non-str/list types fall back to str()."""
+        result = count_system_tokens(12345, apply_claude_correction=False)
+        assert result > 0
+
+    def test_claude_correction_applied(self):
+        """Checks that Claude correction coefficient is applied."""
+        text = "You are a helpful assistant that answers questions about programming and software engineering."
+        without = count_system_tokens(text, apply_claude_correction=False)
+        with_corr = count_system_tokens(text, apply_claude_correction=True)
+        assert with_corr > without
+
 
 class TestEstimateRequestTokens:
     """Тесты для функции estimate_request_tokens."""
@@ -634,6 +779,24 @@ class TestEstimateRequestTokens:
         assert result["messages_tokens"] > 0
         assert result["system_tokens"] > 0
         assert result["total_tokens"] == result["messages_tokens"] + result["system_tokens"]
+
+    def test_anthropic_system_blocks(self):
+        """
+        Что он делает: Проверяет оценку токенов для Anthropic system block списка.
+        Цель: Убедиться, что system блоки тоже считаются.
+        """
+        print("Тест: Anthropic system blocks...")
+        messages = [{"role": "user", "content": "Hello!"}]
+        system_prompt = [
+            {"type": "text", "text": "你是 Claude Code"},
+            {"type": "text", "text": "Follow tools strictly", "cache_control": {"type": "ephemeral"}},
+        ]
+
+        result = estimate_request_tokens(messages, system_prompt=system_prompt, apply_claude_correction=False)
+        print(f"Результат: {result}")
+
+        assert result["system_tokens"] > 0
+        assert result["total_tokens"] == result["messages_tokens"] + result["system_tokens"]
     
     def test_full_request(self):
         """
@@ -666,6 +829,43 @@ class TestEstimateRequestTokens:
         
         expected_total = result["messages_tokens"] + result["tools_tokens"] + result["system_tokens"]
         assert result["total_tokens"] == expected_total, "Total должен быть суммой компонентов"
+
+    def test_anthropic_messages_with_flat_tools(self):
+        """
+        Что он делает: Simulates Anthropic /v1/messages with tools+system scenario.
+        Цель: Verify estimate_request_tokens no longer undercounts flat tools.
+        """
+        messages = [
+            {"role": "user", "content": "请先读取项目结构，再回答。"}
+        ]
+        tools = [
+            {
+                "name": "read_file",
+                "description": "Read a file from workspace",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string", "description": "Absolute path"}
+                    },
+                    "required": ["path"]
+                }
+            }
+        ]
+        system_prompt = [{"type": "text", "text": "你是代码助手。"}]
+
+        result = estimate_request_tokens(
+            messages,
+            tools=tools,
+            system_prompt=system_prompt,
+            apply_claude_correction=False
+        )
+
+        assert result["messages_tokens"] > 0
+        assert result["tools_tokens"] > 4
+        assert result["system_tokens"] > 0
+        assert result["total_tokens"] == (
+            result["messages_tokens"] + result["tools_tokens"] + result["system_tokens"]
+        )
     
     def test_empty_messages(self):
         """


### PR DESCRIPTION
## Summary

The Anthropic API path (`/v1/messages`) significantly underreports `input_tokens` due to multiple token counting gaps. This PR fixes all of them in a single focused change.

### Problems Fixed

1. **`count_message_tokens` ignores Anthropic content blocks** — Only `text` and `image_url` were handled. `tool_use`, `tool_result`, `image`, and unknown block types were silently skipped, causing token undercount in conversations with tool calls.

2. **`count_tools_tokens` ignores Anthropic flat tool format** — Only OpenAI `{"type": "function", "function": {...}}` format was recognized. Anthropic flat tools (top-level `name`/`description`/`input_schema`) were counted as 4 service tokens only, missing all actual content.

3. **`estimate_request_tokens` called with messages only** — `stream_kiro_to_anthropic` and `collect_anthropic_response` used `count_message_tokens(messages)` instead of `estimate_request_tokens(messages, tools, system)`, completely ignoring tools and system prompt in the fallback estimate.

4. **No support for Anthropic system block list** — `count_system_tokens` did not exist. When system prompt was passed as a list of content blocks (for prompt caching), it was not counted at all.

5. **`context_usage=0%` zeroes out fallback estimate** — `calculate_tokens_from_context_usage` returns `(0, ..., "unknown", ...)` when percentage is 0, but the code unconditionally overwrote the local estimate, setting `input_tokens` to 0.

6. **`AnthropicUsage` drops cache usage fields** — The model lacked `cache_read_input_tokens` and `cache_creation_input_tokens` fields and did not allow extra fields, so upstream cache usage was silently dropped.

7. **Cache usage never forwarded to client** — Neither streaming nor non-streaming responses included `cache_read_input_tokens` / `cache_creation_input_tokens` from upstream Kiro responses.

### Changes

| File | Change |
|------|--------|
| `kiro/tokenizer.py` | Support `tool_use`/`tool_result`/`image` blocks in `count_message_tokens`; support Anthropic flat tool format in `count_tools_tokens`; add `count_system_tokens` for block list format; propagate `apply_claude_correction` in `estimate_request_tokens` |
| `kiro/streaming_anthropic.py` | Accept `request_tools`/`request_system` params; use `estimate_request_tokens` instead of `count_message_tokens`; guard context_usage override with source check; add `_extract_cache_usage_fields` to forward cache usage (supports both camelCase and snake_case keys) |
| `kiro/routes_anthropic.py` | Serialize tools and system prompt (including Pydantic objects) for tokenizer |
| `kiro/models_anthropic.py` | Add `cache_read_input_tokens`/`cache_creation_input_tokens` optional fields and `extra="allow"` to `AnthropicUsage` |

### Test Coverage

13 new tests added:

- `TestCountSystemTokens` (8 tests) — None, empty, plain string, dict block list, cache_control counting, non-dict fallback, unknown type fallback, Claude correction
- `test_openai_flat_tool_format` — Flat tool format token count exceeds base overhead
- `test_anthropic_flat_and_openai_function_are_close` — Both formats produce similar counts (<15% diff)
- `test_anthropic_messages_with_flat_tools` — Full request estimation with flat tools + system
- `test_context_usage_zero_keeps_fallback_estimate` — 0% context usage preserves fallback
- `test_non_streaming_passes_upstream_cache_usage_fields` — Cache fields forwarded in non-streaming

All 1448 existing + new tests pass.

## Test plan

- [x] `pytest -v` — all 1448 tests pass
- [ ] Manual test with Anthropic SDK client using tool calls — verify `input_tokens` is no longer near-zero
- [ ] Manual test with prompt caching (`cache_control`) — verify `cache_read_input_tokens` appears in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)