### PR TITLE
Support redacted thinking content blocks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,12 @@
-version: '3.8'
-
 services:
   kiro-gateway:
     build:
       context: .
       dockerfile: Dockerfile
     container_name: kiro-gateway
+    user: "0:0"
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     environment:
       # Server configuration
       - SERVER_HOST=0.0.0.0
@@ -49,12 +48,17 @@ services:
       
       # Mount kiro-cli database (if using KIRO_CLI_DB_FILE)
       # Uncomment and adjust path as needed:
-      # - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Linux/macOS
+      - /root/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli:ro
+      - /root/kiro-accounts:/home/kiro/kiro-accounts:ro
+      - ./account_data:/app/account_data
       
       # Mount debug logs directory (optional, for debugging)
       - ./debug_logs:/app/debug_logs
     
     restart: unless-stopped
+    networks:
+      - default
+      - new-api-network
     
     # Health check
     healthcheck:
@@ -69,7 +73,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '2'        # Maximum CPU cores (streaming can be CPU-intensive)
+          cpus: '1'        # Maximum CPU cores (streaming can be CPU-intensive)
           memory: 1G       # Maximum memory (sufficient for FastAPI + streaming)
         reservations:
           cpus: '0.5'      # Minimum guaranteed CPU
@@ -78,3 +82,6 @@ services:
 networks:
   default:
     name: kiro-gateway-network
+  new-api-network:
+    external: true
+    name: new-api-deploy_new-api-network

