### PR TITLE
fix(anthropic): include tool_use content in output_tokens calculation

### DIFF
--- a/kiro/streaming_anthropic.py
+++ b/kiro/streaming_anthropic.py
@@ -621,8 +621,12 @@ async def stream_kiro_to_anthropic(
                 f"{'Model will be notified automatically about truncation.' if TRUNCATION_RECOVERY else 'Set TRUNCATION_RECOVERY=true in .env to auto-notify model about truncation.'}"
             )
         
-        # Calculate output tokens
-        output_tokens = count_tokens(full_content + full_thinking_content)
+        # Calculate output tokens (include tool_use block content)
+        tool_content = ""
+        for tb in tool_blocks:
+            tool_content += json.dumps(tb.get("input", {}), ensure_ascii=False)
+            tool_content += tb.get("name", "")
+        output_tokens = count_tokens(full_content + full_thinking_content + tool_content)
         
         # Calculate total tokens from context usage if available
         if context_usage_percentage is not None:
@@ -803,8 +807,13 @@ async def collect_anthropic_response(
             "input": tool_input
         })
     
-    # Calculate output tokens
-    output_tokens = count_tokens(result.content + result.thinking_content)
+    # Calculate output tokens (include tool_use block content)
+    tool_content = ""
+    for tc in result.tool_calls:
+        func = tc.get("function", {})
+        tool_content += func.get("name", "")
+        tool_content += func.get("arguments", "")
+    output_tokens = count_tokens(result.content + result.thinking_content + tool_content)
     
     # Calculate from context usage if available
     if result.context_usage_percentage is not None:

--- a/kiro/streaming_openai.py
+++ b/kiro/streaming_openai.py
@@ -301,8 +301,13 @@ async def stream_kiro_to_openai_internal(
         else:
             finish_reason = "stop"
         
-        # Count completion_tokens (output) using tiktoken
-        completion_tokens = count_tokens(full_content + full_thinking_content)
+        # Count completion_tokens (output) using tiktoken (include tool_use content)
+        tool_content = ""
+        for tc in all_tool_calls:
+            func = tc.get("function", {})
+            tool_content += func.get("name", "")
+            tool_content += func.get("arguments", "")
+        completion_tokens = count_tokens(full_content + full_thinking_content + tool_content)
         
         # Calculate total_tokens based on context_usage_percentage from Kiro API
         # context_usage shows TOTAL percentage of context usage (input + output)


### PR DESCRIPTION
## Summary

- `output_tokens` / `completion_tokens` calculation was ignoring tool_use block content (tool name + input arguments JSON), only counting text and thinking content
- A `write_file` tool call with ~4500 chars of content was reporting only 26 output_tokens instead of ~1300+
- Fixed all three code paths:
  - **Anthropic streaming** (`stream_kiro_to_anthropic`): includes `tool_blocks` content in `count_tokens()`
  - **Anthropic non-streaming** (`collect_anthropic_response`): includes `result.tool_calls` content in `count_tokens()`
  - **OpenAI streaming** (`stream_kiro_to_openai`): includes `all_tool_calls` content in `count_tokens()`. The non-streaming path (`collect_stream_response`) reads usage from streaming output, so it's automatically fixed.

## Root Cause

In all three paths, output tokens were calculated as:

```python
output_tokens = count_tokens(full_content + full_thinking_content)
```

When the response contains `tool_use` blocks, the tool name and input arguments were never fed into `count_tokens()`. For tool-only responses (no text), `full_content` is empty, resulting in near-zero output token counts.

## Test Results

| Protocol | Mode | Before | After |
|----------|------|--------|-------|
| Anthropic | streaming | 26 tokens | ~1334 tokens |
| Anthropic | non-streaming | 26 tokens | ~1334 tokens |
| OpenAI | streaming | ~26 tokens | ~2147 tokens |
| OpenAI | non-streaming | ~26 tokens | ~2158 tokens |

(All tests used a `write_file` tool call generating a Flask CRUD app, ~4500-6000 chars of tool input)

## Test plan

- [x] Anthropic streaming: tool_use response token count verified
- [x] Anthropic non-streaming: tool_use response token count verified
- [x] OpenAI streaming: tool_use response token count verified
- [x] OpenAI non-streaming: tool_use response token count verified
- [x] Text-only responses unaffected (no tool_blocks = no change)