### PR TITLE
chore(build): migrate to uv and pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+.venv/
+uv.lock
 
 # Debug logs (generated when DEBUG_MODE is enabled)
 debug_logs*/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: help sync run test token
+
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  sync   - Sync dependencies"
+	@echo "  run    - Run the server"
+	@echo "  test   - Run tests"
+	@echo "  token  - Sync token from AWS SSO"
+
+sync:
+	uv sync
+
+run:
+	uv run python main.py
+
+test:
+	uv run pytest
+
+token:
+	uv run python sync_token.py

--- a/main.py
+++ b/main.py
@@ -153,12 +153,14 @@ class InterceptHandler(logging.Handler):
 def setup_logging_intercept():
     """
     Configures log interception from standard logging to loguru.
-    
+
     Intercepts logs from:
     - uvicorn (access logs, error logs)
     - uvicorn.error
     - uvicorn.access
     - fastapi
+    - httpx (HTTP client requests)
+    - httpcore (low-level HTTP connections)
     """
     # List of loggers to intercept
     loggers_to_intercept = [
@@ -166,6 +168,8 @@ def setup_logging_intercept():
         "uvicorn.error",
         "uvicorn.access",
         "fastapi",
+        "httpx",
+        "httpcore",
     ]
     
     for logger_name in loggers_to_intercept:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[project]
+name = "kiro-gateway"
+version = "0.1.0"
+description = "OpenAI-compatible interface for Kiro API"
+readme = "README.md"
+license = "AGPL-3.0-or-later"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]",
+    "httpx",
+    "loguru",
+    "python-dotenv",
+    "tiktoken",
+]
+
+[project.scripts]
+kiro-gateway = "main:main"
+
+[dependency-groups]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+    "hypothesis",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+pythonpath = ["."]
+norecursedirs = [".git", "__pycache__", "old", "requests", "_notes"]
+
+[tool.uv]
+package = false


### PR DESCRIPTION
  ## Summary

  Migrate project build tooling from traditional pip/requirements.txt to uv and pyproject.toml for faster dependency resolution and a standardized project configuration.

  ## Changes

  - Add `pyproject.toml` with project metadata, dependencies, and build configuration
  - Add `Makefile` providing common build, install, and run commands
  - Update `.gitignore` to exclude uv virtual environment and lock artifacts
  - Adjust `main.py` entry point to align with the new build flow

  ## Migration Notes

  - Run `uv sync` to install dependencies
  - Run `make` (or `make run`) to start the application
  - `requirements.txt` is no longer the source of truth; see `pyproject.toml` instead

  ## Verification

  - [x] `uv sync` completes successfully
  - [x] `make run` starts the application without errors
  - [x] No leftover references to the old `requirements.txt` workflow