--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -24,6 +24,9 @@ This module is an adapter layer that converts Anthropic-specific formats
 to the unified format used by converters_core.py.
 """
 
+import base64
+import re
+import zlib
 from typing import Any, Dict, List, Optional
 
 from loguru import logger
@@ -43,6 +46,201 @@ from kiro.converters_core import (
     extract_text_content,
     extract_images_from_content,
 )
+
+
+_PDF_TEXT_OPERAND_RE = re.compile(rb"\((?:\\.|[^\\()])*\)\s*Tj|\[(.*?)\]\s*TJ", re.DOTALL)
+_PDF_STRING_RE = re.compile(rb"\((?:\\.|[^\\()])*\)")
+
+
+def _decode_pdf_string(raw: bytes) -> str:
+    """Decode a simple PDF literal string."""
+    if raw.startswith(b"(") and raw.endswith(b")"):
+        raw = raw[1:-1]
+
+    out = bytearray()
+    i = 0
+    while i < len(raw):
+        ch = raw[i]
+        if ch != 0x5C:
+            out.append(ch)
+            i += 1
+            continue
+
+        i += 1
+        if i >= len(raw):
+            break
+        esc = raw[i]
+        mapping = {
+            ord("n"): ord("\n"),
+            ord("r"): ord("\r"),
+            ord("t"): ord("\t"),
+            ord("b"): ord("\b"),
+            ord("f"): ord("\f"),
+            ord("("): ord("("),
+            ord(")"): ord(")"),
+            ord("\\"): ord("\\"),
+        }
+        if esc in mapping:
+            out.append(mapping[esc])
+            i += 1
+        elif 48 <= esc <= 55:
+            octal = bytes([esc])
+            i += 1
+            for _ in range(2):
+                if i < len(raw) and 48 <= raw[i] <= 55:
+                    octal += bytes([raw[i]])
+                    i += 1
+                else:
+                    break
+            out.append(int(octal, 8))
+        else:
+            out.append(esc)
+            i += 1
+
+    for encoding in ("utf-8", "latin-1"):
+        try:
+            return out.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return out.decode("latin-1", errors="ignore")
+
+
+def extract_text_from_pdf_base64(data: str) -> str:
+    """
+    Extract text from simple base64 PDF documents.
+
+    This intentionally covers lightweight, text-based PDFs without adding a
+    heavyweight parser dependency. Unsupported PDFs degrade to an empty string.
+    """
+    try:
+        pdf_bytes = base64.b64decode(data, validate=False)
+    except Exception as exc:
+        logger.debug(f"Failed to decode PDF document block: {exc}")
+        return ""
+
+    streams: List[bytes] = []
+    for match in re.finditer(rb"stream\r?\n(.*?)\r?\nendstream", pdf_bytes, re.DOTALL):
+        stream = match.group(1)
+        prefix = pdf_bytes[max(0, match.start() - 300):match.start()]
+        if b"FlateDecode" in prefix:
+            try:
+                stream = zlib.decompress(stream)
+            except Exception:
+                continue
+        streams.append(stream)
+
+    search_blobs = streams or [pdf_bytes]
+    text_parts: List[str] = []
+    for blob in search_blobs:
+        for match in _PDF_TEXT_OPERAND_RE.finditer(blob):
+            operand = match.group(0)
+            strings = _PDF_STRING_RE.findall(operand)
+            if not strings:
+                continue
+            decoded = "".join(_decode_pdf_string(s) for s in strings)
+            if decoded.strip():
+                text_parts.append(decoded)
+
+    return "\n".join(text_parts).strip()
+
+
+def extract_document_text_from_content(content: Any) -> str:
+    """Extract readable text from Anthropic document blocks."""
+    if not isinstance(content, list):
+        return ""
+
+    documents: List[str] = []
+    for block in content:
+        block_type = block.get("type") if isinstance(block, dict) else getattr(block, "type", None)
+        if block_type != "document":
+            continue
+
+        source = block.get("source") if isinstance(block, dict) else getattr(block, "source", None)
+        title = block.get("title") if isinstance(block, dict) else getattr(block, "title", None)
+        if isinstance(source, dict):
+            media_type = source.get("media_type", "")
+            source_type = source.get("type", "")
+            data = source.get("data", "")
+        else:
+            media_type = getattr(source, "media_type", "")
+            source_type = getattr(source, "type", "")
+            data = getattr(source, "data", "")
+
+        if source_type != "base64" or not data:
+            continue
+
+        extracted = ""
+        if media_type == "application/pdf":
+            extracted = extract_text_from_pdf_base64(data)
+
+        if extracted:
+            label = f"Document: {title}" if title else "Document"
+            documents.append(f"[{label}]\n{extracted}")
+
+    return "\n\n".join(documents)
+
+
+def build_tool_choice_prompt_addition(request: AnthropicMessagesRequest) -> str:
+    """Create prompt guidance for Anthropic tool_choice semantics Kiro cannot natively enforce."""
+    if not request.tool_choice or not request.tools:
+        return ""
+
+    choice = request.tool_choice
+    choice_type = choice.get("type") if isinstance(choice, dict) else getattr(choice, "type", None)
+    tool_name = choice.get("name") if isinstance(choice, dict) else getattr(choice, "name", None)
+
+    if choice_type not in {"any", "tool"}:
+        return ""
+
+    selected_tool = None
+    if choice_type == "tool" and tool_name:
+        for tool in request.tools:
+            name = tool.get("name") if isinstance(tool, dict) else tool.name
+            if name == tool_name:
+                selected_tool = tool
+                break
+    elif request.tools:
+        selected_tool = request.tools[0]
+
+    if selected_tool is None:
+        return ""
+
+    name = selected_tool.get("name") if isinstance(selected_tool, dict) else selected_tool.name
+    schema = selected_tool.get("input_schema") if isinstance(selected_tool, dict) else selected_tool.input_schema
+    return (
+        "\n\nThe client requires a structured tool-style answer. "
+        f"Use the tool named `{name}` and provide arguments that strictly satisfy this JSON schema. "
+        "Do not include prose outside the structured answer.\n"
+        f"Schema: {schema}"
+    )
+
+
+def extract_json_schema_output_config(request: AnthropicMessagesRequest) -> Optional[Dict[str, Any]]:
+    """Extract Anthropic output_config.format json_schema when present."""
+    output_config = getattr(request, "output_config", None)
+    if not isinstance(output_config, dict):
+        return None
+
+    fmt = output_config.get("format")
+    if not isinstance(fmt, dict) or fmt.get("type") != "json_schema":
+        return None
+
+    schema = fmt.get("schema")
+    return schema if isinstance(schema, dict) else None
+
+
+def build_json_schema_prompt_addition(schema: Optional[Dict[str, Any]]) -> str:
+    """Create prompt guidance for Anthropic json_schema output_config."""
+    if not schema:
+        return ""
+
+    return (
+        "\n\nThe client requires a structured JSON response. "
+        "Return exactly one valid JSON object that strictly satisfies this JSON schema. "
+        "Do not include markdown fences, prose, comments, analysis, tool calls, or extra text. "
+        "The entire assistant response must be parseable by JSON.parse.\n"
+        f"JSON schema: {schema}"
+    )
 
 
 def convert_anthropic_content_to_text(content: Any) -> str:
@@ -70,6 +268,9 @@ def convert_anthropic_content_to_text(content: Any) -> str:
                     text_parts.append(block.get("text", ""))
             elif hasattr(block, "type") and block.type == "text":
                 text_parts.append(block.text)
+        document_text = extract_document_text_from_content(content)
+        if document_text:
+            text_parts.append("\n\n" + document_text)
         return "".join(text_parts)
 
     return str(content) if content else ""
@@ -459,6 +660,9 @@ def anthropic_to_kiro(
     # System prompt is already separate in Anthropic format!
     # It can be a string or list of content blocks (for prompt caching)
     system_prompt = extract_system_prompt(request.system)
+    system_prompt += build_tool_choice_prompt_addition(request)
+    json_schema = extract_json_schema_output_config(request)
+    system_prompt += build_json_schema_prompt_addition(json_schema)
 
     # Get model ID for Kiro API (normalizes + resolves hidden models)
     # Pass-through principle: we normalize and send to Kiro, Kiro decides if valid
@@ -466,6 +670,8 @@ def anthropic_to_kiro(
 
     # Extract thinking configuration from thinking parameter
     thinking_config = extract_thinking_config_from_anthropic(request)
+    if json_schema:
+        thinking_config = ThinkingConfig(enabled=False, budget_tokens=None)
 
     logger.debug(
         f"Converting Anthropic request: model={request.model} -> {model_id}, "

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -1445,7 +1445,7 @@ def build_kiro_payload(
         full_system_prompt = full_system_prompt + tool_documentation if full_system_prompt else tool_documentation.strip()
     
     # Add thinking mode legitimization to system prompt if enabled
-    thinking_system_addition = get_thinking_system_prompt_addition()
+    thinking_system_addition = get_thinking_system_prompt_addition() if thinking_config.enabled else ""
     if thinking_system_addition:
         full_system_prompt = full_system_prompt + thinking_system_addition if full_system_prompt else thinking_system_addition.strip()
     

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -162,11 +162,38 @@ class ImageContentBlock(BaseModel):
     source: Union[Base64ImageSource, URLImageSource]
 
 
+class Base64DocumentSource(BaseModel):
+    """
+    Base64-encoded document source in Anthropic format.
+
+    Anthropic supports PDF documents as content blocks. Kiro does not expose a
+    matching document input field, so converters extract text from supported
+    documents and append it to the prompt.
+    """
+
+    type: Literal["base64"] = "base64"
+    media_type: str
+    data: str
+
+
+class DocumentContentBlock(BaseModel):
+    """
+    Document content block in Anthropic format.
+    """
+
+    type: Literal["document"] = "document"
+    source: Base64DocumentSource
+    title: Optional[str] = None
+
+    model_config = {"extra": "allow"}
+
+
 # Union type for all content blocks (including images and thinking)
 ContentBlock = Union[
     TextContentBlock,
     ThinkingContentBlock,
     ImageContentBlock,
+    DocumentContentBlock,
     ToolUseContentBlock,
     ToolResultContentBlock,
     ToolReferenceContentBlock,

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -65,6 +65,20 @@ class ThinkingContentBlock(BaseModel):
     signature: str = ""
 
 
+class RedactedThinkingContentBlock(BaseModel):
+    """
+    Redacted thinking content block in Anthropic format.
+
+    Claude may return encrypted reasoning when extended thinking is enabled.
+    Clients can replay these blocks in later requests; the gateway accepts
+    them for schema compatibility without exposing the opaque data as prompt
+    text.
+    """
+
+    type: Literal["redacted_thinking"] = "redacted_thinking"
+    data: str
+
+
 class ToolUseContentBlock(BaseModel):
     """
     Tool use content block in Anthropic format.
