### PR TITLE
fix(config): migrate API endpoints to runtime.kiro.dev

### DIFF
--- a/kiro/config.py
+++ b/kiro/config.py
@@ -176,13 +176,12 @@ KIRO_REFRESH_URL_TEMPLATE: str = "https://prod.{region}.auth.desktop.kiro.dev/re
 AWS_SSO_OIDC_URL_TEMPLATE: str = "https://oidc.{region}.amazonaws.com/token"
 
 # Host for main API (generateAssistantResponse)
-# Universal endpoint for all regions (us-east-1, eu-central-1, etc.)
-# See: https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/security-data-perimeter.html
-# Fixed in issue #58 - codewhisperer.{region}.amazonaws.com doesn't exist for non-us-east-1 regions
-KIRO_API_HOST_TEMPLATE: str = "https://q.{region}.amazonaws.com"
+# Migrated to kiro.dev endpoints per AWS notice (effective May 15, 2026)
+# See: https://github.com/jwadow/kiro-gateway/issues/146
+KIRO_API_HOST_TEMPLATE: str = "https://runtime.{region}.kiro.dev"
 
 # Host for Q API (ListAvailableModels)
-KIRO_Q_HOST_TEMPLATE: str = "https://q.{region}.amazonaws.com"
+KIRO_Q_HOST_TEMPLATE: str = "https://runtime.{region}.kiro.dev"
 
 # ==================================================================================================
 # Token Settings

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -483,9 +483,9 @@ class TestKiroAuthManagerProperties:
             region="us-east-1"
         )
         
-        print("Verification: api_host contains q.{region}.amazonaws.com pattern...")
+        print("Verification: api_host contains runtime.{region}.kiro.dev pattern...")
         print(f"api_host: {manager.api_host}")
-        assert "q.us-east-1.amazonaws.com" in manager.api_host
+        assert "runtime.us-east-1.kiro.dev" in manager.api_host
         assert "us-east-1" in manager.api_host
     
     def test_fingerprint_property(self):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -969,3 +969,72 @@ class TestAccountSystemConfig:
         
         print(f"Comparing STATE_SAVE_INTERVAL_SECONDS: Expected 10, Got {config_module.STATE_SAVE_INTERVAL_SECONDS}")
         assert config_module.STATE_SAVE_INTERVAL_SECONDS == 10
+
+
+class TestKiroApiHostConfig:
+    """Tests for Kiro API host endpoint migration to kiro.dev."""
+
+    def test_kiro_api_host_template_uses_kiro_dev(self):
+        """
+        What it does: Verifies KIRO_API_HOST_TEMPLATE points to runtime.kiro.dev.
+        Purpose: Ensure endpoint migration from q.amazonaws.com to kiro.dev (issue #146).
+        """
+        from kiro.config import KIRO_API_HOST_TEMPLATE
+
+        assert "runtime" in KIRO_API_HOST_TEMPLATE
+        assert "kiro.dev" in KIRO_API_HOST_TEMPLATE
+        assert "amazonaws.com" not in KIRO_API_HOST_TEMPLATE
+        assert "{region}" in KIRO_API_HOST_TEMPLATE
+
+    def test_kiro_q_host_template_uses_kiro_dev(self):
+        """
+        What it does: Verifies KIRO_Q_HOST_TEMPLATE points to runtime.kiro.dev.
+        Purpose: Ensure endpoint migration from q.amazonaws.com to kiro.dev (issue #146).
+        """
+        from kiro.config import KIRO_Q_HOST_TEMPLATE
+
+        assert "runtime" in KIRO_Q_HOST_TEMPLATE
+        assert "kiro.dev" in KIRO_Q_HOST_TEMPLATE
+        assert "amazonaws.com" not in KIRO_Q_HOST_TEMPLATE
+        assert "{region}" in KIRO_Q_HOST_TEMPLATE
+
+    def test_get_kiro_api_host_formats_region_us_east_1(self):
+        """
+        What it does: Verifies get_kiro_api_host returns correct URL for us-east-1.
+        Purpose: Ensure the function formats the new kiro.dev URL correctly.
+        """
+        from kiro.config import get_kiro_api_host
+
+        url = get_kiro_api_host("us-east-1")
+        assert url == "https://runtime.us-east-1.kiro.dev"
+
+    def test_get_kiro_api_host_formats_region_eu_central_1(self):
+        """
+        What it does: Verifies get_kiro_api_host returns correct URL for eu-central-1.
+        Purpose: Ensure the function works with EU region (both supported regions per AWS notice).
+        """
+        from kiro.config import get_kiro_api_host
+
+        url = get_kiro_api_host("eu-central-1")
+        assert url == "https://runtime.eu-central-1.kiro.dev"
+
+    def test_get_kiro_q_host_formats_region(self):
+        """
+        What it does: Verifies get_kiro_q_host returns correct URL.
+        Purpose: Ensure Q host also uses the new kiro.dev endpoint.
+        """
+        from kiro.config import get_kiro_q_host
+
+        url = get_kiro_q_host("us-east-1")
+        assert url == "https://runtime.us-east-1.kiro.dev"
+
+    def test_auth_endpoints_unchanged(self):
+        """
+        What it does: Verifies auth/SSO endpoints are NOT migrated.
+        Purpose: Per AWS notice, authentication and SSO endpoints are not affected.
+        """
+        from kiro.config import KIRO_REFRESH_URL_TEMPLATE, AWS_SSO_OIDC_URL_TEMPLATE
+
+        assert "auth.desktop.kiro.dev" in KIRO_REFRESH_URL_TEMPLATE
+        assert "oidc" in AWS_SSO_OIDC_URL_TEMPLATE
+        assert "amazonaws.com" in AWS_SSO_OIDC_URL_TEMPLATE


### PR DESCRIPTION
## Summary

Migrates `KIRO_API_HOST_TEMPLATE` and `KIRO_Q_HOST_TEMPLATE` from the legacy `q.<region>.amazonaws.com` to the new `runtime.<region>.kiro.dev` endpoint, per the AWS deprecation notice effective May 15, 2026.

Addresses #146

## What changed

- `KIRO_API_HOST_TEMPLATE`: `https://q.{region}.amazonaws.com` → `https://runtime.{region}.kiro.dev`
- `KIRO_Q_HOST_TEMPLATE`: same
- Updated `test_api_host_property` assertion in auth manager tests
- Added `TestKiroApiHostConfig` test class (6 tests)

## Test results

| Endpoint | Auth | profileArn | Result |
|----------|------|-----------|--------|
| `q.us-east-1.amazonaws.com` | OIDC (kiro-cli) | not sent | **200 OK** |
| `runtime.us-east-1.kiro.dev` | OIDC (kiro-cli) | not sent | **400** (profileArn required) |
| `runtime.us-east-1.kiro.dev` | OIDC (kiro-cli) | sent | **403** |
| `management.us-east-1.kiro.dev` | OIDC (kiro-cli) | — | **400** on `/ListAvailableModels` |

The new endpoint requires `profileArn` but rejects OIDC tokens even when it's provided. This PR works for Desktop auth users (who already have profileArn), but the migration isn't a simple URL swap for OIDC flows.

## Notes

- Auth/SSO endpoints (`oidc.<region>.amazonaws.com`, `prod.<region>.auth.desktop.kiro.dev`) are not affected per the AWS notice
- The new endpoints are already live
- Happy to iterate once we understand what the new endpoint expects from OIDC users