### PR TITLE
fix(endpoint): migrate API from q.amazonaws.com to runtime.kiro.dev

### DIFF
--- a/kiro/auth.py
+++ b/kiro/auth.py
@@ -340,7 +340,7 @@ class KiroAuthManager:
                     if 'region' in registration_data and not self._sso_region:
                         self._sso_region = registration_data['region']
                         logger.debug(f"SSO region from device-registration: {self._sso_region}")
-            
+
             # Try to auto-detect API region from profile ARN in state table
             # This is separate from SSO region because q.amazonaws.com endpoints
             # only exist in specific regions (Issue #132, #133)
@@ -351,6 +351,9 @@ class KiroAuthManager:
                     profile_data = json.loads(profile_row[0])
                     arn = profile_data.get("arn", "")
                     if arn:
+                        if not self._profile_arn:
+                            self._profile_arn = arn
+                            logger.debug(f"Profile ARN from state table: {self._profile_arn}")
                         # ARN format: arn:aws:codewhisperer:REGION:account:profile/id
                         # Extract region from 4th component (index 3)
                         parts = arn.split(":")
@@ -367,7 +370,7 @@ class KiroAuthManager:
                 logger.debug(f"Failed to parse profile data from state table: {e}")
             except Exception as e:
                 logger.debug(f"Failed to auto-detect API region from profile ARN: {e}")
-            
+
             conn.close()
             logger.info(f"Credentials loaded from SQLite database: {db_path}")
             

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -179,10 +179,10 @@ AWS_SSO_OIDC_URL_TEMPLATE: str = "https://oidc.{region}.amazonaws.com/token"
 # Universal endpoint for all regions (us-east-1, eu-central-1, etc.)
 # See: https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/security-data-perimeter.html
 # Fixed in issue #58 - codewhisperer.{region}.amazonaws.com doesn't exist for non-us-east-1 regions
-KIRO_API_HOST_TEMPLATE: str = "https://q.{region}.amazonaws.com"
+KIRO_API_HOST_TEMPLATE: str = "https://runtime.{region}.kiro.dev"
 
 # Host for Q API (ListAvailableModels)
-KIRO_Q_HOST_TEMPLATE: str = "https://q.{region}.amazonaws.com"
+KIRO_Q_HOST_TEMPLATE: str = "https://runtime.{region}.kiro.dev"
 
 # ==================================================================================================
 # Token Settings
@@ -217,12 +217,8 @@ BASE_RETRY_DELAY: float = 1.0
 # Why "hidden"? These models work but are not advertised by Kiro's /ListAvailableModels.
 # We expose them to our users because they're useful.
 HIDDEN_MODELS: Dict[str, str] = {
-    # Claude 3.7 Sonnet - legacy flagship model, still works!
-    # Hidden in Kiro API but functional. Great for users who prefer it.
-    "claude-3.7-sonnet": "CLAUDE_3_7_SONNET_20250219_V1_0",
-    
-    # Add other hidden/experimental models here as discovered.
-    # Example: "claude-secret-model": "INTERNAL_SECRET_MODEL_ID",
+    # Claude 3.7 Sonnet - legacy model, maps to "auto" on new runtime endpoint
+    "claude-3.7-sonnet": "auto",
 }
 
 # ==================================================================================================

--- a/kiro/http_client.py
+++ b/kiro/http_client.py
@@ -31,6 +31,7 @@ with connection pooling for better resource management.
 """
 
 import asyncio
+import json
 from typing import Optional
 
 import httpx
@@ -218,7 +219,7 @@ class KiroHttpClient:
                 request_kwargs = {"headers": headers}
                 
                 if json_data is not None:
-                    request_kwargs["json"] = json_data
+                    request_kwargs["content"] = json.dumps(json_data).encode()
                 
                 if params is not None:
                     request_kwargs["params"] = params

--- a/kiro/model_resolver.py
+++ b/kiro/model_resolver.py
@@ -41,6 +41,31 @@ if TYPE_CHECKING:
     from kiro.cache import ModelInfoCache
 
 
+# Valid model IDs accepted by runtime.{region}.kiro.dev
+VALID_RUNTIME_MODEL_IDS: set = {
+    "auto",
+    "claude-sonnet-4",
+    "claude-sonnet-4.5",
+    "claude-sonnet-4.6",
+    "claude-opus-4.5",
+    "claude-opus-4.6",
+    "claude-opus-4.7",
+    "claude-haiku-4.5",
+}
+
+
+def to_runtime_model_id(normalized: str) -> str:
+    """
+    Map a normalized model name to a valid runtime.kiro.dev model ID.
+
+    Returns the model as-is if it's in the valid set, otherwise "auto".
+    """
+    if normalized in VALID_RUNTIME_MODEL_IDS:
+        return normalized
+    logger.debug(f"Model '{normalized}' not valid for runtime endpoint, defaulting to 'auto'")
+    return "auto"
+
+
 @dataclass(frozen=True)
 class ModelResolution:
     """
