### PR TITLE
feat(api): expose upstream tokenLimits on /v1/models

### DIFF
--- a/kiro/account_manager.py
+++ b/kiro/account_manager.py
@@ -808,6 +808,21 @@ class AccountManager:
             if account.auth_manager is not None:
                 return account
         raise RuntimeError("No initialized accounts available")
+
+    def iter_initialized_accounts(self):
+        """
+        Yield every account whose ``auth_manager`` has been initialized.
+
+        Public accessor intended for read-only introspection (e.g. building
+        the ``/v1/models`` response). Use this instead of reaching into
+        ``self._accounts`` directly.
+
+        Yields:
+            Account: initialized accounts, in insertion order.
+        """
+        for account in self._accounts.values():
+            if account.auth_manager is not None:
+                yield account
     
     def get_all_available_models(self) -> List[str]:
         """

--- a/kiro/cache.py
+++ b/kiro/cache.py
@@ -141,6 +141,35 @@ class ModelInfoCache:
             return model["tokenLimits"].get("maxInputTokens") or DEFAULT_MAX_INPUT_TOKENS
         return DEFAULT_MAX_INPUT_TOKENS
     
+    def get_token_limits(self, model_id: str) -> Optional[Dict[str, int]]:
+        """
+        Returns raw tokenLimits for the model, as reported by Kiro's
+        ListAvailableModels (``{"maxInputTokens": int, "maxOutputTokens": int}``).
+
+        Unlike :meth:`get_max_input_tokens`, this does not fall back to the
+        ``DEFAULT_MAX_INPUT_TOKENS`` constant — callers that want the *real*
+        upstream ceiling (for example, the OpenAI-compatible ``/v1/models``
+        response) can distinguish "unknown" from "default".
+
+        Args:
+            model_id: Model ID
+
+        Returns:
+            Dict with integer ``maxInputTokens`` / ``maxOutputTokens`` keys
+            (either may be missing), or ``None`` if the model is unknown or
+            has no ``tokenLimits`` metadata.
+        """
+        model = self._cache.get(model_id)
+        if not model:
+            return None
+        tl = model.get("tokenLimits") or {}
+        out: Dict[str, int] = {}
+        for key in ("maxInputTokens", "maxOutputTokens"):
+            val = tl.get(key)
+            if isinstance(val, int):
+                out[key] = val
+        return out or None
+
     def is_empty(self) -> bool:
         """
         Checks if the cache is empty.

--- a/kiro/models_openai.py
+++ b/kiro/models_openai.py
@@ -39,12 +39,22 @@ class OpenAIModel(BaseModel):
     Data model for describing an AI model in OpenAI format.
     
     Used in the /v1/models endpoint response.