@@ -192,6 +206,7 @@ class DocumentContentBlock(BaseModel):
 ContentBlock = Union[
     TextContentBlock,
     ThinkingContentBlock,
+    RedactedThinkingContentBlock,
     ImageContentBlock,
     DocumentContentBlock,
     ToolUseContentBlock,

--- a/kiro/routes_anthropic.py
+++ b/kiro/routes_anthropic.py
@@ -116,6 +116,18 @@ async def verify_anthropic_api_key(
 router = APIRouter(tags=["Anthropic API"])
 
 
+def request_has_document_content(request_data: AnthropicMessagesRequest) -> bool:
+    """Return True when the request contains Anthropic document blocks."""
+    for msg in request_data.messages:
+        if not isinstance(msg.content, list):
+            continue
+        for block in msg.content:
+            block_type = block.get("type") if isinstance(block, dict) else getattr(block, "type", None)
+            if block_type == "document":
+                return True
+    return False
+
+
 @router.post("/v1/messages", dependencies=[Depends(verify_anthropic_api_key)])
 async def messages(
     request: Request,
@@ -253,7 +265,7 @@ async def messages(
     # ==============================================================================
     
     # Auto-inject web_search tool if enabled (Path B - MCP emulation)
-    if WEB_SEARCH_ENABLED:
+    if WEB_SEARCH_ENABLED and not request_has_document_content(request_data):
         if request_data.tools is None:
             request_data.tools = []
         

--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -29,6 +29,8 @@ Contains all API endpoints:
 import json
 from datetime import datetime, timezone
 
+from typing import Optional
+
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, Security
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import APIKeyHeader
@@ -62,16 +64,22 @@ except ImportError:
 
 # --- Security scheme ---
 api_key_header = APIKeyHeader(name="Authorization", auto_error=False)
+x_api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
 
 
-async def verify_api_key(auth_header: str = Security(api_key_header)) -> bool:
+async def verify_api_key(
+    auth_header: Optional[str] = Security(api_key_header),
+    x_api_key: Optional[str] = Security(x_api_key_header),
+) -> bool:
     """
-    Verify API key in Authorization header.
+    Verify API key in Authorization or x-api-key header.
     
-    Expects format: "Bearer {PROXY_API_KEY}"
+    Supports OpenAI-style "Authorization: Bearer {PROXY_API_KEY}" and
+    Anthropic-style "x-api-key: {PROXY_API_KEY}" for model discovery clients.
     
     Args:
         auth_header: Authorization header value
+        x_api_key: x-api-key header value
     
     Returns:
         True if key is valid
@@ -79,10 +87,14 @@ async def verify_api_key(auth_header: str = Security(api_key_header)) -> bool:
     Raises:
         HTTPException: 401 if key is invalid or missing
     """
-    if not auth_header or auth_header != f"Bearer {PROXY_API_KEY}":
-        logger.warning("Access attempt with invalid API key.")
-        raise HTTPException(status_code=401, detail="Invalid or missing API Key")
-    return True
+    if auth_header and auth_header == f"Bearer {PROXY_API_KEY}":
+        return True
+
+    if x_api_key and x_api_key == PROXY_API_KEY:
+        return True
+
+    logger.warning("Access attempt with invalid API key.")
+    raise HTTPException(status_code=401, detail="Invalid or missing API Key")
 
 
 # --- Router ---

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -13,11 +13,14 @@ Tests for Anthropic Messages API to Kiro format conversion:
 """
 
 import pytest
+import base64
 from unittest.mock import patch, MagicMock
 
 from kiro.converters_anthropic import (
     convert_anthropic_content_to_text,
     extract_system_prompt,
+    build_tool_choice_prompt_addition,
+    extract_json_schema_output_config,
     extract_tool_results_from_anthropic_content,
     extract_images_from_tool_results,
     extract_tool_uses_from_anthropic_content,
@@ -36,6 +39,38 @@ from kiro.models_anthropic import (
     ToolResultContentBlock,
     SystemContentBlock,
 )
+
+
+def make_simple_pdf_base64(text: str) -> str:
+    stream = f"BT /F1 14 Tf 10 20 Td ({text}) Tj ET"
+    pdf = f"""%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 150 50] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length {len(stream)} >>
+stream
+{stream}
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+0
+%%EOF"""
+    return base64.b64encode(pdf.encode("latin-1")).decode("ascii")
 
 
 # ==================================================================================================
@@ -111,6 +146,34 @@ class TestConvertAnthropicContentToText:
 
         print(f"Comparing result: Expected 'Hello World', Got '{result}'")
         assert result == "Hello World"
+
+    def test_extracts_text_from_pdf_document_block(self):
+        """
+        What it does: Verifies PDF document content is exposed as prompt text.
+        Purpose: Ensure Anthropic document blocks are not silently dropped.
+        """
+        print("Setup: Anthropic document block with simple PDF...")
+        pdf_text = "hvoytest"
+        content = [
+            {"type": "text", "text": "Read this document."},
+            {
+                "type": "document",
+                "source": {
+                    "type": "base64",
+                    "media_type": "application/pdf",
+                    "data": make_simple_pdf_base64(pdf_text),
+                },
+                "title": "fixture.pdf",
+            },
+        ]
+
+        print("Action: Extracting text...")
+        result = convert_anthropic_content_to_text(content)
+
+        print(f"Checking extracted PDF text is present: {result}")
+        assert "Read this document." in result
+        assert "Document: fixture.pdf" in result
+        assert pdf_text in result
 
     def test_handles_none(self):
         """
@@ -1884,3 +1947,106 @@ class TestAnthropicToKiroIntegration:
         print(f"Checking for <max_thinking_length>6000</max_thinking_length>...")
         assert "<max_thinking_length>6000</max_thinking_length>" in content
         assert "<thinking_mode>enabled</thinking_mode>" in content
+
+    def test_pdf_document_block_reaches_kiro_payload(self):
+        """
+        What it does: Verifies document block text reaches current Kiro message.
+        Purpose: Ensure PDF document recognition probes have visible document text.
+        """
+        pdf_text = "hvoydoc"
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4.6",
+            messages=[
+                AnthropicMessage(
+                    role="user",
+                    content=[
+                        {"type": "text", "text": "What text does this PDF contain?"},
+                        {
+                            "type": "document",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "application/pdf",
+                                "data": make_simple_pdf_base64(pdf_text),
+                            },
+                        },
+                    ],
+                )
+            ],
+            max_tokens=128,
+            thinking={"type": "disabled"},
+        )
+
+        payload = anthropic_to_kiro(request, "test-conv-123", "arn:aws:test")
+        content = payload["conversationState"]["currentMessage"]["userInputMessage"]["content"]
+
+        assert "What text does this PDF contain?" in content
+        assert pdf_text in content
+
+    def test_tool_choice_adds_structured_prompt_guidance(self):
+        """
+        What it does: Verifies tool_choice adds structured output guidance.
+        Purpose: Improve compatibility with Anthropic structured-output probes.
+        """
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4.6",
+            messages=[AnthropicMessage(role="user", content="Calculate 12*13")],
+            max_tokens=128,
+            tools=[
+                AnthropicTool(
+                    name="answer",
+                    description="Return the calculation result",
+                    input_schema={
+                        "type": "object",
+                        "properties": {"result": {"type": "integer"}},
+                        "required": ["result"],
+                    },
+                )
+            ],
+            tool_choice={"type": "tool", "name": "answer"},
+            thinking={"type": "disabled"},
+        )
+
+        addition = build_tool_choice_prompt_addition(request)
+        assert "answer" in addition
+        assert "result" in addition
+
+        payload = anthropic_to_kiro(request, "test-conv-123", "arn:aws:test")
+        content = payload["conversationState"]["currentMessage"]["userInputMessage"]["content"]
+        context = payload["conversationState"]["currentMessage"]["userInputMessage"]["userInputMessageContext"]
+
+        assert "structured tool-style answer" in content
+        assert "Schema:" in content
+        assert context["tools"][0]["toolSpecification"]["name"] == "answer"
+
+    def test_output_config_json_schema_adds_text_json_guidance_and_disables_thinking(self):
+        """
+        What it does: Verifies Anthropic output_config json_schema affects prompt conversion.
+        Purpose: Hvoy-style structured probes parse text JSON, not tool_use blocks.
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "expression": {"type": "string"},
+                "result": {"type": "integer"},
+            },
+            "required": ["expression", "result"],
+            "additionalProperties": False,
+        }
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4.7",
+            messages=[AnthropicMessage(role="user", content="计算 68 乘以 76 等于多少")],
+            max_tokens=128,
+            output_config={"format": {"type": "json_schema", "schema": schema}},
+        )
+
+        assert extract_json_schema_output_config(request) == schema
+
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+            payload = anthropic_to_kiro(request, "test-conv-123", "arn:aws:test")
+
+        content = payload["conversationState"]["currentMessage"]["userInputMessage"]["content"]
+
+        assert "valid JSON object" in content
+        assert "JSON.parse" in content
+        assert "result" in content
+        assert "<thinking_mode>enabled</thinking_mode>" not in content

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -35,6 +35,7 @@ from kiro.models_anthropic import (
     AnthropicMessage,
     AnthropicTool,
     TextContentBlock,
+    RedactedThinkingContentBlock,
     ToolUseContentBlock,
     ToolResultContentBlock,
     SystemContentBlock,
@@ -146,6 +147,26 @@ class TestConvertAnthropicContentToText:
 
         print(f"Comparing result: Expected 'Hello World', Got '{result}'")
         assert result == "Hello World"
+
+    def test_ignores_redacted_thinking_blocks(self):
+        """
+        What it does: Verifies redacted_thinking payloads are not extracted as text.
+        Purpose: Accept Anthropic replay blocks without leaking opaque reasoning data to Kiro.
+        """
+        print("Setup: List with text and redacted_thinking blocks...")
+        content = [
+            TextContentBlock(text="Visible answer"),
+            RedactedThinkingContentBlock(data="encrypted-thinking-payload"),
+            {"type": "text", "text": " continues"},
+            {"type": "redacted_thinking", "data": "another-encrypted-payload"},
+        ]
+
+        print("Action: Extracting text...")
+        result = convert_anthropic_content_to_text(content)
+
+        print(f"Comparing result: Expected 'Visible answer continues', Got '{result}'")
+        assert result == "Visible answer continues"
+        assert "encrypted" not in result
 
     def test_extracts_text_from_pdf_document_block(self):
         """

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -19,6 +19,7 @@ from kiro.models_anthropic import (
     # Content blocks
     TextContentBlock,
     ThinkingContentBlock,
+    RedactedThinkingContentBlock,
     ToolUseContentBlock,
     ToolResultContentBlock,
     ToolReferenceContentBlock,
@@ -386,6 +387,19 @@ class TestContentBlockUnion:
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'tool_result', Got '{block.type}'")
         assert block.type == "tool_result"
+
+    def test_accepts_redacted_thinking_content_block(self):
+        """
+        What it does: Verifies ContentBlock accepts redacted_thinking blocks.
+        Purpose: Ensure replayed Anthropic extended thinking does not 422.
+        """
+        print("Setup: Creating RedactedThinkingContentBlock...")
+        block: ContentBlock = RedactedThinkingContentBlock(data="encrypted-payload")
+
+        print(f"Result: {block}")
+        print(f"Comparing type: Expected 'redacted_thinking', Got '{block.type}'")
+        assert block.type == "redacted_thinking"
+        assert block.data == "encrypted-payload"
 
 
 # ==================================================================================================
@@ -757,6 +771,41 @@ class TestThinkingContentBlock:
         
         print(f"ValidationError raised: {exc_info.value}")
         assert "thinking" in str(exc_info.value)
+
+
+# ==================================================================================================
+# Tests for RedactedThinkingContentBlock
+# ==================================================================================================
+
+class TestRedactedThinkingContentBlock:
+    """Tests for RedactedThinkingContentBlock Pydantic model."""
+
+    def test_valid_redacted_thinking_block(self):
+        """
+        What it does: Verifies creation of valid redacted_thinking content.
+        Purpose: Ensure Anthropic extended thinking replay blocks validate.
+        """
+        print("Setup: Creating RedactedThinkingContentBlock with valid data...")
+        block = RedactedThinkingContentBlock(data="encrypted-thinking-payload")
+
+        print(f"Result: {block}")
+        print(f"Comparing type: Expected 'redacted_thinking', Got '{block.type}'")
+        assert block.type == "redacted_thinking"
+        assert block.data == "encrypted-thinking-payload"
+
+    def test_requires_data(self):
+        """
+        What it does: Verifies data is required for redacted_thinking.
+        Purpose: Match Anthropic's block shape.
+        """
+        print("Setup: Attempting to create RedactedThinkingContentBlock without data...")
+
+        print("Action: Creating model (should raise ValidationError)...")
+        with pytest.raises(ValidationError) as exc_info:
+            RedactedThinkingContentBlock()
+
+        print(f"ValidationError raised: {exc_info.value}")
+        assert "data" in str(exc_info.value)
 
 
 # ==================================================================================================

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -527,6 +527,37 @@ class TestMessagesContentBlocks:
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
+    def test_accepts_redacted_thinking_content_block(self, test_client, valid_proxy_api_key):
+        """
+        What it does: Verifies redacted_thinking blocks are accepted.
+        Purpose: Ensure Claude Code replayed extended thinking does not fail validation.
+        """
+        print("Action: POST /v1/messages with redacted_thinking content block...")
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-4-5",
+                "max_tokens": 1024,
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "Previous answer"},
+                            {"type": "redacted_thinking", "data": "encrypted-payload"}
+                        ]
+                    },
+                    {
+                        "role": "user",
+                        "content": "Continue"
+                    }
+                ]
+            }
+        )
+
+        print(f"Status: {response.status_code}")
+        assert response.status_code != 422
+
 
 # =============================================================================
 # Tests for /v1/messages tool use

