### PR TITLE
fix(streaming): missing import for stream_with_first_token_retry_anthropic

### DIFF
--- a/kiro/routes_anthropic.py
+++ b/kiro/routes_anthropic.py
@@ -47,6 +47,7 @@ from kiro.converters_anthropic import anthropic_to_kiro
 from kiro.streaming_anthropic import (
     stream_kiro_to_anthropic,
     collect_anthropic_response,
+    stream_with_first_token_retry_anthropic,
 )
 from kiro.http_client import KiroHttpClient
 from kiro.utils import generate_conversation_id


### PR DESCRIPTION
This PR fixes a NameError in `kiro/routes_anthropic.py` where `stream_with_first_token_retry_anthropic` was being called but not imported. Tests have been run and they pass successfully.