+
+    The ``context_length`` / ``max_input_tokens`` / ``max_output_tokens``
+    fields are a local extension (not part of stock OpenAI) that forwards the
+    upstream ``tokenLimits`` Kiro reports via ``ListAvailableModels``. They let
+    clients (e.g. Hermes agent's ``get_model_context_length``) discover the
+    real per-model ceiling instead of falling back to 256K / 128K defaults.
     """
     id: str
     object: str = "model"
     created: int = Field(default_factory=lambda: int(time.time()))
     owned_by: str = "anthropic"
     description: Optional[str] = None
+    # Local extension — real per-model token ceilings from Kiro's tokenLimits.
+    context_length: Optional[int] = None
+    max_input_tokens: Optional[int] = None
+    max_output_tokens: Optional[int] = None
 
 
 class ModelList(BaseModel):

--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -28,6 +28,7 @@ Contains all API endpoints:
 
 import json
 from datetime import datetime, timezone
+from typing import Dict
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, Security
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -142,13 +143,41 @@ async def get_models(request: Request):
         # Legacy: use resolver from first account
         account = request.app.state.account_manager.get_first_account()
         available_model_ids = account.model_resolver.get_available_models()
-    
+
+    # Merge tokenLimits from every initialized account's model_cache so the
+    # response exposes per-model ceilings (see OpenAIModel docstring).  If the
+    # same model appears across multiple accounts we keep the largest limits
+    # observed (callers care about "what's possible", not the strictest tier).
+    token_limits_by_model: Dict[str, Dict[str, int]] = {}
+    try:
+        for account in request.app.state.account_manager.iter_initialized_accounts():
+            cache = getattr(account, "model_cache", None)
+            if not cache:
+                continue
+            for mid in cache.get_all_model_ids():
+                limits = cache.get_token_limits(mid)
+                if not limits:
+                    continue
+                current = token_limits_by_model.setdefault(mid, {})
+                for src, dst in (
+                    ("maxInputTokens", "max_input_tokens"),
+                    ("maxOutputTokens", "max_output_tokens"),
+                ):
+                    val = limits.get(src)
+                    if isinstance(val, int) and val > current.get(dst, 0):
+                        current[dst] = val
+    except Exception as exc:  # pragma: no cover — defensive; never fail /v1/models
+        logger.warning(f"Failed to merge tokenLimits for /v1/models: {exc}")
+
     # Build OpenAI-compatible model list
     openai_models = [
         OpenAIModel(
             id=model_id,
             owned_by="anthropic",
-            description="Claude model via Kiro API"
+            description="Claude model via Kiro API",
+            context_length=token_limits_by_model.get(model_id, {}).get("max_input_tokens"),
+            max_input_tokens=token_limits_by_model.get(model_id, {}).get("max_input_tokens"),
+            max_output_tokens=token_limits_by_model.get(model_id, {}).get("max_output_tokens"),
         )
         for model_id in available_model_ids
     ]

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -268,6 +268,58 @@ class TestModelInfoCacheGetMaxInputTokens:
         assert max_tokens == DEFAULT_MAX_INPUT_TOKENS
 
 
+class TestModelInfoCacheGetTokenLimits:
+    """Tests for get_token_limits (raw tokenLimits passthrough)."""
+
+    @pytest.mark.asyncio
+    async def test_get_token_limits_returns_both_values(self, sample_models_data):
+        """
+        What it does: Verifies get_token_limits returns maxInputTokens and maxOutputTokens.
+        Purpose: Ensure raw limits are surfaced for /v1/models consumers.
+        """
+        cache = ModelInfoCache()
+        await cache.update(sample_models_data)
+
+        limits = cache.get_token_limits("claude-sonnet-4")
+        assert limits == {"maxInputTokens": 200000, "maxOutputTokens": 8192}
+
+    @pytest.mark.asyncio
+    async def test_get_token_limits_returns_none_for_unknown_model(self, sample_models_data):
+        """
+        What it does: Returns None when the model is not in the cache.
+        Purpose: Callers must distinguish "unknown" from "default".
+        """
+        cache = ModelInfoCache()
+        await cache.update(sample_models_data)
+
+        assert cache.get_token_limits("unknown-model") is None
+
+    @pytest.mark.asyncio
+    async def test_get_token_limits_returns_none_when_no_token_limits(self):
+        """
+        What it does: Returns None when the model entry has no tokenLimits.
+        """
+        cache = ModelInfoCache()
+        await cache.update([{"modelId": "bare-model"}])
+
+        assert cache.get_token_limits("bare-model") is None
+
+    @pytest.mark.asyncio
+    async def test_get_token_limits_skips_non_int_values(self):
+        """
+        What it does: Skips tokenLimits entries whose values are None or non-int.
+        Purpose: Upstream sometimes ships partial / null values; we must not propagate them.
+        """
+        cache = ModelInfoCache()
+        await cache.update([{
+            "modelId": "partial-model",
+            "tokenLimits": {"maxInputTokens": 500000, "maxOutputTokens": None},
+        }])
+
+        limits = cache.get_token_limits("partial-model")
+        assert limits == {"maxInputTokens": 500000}
+
+
 class TestModelInfoCacheIsEmpty:
     """Тесты проверки пустоты кэша."""
     

--- a/tests/unit/test_routes_openai.py
+++ b/tests/unit/test_routes_openai.py
@@ -380,6 +380,57 @@ class TestModelsEndpoint:
         for model in response.json()["data"]:
             assert model["owned_by"] == "anthropic"
 
+    def test_models_exposes_token_limits(self, test_client, valid_proxy_api_key):
+        """
+        What it does: Verifies /v1/models surfaces upstream tokenLimits as
+        context_length / max_input_tokens / max_output_tokens fields on each model.
+        Purpose: Lets OpenAI-compatible clients (e.g. gateways probing
+        /v1/models to size context windows) discover real per-model ceilings
+        instead of falling back to conservative defaults.
+        """
+        import asyncio
+        from unittest.mock import MagicMock
+        from kiro.cache import ModelInfoCache
+
+        # Stand up a fresh cache populated with a known model + tokenLimits.
+        cache = ModelInfoCache()
+        asyncio.run(cache.update([
+            {
+                "modelId": "claude-sonnet-4.5",
+                "displayName": "Claude Sonnet 4.5",
+                "tokenLimits": {"maxInputTokens": 200000, "maxOutputTokens": 8192},
+            },
+        ]))
+
+        fake_account = MagicMock()
+        fake_account.auth_manager = object()  # truthy — counts as initialized
+        fake_account.model_cache = cache
+        fake_account.model_resolver.get_available_models.return_value = ["claude-sonnet-4.5"]
+
+        original_mgr = test_client.app.state.account_manager
+        original_sys = test_client.app.state.account_system
+        fake_mgr = MagicMock()
+        fake_mgr.get_all_available_models.return_value = ["claude-sonnet-4.5"]
+        fake_mgr.iter_initialized_accounts.return_value = iter([fake_account])
+        test_client.app.state.account_manager = fake_mgr
+        test_client.app.state.account_system = True
+        try:
+            response = test_client.get(
+                "/v1/models",
+                headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
+            )
+        finally:
+            test_client.app.state.account_manager = original_mgr
+            test_client.app.state.account_system = original_sys
+
+        assert response.status_code == 200
+        models = {m["id"]: m for m in response.json()["data"]}
+        assert "claude-sonnet-4.5" in models
+        m = models["claude-sonnet-4.5"]
+        assert m["context_length"] == 200000
+        assert m["max_input_tokens"] == 200000
+        assert m["max_output_tokens"] == 8192
+
 
 # =============================================================================
 # Tests for chat completions endpoint (/v1/chat/completions)


### PR DESCRIPTION
## Summary

Kiro's `ListAvailableModels` response carries per-model `tokenLimits`
(`maxInputTokens` / `maxOutputTokens`) which we already cache in
`ModelInfoCache` but strip before returning from `/v1/models`.

OpenAI-compatible clients probing the endpoint to size context windows
therefore fall back to conservative defaults (often 128K or 256K) even
for models that actually support 1M input (e.g. `claude-opus-4.6`,
`claude-opus-4.7`, `claude-sonnet-4.6`).

This PR surfaces those limits as three optional fields on each model
entry in the `/v1/models` response:

| Field | Maps to | Notes |
|---|---|---|
| `context_length` | `maxInputTokens` | Alias — the field name most OpenAI-compatible clients probe (LiteLLM, aider, Hermes, etc.) |
| `max_input_tokens` | `maxInputTokens` | Explicit form |
| `max_output_tokens` | `maxOutputTokens` | Explicit form |

All three default to `None` and are purely additive — stock OpenAI
clients that ignore unknown fields are unaffected.

## Example

Before:
```json
{
  "id": "claude-opus-4.7",
  "object": "model",
  "owned_by": "anthropic",
  "description": "Claude model via Kiro API"
}
```

After:
```json
{
  "id": "claude-opus-4.7",
  "object": "model",
  "owned_by": "anthropic",
  "description": "Claude model via Kiro API",
  "context_length": 1000000,
  "max_input_tokens": 1000000,
  "max_output_tokens": 64000
}
```

## Design notes

- **Highest-wins across accounts.** When the account system is enabled
  and the same model ID appears across multiple initialized accounts
  (different tiers), the response reports the *largest* limit observed.
  Callers want the achievable ceiling, not the strictest common
  denominator.

- **No private-attribute access.** Added two small public accessors:
  - `ModelInfoCache.get_token_limits()` — returns the raw
    `maxInputTokens` / `maxOutputTokens` dict (or `None`), letting
    callers distinguish "unknown" from the `DEFAULT_MAX_INPUT_TOKENS`
    fallback that `get_max_input_tokens()` already performs.
  - `AccountManager.iter_initialized_accounts()` — public read-only
    iterator over accounts with an initialized `auth_manager`.

- **Defensive wrapping.** The merge loop in `/v1/models` is wrapped in
  a `try/except` so a cache glitch can never 500 the endpoint.

## Tests

- `tests/unit/test_cache.py`: 4 new tests for `get_token_limits`
  covering happy path, unknown model, missing `tokenLimits`, and
  non-int values.
- `tests/unit/test_routes_openai.py`: 1 integration test that stands
  up a mocked `account_manager` with a known `tokenLimits` payload
  and verifies the new fields appear on the `/v1/models` response.

All 12 new/affected tests pass locally; 1,671 existing tests pass
(one pre-existing failure in `test_config.py::TestServerHostConfig`
caused by local `.env`, unrelated to this change).

## Verified live

Against a running 2.4-dev.10 gateway proxying real Kiro Pro accounts:

```
claude-haiku-4.5       ctx=200000  in=200000   out=64000
claude-opus-4.5        ctx=200000  in=200000   out=64000
claude-opus-4.6        ctx=1000000 in=1000000  out=64000
claude-opus-4.7        ctx=1000000 in=1000000  out=64000
claude-sonnet-4.5      ctx=200000  in=200000   out=64000
claude-sonnet-4.6      ctx=1000000 in=1000000  out=64000
deepseek-3.2           ctx=164000  in=164000   out=64000
qwen3-coder-next       ctx=256000  in=256000   out=64000
```