@@ -103,7 +128,10 @@ def normalize_model_name(name: str) -> str:
     """
     if not name:
         return name
-    
+
+    # Strip context window suffix (e.g., [1m], [200k]) — client-side indicator, not a model ID
+    name = re.sub(r'\[\d+[mk]\]$', '', name, flags=re.IGNORECASE)
+
     # Lowercase for consistent matching
     name_lower = name.lower()
     
@@ -188,7 +216,8 @@ def get_model_id_for_kiro(model_name: str, hidden_models: Dict[str, str]) -> str
         'CLAUDE_3_7_SONNET_20250219_V1_0'
     """
     normalized = normalize_model_name(model_name)
-    return hidden_models.get(normalized, normalized)
+    internal = hidden_models.get(normalized, normalized)
+    return to_runtime_model_id(internal)
 
 
 def extract_model_family(model_name: str) -> Optional[str]:
@@ -301,40 +330,42 @@ class ModelResolver:
         # Layer 2: Check dynamic cache (from /ListAvailableModels)
         if self.cache.is_valid_model(normalized):
             logger.debug(f"Model '{normalized}' found in dynamic cache")
+            runtime_id = to_runtime_model_id(normalized)
             return ModelResolution(
-                internal_id=normalized,
+                internal_id=runtime_id,
                 source="cache",
                 original_request=external_model,
                 normalized=normalized,
                 is_verified=True
             )
-        
+
         # Layer 3: Check hidden models
         if normalized in self.hidden_models:
             internal_id = self.hidden_models[normalized]
+            runtime_id = to_runtime_model_id(internal_id)
             logger.debug(
-                f"Model '{normalized}' found in hidden models → '{internal_id}'"
+                f"Model '{normalized}' found in hidden models → '{runtime_id}'"
             )
             return ModelResolution(
-                internal_id=internal_id,
+                internal_id=runtime_id,
                 source="hidden",
                 original_request=external_model,
                 normalized=normalized,
                 is_verified=True
             )
-        
-        # Layer 4: Pass-through - let Kiro decide!
-        # We don't know all models, Kiro might have hidden ones
+
+        # Layer 4: Pass-through - validate for runtime endpoint
+        runtime_id = to_runtime_model_id(normalized)
         logger.info(
             f"Model '{external_model}' (normalized: '{normalized}') not in cache, "
-            f"passing through to Kiro API"
+            f"mapped to runtime ID: '{runtime_id}'"
         )
         return ModelResolution(
-            internal_id=normalized,  # Send normalized name to Kiro
+            internal_id=runtime_id,
             source="passthrough",
             original_request=external_model,
             normalized=normalized,
-            is_verified=False  # Not verified locally, Kiro will judge
+            is_verified=False
         )
     
     def get_available_models(self) -> List[str]:

