### PR TITLE
[codex] Support Anthropic document PDF blocks

### DIFF
--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -24,6 +24,8 @@ This module is an adapter layer that converts Anthropic-specific formats
 to the unified format used by converters_core.py.
 """
 
+import base64
+from io import BytesIO
 from typing import Any, Dict, List, Optional
 
 from loguru import logger
@@ -43,6 +45,114 @@ from kiro.converters_core import (
     extract_text_content,
     extract_images_from_content,
 )
+
+try:
+    from pypdf import PdfReader
+except ImportError:  # pragma: no cover - exercised only when optional dependency is absent
+    PdfReader = None
+
+
+MAX_EXTRACTED_DOCUMENT_CHARS = 60000
+
+
+def _block_value(block: Any, key: str, default: Any = None) -> Any:
+    if isinstance(block, dict):
+        return block.get(key, default)
+    return getattr(block, key, default)
+
+
+def _truncate_document_text(text: str) -> str:
+    if len(text) <= MAX_EXTRACTED_DOCUMENT_CHARS:
+        return text
+    return text[:MAX_EXTRACTED_DOCUMENT_CHARS] + "\n\n[Document text truncated]"
+
+
+def _extract_pdf_text_from_base64(data: str) -> str:
+    if PdfReader is None:
+        return "[PDF text extraction unavailable: pypdf is not installed]"
+
+    pdf_bytes = base64.b64decode(data)
+    reader = PdfReader(BytesIO(pdf_bytes))
+    page_texts = []
+
+    for index, page in enumerate(reader.pages, start=1):
+        text = page.extract_text() or ""
+        text = text.strip()
+        if text:
+            page_texts.append(f"Page {index}:\n{text}")
+
+    if not page_texts:
+        return "[PDF text extraction returned no text]"
+
+    return _truncate_document_text("\n\n".join(page_texts))
+
+
+def _document_block_to_text(block: Any) -> str:
+    source = _block_value(block, "source", {})
+    title = _block_value(block, "title", None)
+
+    if isinstance(source, dict):
+        source_type = source.get("type")
+        media_type = source.get("media_type", "application/octet-stream")
+        data = source.get("data", "")
+        url = source.get("url", "")
+    else:
+        source_type = getattr(source, "type", None)
+        media_type = getattr(source, "media_type", "application/octet-stream")
+        data = getattr(source, "data", "")
+        url = getattr(source, "url", "")
+
+    label = f"Document: {title or media_type}"
+
+    if source_type == "base64" and data:
+        try:
+            if media_type == "application/pdf":
+                body = _extract_pdf_text_from_base64(data)
+            elif media_type.startswith("text/"):
+                body = base64.b64decode(data).decode("utf-8", errors="replace")
+                body = _truncate_document_text(body)
+            else:
+                byte_count = len(base64.b64decode(data, validate=True))
+                body = f"[Document extraction unsupported for {media_type}; {byte_count} bytes]"
+        except Exception as exc:
+            logger.warning(f"Failed to extract Anthropic document block ({media_type}): {exc}")
+            body = f"[Document extraction failed for {media_type}: {exc}]"
+
+        return f"[{label}]\n{body}"
+
+    if source_type == "url" and url:
+        return f"[{label}]\n[URL document sources are not supported by Kiro Gateway: {url}]"
+
+    return f"[{label}]\n[Document source was empty or unsupported]"
+
+
+def extract_documents_from_anthropic_content(content: Any) -> str:
+    """
+    Extracts document blocks from Anthropic content as plain text.
+
+    Kiro does not accept Anthropic document blocks directly, so PDF/text
+    documents are converted into text and appended to the user message.
+    """
+    if not isinstance(content, list):
+        return ""
+
+    document_parts = []
+
+    for block in content:
+        block_type = _block_value(block, "type")
+
+        if block_type == "document":
+            document_parts.append(_document_block_to_text(block))
+            continue
+
+        if block_type == "tool_result":
+            result_content = _block_value(block, "content", None)
+            if isinstance(result_content, list):
+                for item in result_content:
+                    if _block_value(item, "type") == "document":
+                        document_parts.append(_document_block_to_text(item))
+
+    return "\n\n".join(document_parts)
 
 
 def convert_anthropic_content_to_text(content: Any) -> str:
@@ -284,6 +394,9 @@ def convert_anthropic_messages(
 
         # Extract text content
         text_content = convert_anthropic_content_to_text(content)
+        document_text = extract_documents_from_anthropic_content(content)
+        if document_text:
+            text_content = f"{text_content}\n\n{document_text}".strip()
 
         # Extract tool-related data and images based on role
         tool_calls = None

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -166,8 +166,8 @@ def extract_text_content(content: Any) -> str:
         text_parts = []
         for item in content:
             if isinstance(item, dict):
-                # Skip image and tool_reference blocks - they're handled separately
-                if item.get("type") in ("image", "image_url", "tool_reference"):
+                # Skip non-text blocks handled by adapter-specific extractors.
+                if item.get("type") in ("image", "image_url", "document", "tool_reference"):
                     continue
                 if item.get("type") == "text":
                     text_parts.append(item.get("text", ""))

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -103,7 +103,17 @@ class ToolResultContentBlock(BaseModel):
     type: Literal["tool_result"] = "tool_result"
     tool_use_id: str
     content: Optional[
-        Union[str, List[Union["TextContentBlock", "ImageContentBlock", "ToolReferenceContentBlock"]]]
+        Union[
+            str,
+            List[
+                Union[
+                    "TextContentBlock",
+                    "ImageContentBlock",
+                    "DocumentContentBlock",
+                    "ToolReferenceContentBlock",
+                ]
+            ],
+        ]
     ] = None
     is_error: Optional[bool] = None
 
@@ -162,11 +172,50 @@ class ImageContentBlock(BaseModel):
     source: Union[Base64ImageSource, URLImageSource]
 
 
+class Base64DocumentSource(BaseModel):
+    """
+    Base64-encoded document source in Anthropic format.
+
+    Claude Code sends PDFs read from disk as document blocks with
+    base64 sources.
+    """
+
+    type: Literal["base64"] = "base64"
+    media_type: str
+    data: str
+
+
+class URLDocumentSource(BaseModel):
+    """
+    URL-based document source in Anthropic format.
+    """
+
+    type: Literal["url"] = "url"
+    url: str
+
+
+class DocumentContentBlock(BaseModel):
+    """
+    Document content block in Anthropic format.
+
+    Represents a document such as a PDF included in a message.
+    """
+
+    type: Literal["document"] = "document"
+    source: Union[Base64DocumentSource, URLDocumentSource, Dict[str, Any]]
+    title: Optional[str] = None
+    context: Optional[str] = None
+    cache_control: Optional[Dict[str, Any]] = None
+
+    model_config = {"extra": "allow"}
+
+
 # Union type for all content blocks (including images and thinking)
 ContentBlock = Union[
     TextContentBlock,
     ThinkingContentBlock,
     ImageContentBlock,
+    DocumentContentBlock,
     ToolUseContentBlock,
     ToolResultContentBlock,
     ToolReferenceContentBlock,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ httpx
 loguru
 python-dotenv
 tiktoken
+pypdf
 
 # Testing dependencies
 pytest

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -38,6 +38,10 @@ from kiro.models_anthropic import (
 )
 
 
+# Tiny one-page PDF containing "Resume Alpha" for document block tests
+TEST_PDF_BASE64 = "JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCAzMDAgMTQ0XSAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA0IDAgUiA+PiA+PiAvQ29udGVudHMgNSAwIFIgPj4KZW5kb2JqCjQgMCBvYmoKPDwgL1R5cGUgL0ZvbnQgL1N1YnR5cGUgL1R5cGUxIC9CYXNlRm9udCAvSGVsdmV0aWNhID4+CmVuZG9iago1IDAgb2JqCjw8IC9MZW5ndGggNDMgPj4Kc3RyZWFtCkJUIC9GMSAxMiBUZiA3MiA3MiBUZCAoUmVzdW1lIEFscGhhKSBUaiBFVAplbmRzdHJlYW0KZW5kb2JqCnhyZWYKMCA2CjAwMDAwMDAwMDAgNjU1MzUgZiAKMDAwMDAwMDAwOSAwMDAwMCBuIAowMDAwMDAwMDU4IDAwMDAwIG4gCjAwMDAwMDAxMTUgMDAwMDAgbiAKMDAwMDAwMDI0MSAwMDAwMCBuIAowMDAwMDAwMzExIDAwMDAwIG4gCnRyYWlsZXIKPDwgL1NpemUgNiAvUm9vdCAxIDAgUiA+PgpzdGFydHhyZWYKNDAzCiUlRU9GCg=="
+
+
 # ==================================================================================================
 # Tests for convert_anthropic_content_to_text
 # ==================================================================================================
@@ -1063,6 +1067,44 @@ class TestConvertAnthropicMessages:
         assert result[0].tool_results is not None
         assert len(result[0].tool_results) == 1
         assert result[0].tool_results[0]["tool_use_id"] == "call_123"
+
+    def test_converts_claude_code_pdf_tool_result_to_text(self):
+        """
+        What it does: Verifies Claude Code PDF tool results expose document text.
+        Purpose: Prevent 422s and avoid forwarding raw base64 to Kiro.
+        """
+        print("Setup: User message with tool_result and PDF document block...")
+        messages = [
+            AnthropicMessage(
+                role="user",
+                content=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tooluse_pdf",
+                        "content": "PDF file read: /tmp/resume.pdf",
+                    },
+                    {
+                        "type": "document",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "application/pdf",
+                            "data": TEST_PDF_BASE64,
+                        },
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                ],
+            )
+        ]
+
+        print("Action: Converting messages...")
+        result = convert_anthropic_messages(messages)
+
+        print(f"Result: {result}")
+        assert len(result) == 1
+        assert result[0].tool_results is not None
+        assert result[0].tool_results[0]["content"] == "PDF file read: /tmp/resume.pdf"
+        assert "Resume Alpha" in result[0].content
+        assert TEST_PDF_BASE64 not in result[0].content
 
     def test_converts_full_conversation(self):
         """

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -63,6 +63,9 @@ from kiro.models_anthropic import (
 # Base64 1x1 pixel JPEG for testing
 TEST_IMAGE_BASE64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q=="
 
+# Tiny one-page PDF containing "Resume Alpha" for document block tests
+TEST_PDF_BASE64 = "JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCAzMDAgMTQ0XSAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA0IDAgUiA+PiA+PiAvQ29udGVudHMgNSAwIFIgPj4KZW5kb2JqCjQgMCBvYmoKPDwgL1R5cGUgL0ZvbnQgL1N1YnR5cGUgL1R5cGUxIC9CYXNlRm9udCAvSGVsdmV0aWNhID4+CmVuZG9iago1IDAgb2JqCjw8IC9MZW5ndGggNDMgPj4Kc3RyZWFtCkJUIC9GMSAxMiBUZiA3MiA3MiBUZCAoUmVzdW1lIEFscGhhKSBUaiBFVAplbmRzdHJlYW0KZW5kb2JqCnhyZWYKMCA2CjAwMDAwMDAwMDAgNjU1MzUgZiAKMDAwMDAwMDAwOSAwMDAwMCBuIAowMDAwMDAwMDU4IDAwMDAwIG4gCjAwMDAwMDAxMTUgMDAwMDAgbiAKMDAwMDAwMDI0MSAwMDAwMCBuIAowMDAwMDAwMzExIDAwMDAwIG4gCnRyYWlsZXIKPDwgL1NpemUgNiAvUm9vdCAxIDAgUiA+PgpzdGFydHhyZWYKNDAzCiUlRU9GCg=="
+
 
 # ==================================================================================================
 # Tests for Base64ImageSource
@@ -386,6 +389,37 @@ class TestContentBlockUnion:
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'tool_result', Got '{block.type}'")
         assert block.type == "tool_result"
+
+    def test_message_accepts_document_content_block(self):
+        """
+        What it does: Verifies AnthropicMessage accepts document blocks.
+        Purpose: Claude Code sends PDFs as document blocks after reading files.
+        """
+        print("Setup: Creating AnthropicMessage with PDF document content...")
+        message = AnthropicMessage(
+            role="user",
+            content=[
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "tooluse_pdf",
+                    "content": "PDF file read: /tmp/resume.pdf",
+                },
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "application/pdf",
+                        "data": TEST_PDF_BASE64,
+                    },
+                    "cache_control": {"type": "ephemeral"},
+                },
+            ],
+        )
+
+        print(f"Result: {message}")
+        assert message.role == "user"
+        assert len(message.content) == 2
+        assert message.content[1].type == "document"
 
 
 # ==================================================================================================


### PR DESCRIPTION
## Summary
- Accept Anthropic `document` content blocks in Messages API requests, including Claude Code PDF file-read results.
- Convert base64 PDF and text document blocks into plain text for the Kiro payload instead of forwarding raw base64.
- Add regression coverage for Claude Code's `tool_result` plus PDF `document` shape.

## Root Cause
Claude Code sends PDFs as Anthropic `document` blocks after reading a local PDF. Kiro Gateway's Anthropic schema only accepted text, thinking, image, tool use/result, and tool reference blocks, so those requests failed validation with HTTP 422 before conversion.

## Validation
- `python3 -m pytest tests/unit/test_models_anthropic.py tests/unit/test_converters_anthropic.py -q`
