### PR TITLE
fix: send profileArn for SSO OIDC users with explicit PROFILE_ARN config

### DIFF
--- a/kiro/routes_anthropic.py
+++ b/kiro/routes_anthropic.py
@@ -34,7 +34,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import APIKeyHeader
 from loguru import logger
 
-from kiro.config import PROXY_API_KEY
+from kiro.config import PROXY_API_KEY, PROFILE_ARN
 from kiro.models_anthropic import (
     AnthropicMessagesRequest,
     AnthropicCountTokensRequest,
@@ -379,6 +379,8 @@ async def messages(
             profile_arn_for_payload = ""
             if auth_manager.auth_type == AuthType.KIRO_DESKTOP and auth_manager.profile_arn:
                 profile_arn_for_payload = auth_manager.profile_arn
+            elif PROFILE_ARN:
+                profile_arn_for_payload = PROFILE_ARN
             
             try:
                 kiro_payload = anthropic_to_kiro(
@@ -689,7 +691,9 @@ async def messages(
     profile_arn_for_payload = ""
     if auth_manager.auth_type == AuthType.KIRO_DESKTOP and auth_manager.profile_arn:
         profile_arn_for_payload = auth_manager.profile_arn
-    
+    elif PROFILE_ARN:
+        profile_arn_for_payload = PROFILE_ARN
+
     try:
         kiro_payload = anthropic_to_kiro(
             request_data,

--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -37,6 +37,7 @@ from loguru import logger
 from kiro.config import (
     PROXY_API_KEY,
     APP_VERSION,
+    PROFILE_ARN,
 )
 from kiro.models_openai import (
     OpenAIModel,
@@ -325,6 +326,8 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
             profile_arn_for_payload = ""
             if auth_manager.auth_type == AuthType.KIRO_DESKTOP and auth_manager.profile_arn:
                 profile_arn_for_payload = auth_manager.profile_arn
+            elif PROFILE_ARN:
+                profile_arn_for_payload = PROFILE_ARN
             
             try:
                 kiro_payload = build_kiro_payload(
@@ -576,7 +579,9 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
     profile_arn_for_payload = ""
     if auth_manager.auth_type == AuthType.KIRO_DESKTOP and auth_manager.profile_arn:
         profile_arn_for_payload = auth_manager.profile_arn
-    
+    elif PROFILE_ARN:
+        profile_arn_for_payload = PROFILE_ARN
+
     try:
         kiro_payload = build_kiro_payload(
             request_data,


### PR DESCRIPTION
## Summary

- Users authenticating via AWS IAM Identity Center (SSO OIDC) with a Kiro Pro+ subscription set up through the AWS Console need `profileArn` in the request payload for usage to be tracked in the Kiro dashboard
- Previously `profileArn` was intentionally skipped for all SSO OIDC auth types (correct for Builder ID / free tier users, but wrong for Pro+ IAM Identity Center users)
- This fix sends `PROFILE_ARN` from `.env` when explicitly set, regardless of auth type

## Why this is safe

- Completely opt-in - only fires when `PROFILE_ARN` is explicitly set in `.env`
- Users who don't set `PROFILE_ARN` are unaffected - the `elif PROFILE_ARN:` branch never executes when the value is empty (the default)
- Existing Builder ID / free tier SSO OIDC users see no change in behaviour

## Use case

AWS Console -> Kiro -> Pro+ subscription with IAM Identity Center auth. The `profileArn` is required to attribute usage to the Pro+ account. Without it, requests go through as untracked free tier usage and the dashboard shows no activity.

## Test plan

- Set `PROFILE_ARN` in `.env` and verify `profileArn` appears in `debug_logs/kiro_request_body.json`
- Leave `PROFILE_ARN` unset and verify existing behaviour is unchanged
- Confirm usage appears in Kiro dashboard after setting `PROFILE_ARN`