### PR TITLE
fix(models): add redacted_thinking content block support

### DIFF
--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -65,6 +65,20 @@ class ThinkingContentBlock(BaseModel):
     signature: str = ""
 
 
+class RedactedThinkingContentBlock(BaseModel):
+    """
+    Redacted thinking content block in Anthropic format.
+
+    Claude may return encrypted reasoning when extended thinking is enabled.
+    Clients can replay these blocks in later requests; the gateway accepts
+    them for schema compatibility without exposing the opaque data as prompt
+    text.
+    """
+
+    type: Literal["redacted_thinking"] = "redacted_thinking"
+    data: str
+
+
 class ToolUseContentBlock(BaseModel):
     """
     Tool use content block in Anthropic format.
@@ -166,6 +180,7 @@ class ImageContentBlock(BaseModel):
 ContentBlock = Union[
     TextContentBlock,
     ThinkingContentBlock,
+    RedactedThinkingContentBlock,
     ImageContentBlock,
     ToolUseContentBlock,
     ToolResultContentBlock,

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -32,6 +32,7 @@ from kiro.models_anthropic import (
     AnthropicMessage,
     AnthropicTool,
     TextContentBlock,
+    RedactedThinkingContentBlock,
     ToolUseContentBlock,
     ToolResultContentBlock,
     SystemContentBlock,
@@ -111,6 +112,26 @@ class TestConvertAnthropicContentToText:
 
         print(f"Comparing result: Expected 'Hello World', Got '{result}'")
         assert result == "Hello World"
+
+    def test_ignores_redacted_thinking_blocks(self):
+        """
+        What it does: Verifies redacted_thinking payloads are not extracted as text.
+        Purpose: Accept Anthropic replay blocks without leaking opaque reasoning data to Kiro.
+        """
+        print("Setup: List with text and redacted_thinking blocks...")
+        content = [
+            TextContentBlock(text="Visible answer"),
+            RedactedThinkingContentBlock(data="encrypted-thinking-payload"),
+            {"type": "text", "text": " continues"},
+            {"type": "redacted_thinking", "data": "another-encrypted-payload"},
+        ]
+
+        print("Action: Extracting text...")
+        result = convert_anthropic_content_to_text(content)
+
+        print(f"Comparing result: Expected 'Visible answer continues', Got '{result}'")
+        assert result == "Visible answer continues"
+        assert "encrypted" not in result
 
     def test_handles_none(self):
         """

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -19,6 +19,7 @@ from kiro.models_anthropic import (
     # Content blocks
     TextContentBlock,
     ThinkingContentBlock,
+    RedactedThinkingContentBlock,
     ToolUseContentBlock,
     ToolResultContentBlock,
     ToolReferenceContentBlock,
@@ -386,6 +387,19 @@ class TestContentBlockUnion:
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'tool_result', Got '{block.type}'")
         assert block.type == "tool_result"
+
+    def test_accepts_redacted_thinking_content_block(self):
+        """
+        What it does: Verifies ContentBlock accepts redacted_thinking blocks.
+        Purpose: Ensure replayed Anthropic extended thinking does not 422.
+        """
+        print("Setup: Creating RedactedThinkingContentBlock...")
+        block: ContentBlock = RedactedThinkingContentBlock(data="encrypted-payload")
+
+        print(f"Result: {block}")
+        print(f"Comparing type: Expected 'redacted_thinking', Got '{block.type}'")
+        assert block.type == "redacted_thinking"
+        assert block.data == "encrypted-payload"
 
 
 # ==================================================================================================
@@ -757,6 +771,41 @@ class TestThinkingContentBlock:
         
         print(f"ValidationError raised: {exc_info.value}")
         assert "thinking" in str(exc_info.value)
+
+
+# ==================================================================================================
+# Tests for RedactedThinkingContentBlock
+# ==================================================================================================
+
+class TestRedactedThinkingContentBlock:
+    """Tests for RedactedThinkingContentBlock Pydantic model."""
+
+    def test_valid_redacted_thinking_block(self):
+        """
+        What it does: Verifies creation of valid redacted_thinking content.
+        Purpose: Ensure Anthropic extended thinking replay blocks validate.
+        """
+        print("Setup: Creating RedactedThinkingContentBlock with valid data...")
+        block = RedactedThinkingContentBlock(data="encrypted-thinking-payload")
+
+        print(f"Result: {block}")
+        print(f"Comparing type: Expected 'redacted_thinking', Got '{block.type}'")
+        assert block.type == "redacted_thinking"
+        assert block.data == "encrypted-thinking-payload"
+
+    def test_requires_data(self):
+        """
+        What it does: Verifies data is required for redacted_thinking.
+        Purpose: Match Anthropic's block shape.
+        """
+        print("Setup: Attempting to create RedactedThinkingContentBlock without data...")
+
+        print("Action: Creating model (should raise ValidationError)...")
+        with pytest.raises(ValidationError) as exc_info:
+            RedactedThinkingContentBlock()
+
+        print(f"ValidationError raised: {exc_info.value}")
+        assert "data" in str(exc_info.value)
 
 
 # ==================================================================================================

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -527,6 +527,37 @@ class TestMessagesContentBlocks:
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
+    def test_accepts_redacted_thinking_content_block(self, test_client, valid_proxy_api_key):
+        """
+        What it does: Verifies redacted_thinking blocks are accepted.
+        Purpose: Ensure Claude Code replayed extended thinking does not fail validation.
+        """
+        print("Action: POST /v1/messages with redacted_thinking content block...")
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-4-5",
+                "max_tokens": 1024,
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "Previous answer"},
+                            {"type": "redacted_thinking", "data": "encrypted-payload"}
+                        ]
+                    },
+                    {
+                        "role": "user",
+                        "content": "Continue"
+                    }
+                ]
+            }
+        )
+
+        print(f"Status: {response.status_code}")
+        assert response.status_code != 422
+
 
 # =============================================================================
 # Tests for /v1/messages tool use


### PR DESCRIPTION
## Summary

Claude and Anthropic clients may replay redacted_thinking content blocks in Messages API history. The gateway should validate those official blocks while keeping the opaque redacted payload out of prompt text conversion.

## Changes

- Add RedactedThinkingContentBlock for Anthropic redacted_thinking content
- Include redacted_thinking in the ContentBlock union
- Keep converter behavior ignoring non-text redacted thinking payload data
- Add model, converter, and route coverage for replayed redacted thinking blocks

## Test plan

- [x] Added model validation tests for RedactedThinkingContentBlock
- [x] Added ContentBlock union test for redacted_thinking blocks
- [x] Added converter test ensuring redacted_thinking data is ignored as prompt text
- [x] Added /v1/messages route validation test for replayed redacted_thinking content

## CLA

I have read the CLA and I accept its terms.