### PR TITLE
fix(openai): accept x-api-key for model discovery

### DIFF
--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -29,6 +29,8 @@ Contains all API endpoints:
 import json
 from datetime import datetime, timezone
 
+from typing import Optional
+
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, Security
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import APIKeyHeader
@@ -62,16 +64,22 @@ except ImportError:
 
 # --- Security scheme ---
 api_key_header = APIKeyHeader(name="Authorization", auto_error=False)
+x_api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
 
 
-async def verify_api_key(auth_header: str = Security(api_key_header)) -> bool:
+async def verify_api_key(
+    auth_header: Optional[str] = Security(api_key_header),
+    x_api_key: Optional[str] = Security(x_api_key_header),
+) -> bool:
     """
-    Verify API key in Authorization header.
+    Verify API key in Authorization or x-api-key header.
     
-    Expects format: "Bearer {PROXY_API_KEY}"
+    Supports OpenAI-style "Authorization: Bearer {PROXY_API_KEY}" and
+    Anthropic-style "x-api-key: {PROXY_API_KEY}" for model discovery clients.
     
     Args:
         auth_header: Authorization header value
+        x_api_key: x-api-key header value
     
     Returns:
         True if key is valid
@@ -79,10 +87,14 @@ async def verify_api_key(auth_header: str = Security(api_key_header)) -> bool:
     Raises:
         HTTPException: 401 if key is invalid or missing
     """
-    if not auth_header or auth_header != f"Bearer {PROXY_API_KEY}":
-        logger.warning("Access attempt with invalid API key.")
-        raise HTTPException(status_code=401, detail="Invalid or missing API Key")
-    return True
+    if auth_header and auth_header == f"Bearer {PROXY_API_KEY}":
+        return True
+
+    if x_api_key and x_api_key == PROXY_API_KEY:
+        return True
+
+    logger.warning("Access attempt with invalid API key.")
+    raise HTTPException(status_code=401, detail="Invalid or missing API Key")
 
 
 # --- Router ---

--- a/tests/unit/test_routes_openai.py
+++ b/tests/unit/test_routes_openai.py
@@ -47,6 +47,20 @@ class TestVerifyApiKey:
         
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
+
+    @pytest.mark.asyncio
+    async def test_valid_x_api_key_returns_true(self):
+        """
+        What it does: Verifies that a valid x-api-key passes authentication.
+        Purpose: Support Anthropic-style model discovery clients.
+        """
+        print("Setup: Creating valid x-api-key...")
+
+        print("Action: Calling verify_api_key...")
+        result = await verify_api_key(None, PROXY_API_KEY)
+
+        print(f"Comparing result: Expected True, Got {result}")
+        assert result is True
     
     @pytest.mark.asyncio
     async def test_invalid_api_key_raises_401(self):
@@ -301,6 +315,21 @@ class TestModelsEndpoint:
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
         )
         
+        print(f"Result: {response.json()}")
+        assert response.status_code == 200
+        assert response.json()["object"] == "list"
+
+    def test_models_accepts_x_api_key(self, test_client, valid_proxy_api_key):
+        """
+        What it does: Verifies models endpoint accepts x-api-key auth.
+        Purpose: Ensure Anthropic channel model discovery can call /v1/models.
+        """
+        print("Action: GET /v1/models with valid x-api-key...")
+        response = test_client.get(
+            "/v1/models",
+            headers={"x-api-key": valid_proxy_api_key}
+        )
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
         assert response.json()["object"] == "list"


### PR DESCRIPTION
## Summary

Anthropic-style channel model discovery can call OpenAI-compatible endpoints with `x-api-key` instead of `Authorization: Bearer ...`. This PR lets the OpenAI route auth helper accept both header styles.

## Changes

- Add `x-api-key` as an accepted auth header on OpenAI-compatible routes
- Keep existing `Authorization: Bearer` behavior unchanged
- Add coverage for direct auth helper validation and `/v1/models`

## Test plan

- [x] Added unit test for `verify_api_key` accepting `x-api-key`
- [x] Added route test for `GET /v1/models` with `x-api-key`

## CLA

I have read the CLA and I accept its terms.