--- a/kiro/routes_anthropic.py
+++ b/kiro/routes_anthropic.py
@@ -685,10 +685,8 @@ async def messages(
     conversation_id = generate_conversation_id()
     
     # Build payload for Kiro
-    # profileArn is only needed for Kiro Desktop auth
-    profile_arn_for_payload = ""
-    if auth_manager.auth_type == AuthType.KIRO_DESKTOP and auth_manager.profile_arn:
-        profile_arn_for_payload = auth_manager.profile_arn
+    # profileArn is required by runtime.kiro.dev for all auth types
+    profile_arn_for_payload = auth_manager.profile_arn or ""
     
     try:
         kiro_payload = anthropic_to_kiro(

--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -571,11 +571,8 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
     conversation_id = generate_conversation_id()
     
     # Build payload for Kiro
-    # profileArn is only needed for Kiro Desktop auth
-    # AWS SSO OIDC (Builder ID) users don't need profileArn and it causes 403 if sent
-    profile_arn_for_payload = ""
-    if auth_manager.auth_type == AuthType.KIRO_DESKTOP and auth_manager.profile_arn:
-        profile_arn_for_payload = auth_manager.profile_arn
+    # profileArn is required by runtime.kiro.dev for all auth types
+    profile_arn_for_payload = auth_manager.profile_arn or ""
     
     try:
         kiro_payload = build_kiro_payload(

--- a/kiro/utils.py
+++ b/kiro/utils.py
@@ -78,7 +78,8 @@ def get_kiro_headers(auth_manager: "KiroAuthManager", token: str) -> dict:
     
     return {
         "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json",
+        "Content-Type": "application/x-amz-json-1.0",
+        "x-amz-target": "AmazonCodeWhispererStreamingService.GenerateAssistantResponse",
         "User-Agent": f"aws-sdk-js/1.0.27 ua/2.1 os/win32#10.0.19044 lang/js md/nodejs#22.21.1 api/codewhispererstreaming#1.0.27 m/E KiroIDE-0.7.45-{fingerprint}",
         "x-amz-user-agent": f"aws-sdk-js/1.0.27 KiroIDE-0.7.45-{fingerprint}",
         "x-amzn-codewhisperer-optout": "true",

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -483,9 +483,9 @@ class TestKiroAuthManagerProperties:
             region="us-east-1"
         )
         
-        print("Verification: api_host contains q.{region}.amazonaws.com pattern...")
+        print("Verification: api_host contains runtime.{region}.kiro.dev pattern...")
         print(f"api_host: {manager.api_host}")
-        assert "q.us-east-1.amazonaws.com" in manager.api_host
+        assert "runtime.us-east-1.kiro.dev" in manager.api_host
         assert "us-east-1" in manager.api_host
     
     def test_fingerprint_property(self):

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -6,6 +6,7 @@ Tests retry logic, error handling, and HTTP client management.
 """
 
 import asyncio
+import json
 import pytest
 from unittest.mock import AsyncMock, Mock, patch, MagicMock
 from datetime import datetime, timezone, timedelta
@@ -1046,7 +1047,7 @@ class TestKiroHttpClientConnectionCloseHeader:
         mock_request = Mock()
         captured_headers = {}
         
-        def capture_build_request(method, url, json, headers):
+        def capture_build_request(method, url, content, headers):
             captured_headers.update(headers)
             return mock_request
         
@@ -1086,7 +1087,7 @@ class TestKiroHttpClientConnectionCloseHeader:
         
         captured_headers = {}
         
-        async def capture_request(method, url, json, headers):
+        async def capture_request(method, url, content, headers):
             captured_headers.update(headers)
             return mock_response
         
@@ -1124,7 +1125,7 @@ class TestKiroHttpClientConnectionCloseHeader:
         mock_request = Mock()
         captured_headers = {}
         
-        def capture_build_request(method, url, json, headers):
+        def capture_build_request(method, url, content, headers):
             captured_headers.update(headers)
             return mock_request
         
@@ -1273,10 +1274,10 @@ class TestKiroHttpClientRequestParameters:
                     params={"filter": "active"}
                 )
         
-        print("Verification: Both params and json passed...")
+        print("Verification: Both params and content passed...")
         print(f"Captured kwargs: {captured_kwargs}")
         assert "params" in captured_kwargs, f"params not found: {captured_kwargs}"
-        assert "json" in captured_kwargs, f"json not found: {captured_kwargs}"
+        assert "content" in captured_kwargs, f"content not found: {captured_kwargs}"
         assert captured_kwargs["params"]["filter"] == "active"
-        assert captured_kwargs["json"]["data"] == "value"
+        assert json.loads(captured_kwargs["content"])["data"] == "value"
         assert response.status_code == 200

--- a/tests/unit/test_model_resolver.py
+++ b/tests/unit/test_model_resolver.py
@@ -581,53 +581,53 @@ class TestGetModelIdForKiro:
     
     def test_returns_internal_id_for_hidden_model(self):
         """
-        What it does: Returns internal ID for hidden model.
-        Goal: Check hidden model resolution.
+        What it does: Returns runtime-valid ID for hidden model.
+        Goal: Check hidden model resolution maps to valid runtime ID.
         """
         hidden = {"claude-3.7-sonnet": "CLAUDE_3_7_SONNET_20250219_V1_0"}
-        
+
         print("Action: get_model_id_for_kiro('claude-3.7-sonnet', hidden)...")
         result = get_model_id_for_kiro("claude-3.7-sonnet", hidden)
-        
-        print(f"Comparing result: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0', Got '{result}'")
-        assert result == "CLAUDE_3_7_SONNET_20250219_V1_0"
-    
+
+        print(f"Comparing result: Expected 'auto' (invalid runtime ID falls back), Got '{result}'")
+        assert result == "auto"
+
     def test_normalizes_then_checks_hidden(self):
         """
         What it does: Normalizes first, then checks hidden.
         Goal: Check operation order.
         """
         hidden = {"claude-3.7-sonnet": "CLAUDE_3_7_SONNET_20250219_V1_0"}
-        
+
         print("Action: get_model_id_for_kiro('claude-3-7-sonnet', hidden)...")
         result = get_model_id_for_kiro("claude-3-7-sonnet", hidden)
-        
-        print(f"Comparing result: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0', Got '{result}'")
-        assert result == "CLAUDE_3_7_SONNET_20250219_V1_0"
-    
+
+        print(f"Comparing result: Expected 'auto' (invalid runtime ID falls back), Got '{result}'")
+        assert result == "auto"
+
     def test_normalizes_with_date_then_checks_hidden(self):
         """
         What it does: Normalizes with date suffix, then checks hidden.
         Goal: Check full normalization chain.
         """
         hidden = {"claude-3.7-sonnet": "CLAUDE_3_7_SONNET_20250219_V1_0"}
-        
+
         print("Action: get_model_id_for_kiro('claude-3-7-sonnet-20250219', hidden)...")
         result = get_model_id_for_kiro("claude-3-7-sonnet-20250219", hidden)
-        
-        print(f"Comparing result: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0', Got '{result}'")
-        assert result == "CLAUDE_3_7_SONNET_20250219_V1_0"
-    
+
+        print(f"Comparing result: Expected 'auto' (invalid runtime ID falls back), Got '{result}'")
+        assert result == "auto"
+
     def test_passthrough_unknown_model(self):
         """
-        What it does: Passthrough for unknown models.
-        Goal: Check that unknown models pass through normalized.
+        What it does: Unknown models default to 'auto' for runtime endpoint.
+        Goal: Check that unknown models get mapped to 'auto'.
         """
         print("Action: get_model_id_for_kiro('claude-unknown-model', {})...")
         result = get_model_id_for_kiro("claude-unknown-model", {})
-        
-        print(f"Comparing result: Expected 'claude-unknown-model', Got '{result}'")
-        assert result == "claude-unknown-model"
+
+        print(f"Comparing result: Expected 'auto', Got '{result}'")
+        assert result == "auto"
 
 
 # =============================================================================
@@ -702,36 +702,36 @@ class TestModelResolverResolve:
     def test_resolve_finds_model_in_hidden(self, model_resolver):
         """
         What it does: Finds model in hidden models.
-        Goal: Check Layer 3 (Hidden Models).
+        Goal: Check Layer 3 (Hidden Models) maps to valid runtime ID.
         """
         print("Action: Resolving 'claude-3-7-sonnet'...")
         result = model_resolver.resolve("claude-3-7-sonnet")
-        
+
         print(f"Check result: {result}")
-        print(f"Comparing internal_id: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0', Got '{result.internal_id}'")
-        assert result.internal_id == "CLAUDE_3_7_SONNET_20250219_V1_0"
-        
+        print(f"Comparing internal_id: Expected 'auto' (hidden maps to invalid runtime ID), Got '{result.internal_id}'")
+        assert result.internal_id == "auto"
+
         print(f"Comparing source: Expected 'hidden', Got '{result.source}'")
         assert result.source == "hidden"
-        
+
         print(f"Comparing is_verified: Expected True, Got {result.is_verified}")
         assert result.is_verified is True
-    
+
     def test_resolve_passthrough_for_unknown(self, model_resolver):
         """
-        What it does: Passthrough for unknown model.
-        Goal: Check Layer 4 (Pass-through).
+        What it does: Passthrough for unknown model defaults to 'auto'.
+        Goal: Check Layer 4 validates for runtime endpoint.
         """
         print("Action: Resolving 'claude-haiku-4-6' (does not exist)...")
         result = model_resolver.resolve("claude-haiku-4-6")
-        
+
         print(f"Check result: {result}")
-        print(f"Comparing internal_id: Expected 'claude-haiku-4.6', Got '{result.internal_id}'")
-        assert result.internal_id == "claude-haiku-4.6"
-        
+        print(f"Comparing internal_id: Expected 'auto', Got '{result.internal_id}'")
+        assert result.internal_id == "auto"
+
         print(f"Comparing source: Expected 'passthrough', Got '{result.source}'")
         assert result.source == "passthrough"
-        
+
         print(f"Comparing is_verified: Expected False, Got {result.is_verified}")
         assert result.is_verified is False
     
@@ -1391,41 +1391,41 @@ class TestModelAliasSystemEdgeCases:
     
     def test_alias_to_non_existent_model(self, mock_model_cache):
         """
-        What it does: Alias pointing to non-existent model.
-        Purpose: Ensure passthrough works for aliased non-existent models.
+        What it does: Alias pointing to non-existent model defaults to 'auto'.
+        Purpose: Ensure runtime validation applies for aliased non-existent models.
         """
         print("Setup: Creating resolver with alias to non-existent model...")
         aliases = {"future-model": "claude-haiku-5.0"}
         resolver = ModelResolver(cache=mock_model_cache, aliases=aliases)
-        
+
         print("Action: Resolving 'future-model'...")
         result = resolver.resolve("future-model")
-        
-        print(f"Comparing internal_id: Expected 'claude-haiku-5.0', Got '{result.internal_id}'")
-        assert result.internal_id == "claude-haiku-5.0"
-        
+
+        print(f"Comparing internal_id: Expected 'auto', Got '{result.internal_id}'")
+        assert result.internal_id == "auto"
+
         print(f"Comparing source: Expected 'passthrough', Got '{result.source}'")
         assert result.source == "passthrough"
-        
+
         print(f"Comparing is_verified: Expected False, Got {result.is_verified}")
         assert result.is_verified is False
-    
+
     def test_alias_to_hidden_model(self, mock_model_cache):
         """
         What it does: Alias pointing to hidden model.
-        Purpose: Ensure alias works with hidden models.
+        Purpose: Ensure alias works with hidden models and runtime validation.
         """
         print("Setup: Creating resolver with alias to hidden model...")
         hidden = {"claude-3.7-sonnet": "CLAUDE_3_7_SONNET_20250219_V1_0"}
         aliases = {"legacy-sonnet": "claude-3.7-sonnet"}
         resolver = ModelResolver(cache=mock_model_cache, hidden_models=hidden, aliases=aliases)
-        
+
         print("Action: Resolving 'legacy-sonnet'...")
         result = resolver.resolve("legacy-sonnet")
-        
-        print(f"Comparing internal_id: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0', Got '{result.internal_id}'")
-        assert result.internal_id == "CLAUDE_3_7_SONNET_20250219_V1_0"
-        
+
+        print(f"Comparing internal_id: Expected 'auto' (invalid runtime ID), Got '{result.internal_id}'")
+        assert result.internal_id == "auto"
+
         print(f"Comparing source: Expected 'hidden', Got '{result.source}'")
         assert result.source == "hidden"
     
@@ -1480,13 +1480,13 @@ class TestModelAliasSystemEdgeCases:
         print("Setup: Creating resolver with lowercase alias...")
         aliases = {"auto-kiro": "auto"}
         resolver = ModelResolver(cache=mock_model_cache, aliases=aliases)
-        
+
         print("Action: Resolving 'AUTO-KIRO' (uppercase)...")
         result = resolver.resolve("AUTO-KIRO")
-        
-        print(f"Comparing internal_id: Expected 'AUTO-KIRO' (passthrough preserves case), Got '{result.internal_id}'")
-        # Should NOT match alias, should passthrough as-is (preserving original case)
-        assert result.internal_id == "AUTO-KIRO"
+
+        print(f"Comparing internal_id: Expected 'auto' (runtime validation), Got '{result.internal_id}'")
+        # Should NOT match alias, goes through passthrough, maps to 'auto' via runtime validation
+        assert result.internal_id == "auto"
         assert result.source == "passthrough"
 
 
@@ -1709,17 +1709,17 @@ class TestAliasSystemSecurity:
         print("Setup: Creating resolver with alias...")
         aliases = {"my-model": "claude-opus-5"}
         resolver = ModelResolver(cache=mock_model_cache, aliases=aliases)
-        
+
         print("Action: Resolving 'my-model' (points to non-existent Opus)...")
         result = resolver.resolve("my-model")
-        
+
         print(f"Result: {result}")
         print("Check: Does NOT fallback to Sonnet or Haiku...")
         assert "sonnet" not in result.internal_id.lower()
         assert "haiku" not in result.internal_id.lower()
-        
-        print("Check: Passthrough preserves family...")
-        assert "opus" in result.internal_id.lower()
+
+        print("Check: Unknown models default to 'auto' (safe fallback)...")
+        assert result.internal_id == "auto"
     
     def test_alias_suggestions_respect_target_family(self, mock_model_cache):
         """


### PR DESCRIPTION
## Summary

AWS is deactivating `q.<region>.amazonaws.com` on May 15, 2026. This PR migrates all API calls to `runtime.<region>.kiro.dev` with the required protocol changes.

Closes #146

## Breaking changes from old endpoint

| Aspect | Old (`q.amazonaws.com`) | New (`runtime.kiro.dev`) |
|--------|------------------------|--------------------------|
| Content-Type | `application/json` | `application/x-amz-json-1.0` |
| x-amz-target | not needed | required |
| Model IDs | `anthropic.claude-sonnet-4-5-20250514-v1:0` | `claude-sonnet-4.5` (dot format) |
| profileArn | optional for SSO OIDC | required for all auth types |
| /ListAvailableModels | available | 404 (not migrated) |

## Changes

- **`kiro/config.py`** — endpoint URL templates → `runtime.{region}.kiro.dev`
- **`kiro/utils.py`** — `Content-Type: application/x-amz-json-1.0` + `x-amz-target` header
- **`kiro/http_client.py`** — `json=` → `content=json.dumps().encode()` (prevents httpx from overriding Content-Type)
- **`kiro/routes_openai.py` + `kiro/routes_anthropic.py`** — profileArn sent for all auth types
- **`kiro/model_resolver.py`** — validates model IDs against runtime endpoint's accepted set; strips context window suffixes (`[1m]`, `[200k]`); unknown models default to `"auto"`
- **`kiro/auth.py`** — loads profileArn from kiro-cli's `state` table (`api.codewhisperer.profile`) for SSO OIDC users who don't have it in token data

## Auth type coverage

| Auth type | profileArn source | Status |
|-----------|------------------|--------|
| Kiro Desktop | credentials JSON file | Works (existing) |
| AWS SSO OIDC (kiro-cli) | `state` table in SQLite | Works (new) |
| SSO OIDC without state entry | `PROFILE_ARN` env var | Fallback not wired — users can set env var manually if needed |

If `PROFILE_ARN` env var fallback is desired for edge cases, the routes could add:
```python
from kiro.config import PROFILE_ARN
profile_arn_for_payload = auth_manager.profile_arn or PROFILE_ARN
```

## Test plan

- [x] E2E streaming: `claude-sonnet-4-5`, `claude-opus-4-5`, `claude-haiku-4-5`, `auto`
- [x] E2E non-streaming: all models above
- [x] Legacy model fallback: `claude-3-7-sonnet` → `auto`
- [x] Context window suffix: `claude-opus-4-6[1m]` → `claude-opus-4.6`
- [x] Both OpenAI (`/v1/chat/completions`) and Anthropic (`/v1/messages`) routes
- [x] Unit tests pass
- [x] Auth type: SSO OIDC via kiro-cli (org account)

## Notes

- `/ListAvailableModels` returns 404 on the new endpoint — gateway falls back to pre-configured model list (existing behavior)
- Valid model IDs on new endpoint: `auto`, `claude-sonnet-4`, `claude-sonnet-4.5`, `claude-sonnet-4.6`, `claude-opus-4.5`, `claude-opus-4.6`, `claude-opus-4.7`, `claude-haiku-4.5`
- Token propagation: freshly refreshed tokens may take a few seconds before the new endpoint accepts them