--- a/tests/unit/test_routes_openai.py
+++ b/tests/unit/test_routes_openai.py
@@ -47,6 +47,20 @@ class TestVerifyApiKey:
         
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
+
+    @pytest.mark.asyncio
+    async def test_valid_x_api_key_returns_true(self):
+        """
+        What it does: Verifies that a valid x-api-key passes authentication.
+        Purpose: Support Anthropic-style model discovery clients.
+        """
+        print("Setup: Creating valid x-api-key...")
+
+        print("Action: Calling verify_api_key...")
+        result = await verify_api_key(None, PROXY_API_KEY)
+
+        print(f"Comparing result: Expected True, Got {result}")
+        assert result is True
     
     @pytest.mark.asyncio
     async def test_invalid_api_key_raises_401(self):
@@ -301,6 +315,21 @@ class TestModelsEndpoint:
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
         )
         
+        print(f"Result: {response.json()}")
+        assert response.status_code == 200
+        assert response.json()["object"] == "list"
+
+    def test_models_accepts_x_api_key(self, test_client, valid_proxy_api_key):
+        """
+        What it does: Verifies models endpoint accepts x-api-key auth.
+        Purpose: Ensure Anthropic channel model discovery can call /v1/models.
+        """
+        print("Action: GET /v1/models with valid x-api-key...")
+        response = test_client.get(
+            "/v1/models",
+            headers={"x-api-key": valid_proxy_api_key}
+        )
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
         assert response.json()["object"] == "list"


### PR DESCRIPTION
## Summary
- accept Anthropic redacted_thinking content blocks in Messages API requests
- keep redacted thinking payloads out of prompt text conversion
- add model, converter, and route tests for replayed redacted thinking blocks

## Tests
- docker run --rm -v /root/kiro-gateway/tests:/app/tests:ro -v /root/kiro-gateway/pytest.ini:/app/pytest.ini:ro kiro-gateway-kiro-gateway:latest python -m pytest -q tests/unit/test_models_anthropic.py tests/unit/test_converters_anthropic.py tests/unit/test_routes_anthropic.py