### PR TITLE
fix(auth): properly strip Bearer prefix in API key validation

### DIFF
--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -79,7 +79,8 @@ async def verify_api_key(auth_header: str = Security(api_key_header)) -> bool:
     Raises:
         HTTPException: 401 if key is invalid or missing
     """
-    if not auth_header or auth_header != f"Bearer {PROXY_API_KEY}":
+    token = auth_header.removeprefix("Bearer ") if auth_header else None
+    if not token or token != PROXY_API_KEY:
         logger.warning("Access attempt with invalid API key.")
         raise HTTPException(status_code=401, detail="Invalid or missing API Key")
     return True


### PR DESCRIPTION
## Summary

Fixes the API key validation logic in `verify_api_key` to correctly strip the `Bearer ` prefix before comparing the token.

Previously, the code compared the full `Authorization` header value (e.g., `Bearer sk-...`) directly against `Bearer {PROXY_API_KEY}`. This meant that if a client sent a token without the exact prefix formatting, validation would fail even with a valid key.

## Changes

- Use `str.removeprefix("Bearer ")` to extract the raw token
- Compare the extracted token directly against `PROXY_API_KEY`

## Files Changed

- `kiro/routes_openai.py`

## Testing

- Verify that requests with `Authorization: Bearer <key>` succeed
- Verify that requests with an invalid or missing token still return 401
