### PR TITLE
fix(schema): drop invalid required values

### DIFF
--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -441,7 +441,7 @@ def sanitize_json_schema(schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     Sanitizes JSON Schema from fields that Kiro API doesn't accept.
     
     Kiro API returns 400 "Improperly formed request" error if:
-    - required is an empty array []
+    - required is not a non-empty array
     - additionalProperties is present in schema
     
     This function recursively processes the schema and removes problematic fields.
@@ -458,9 +458,11 @@ def sanitize_json_schema(schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     result = {}
     
     for key, value in schema.items():
-        # Skip empty required arrays
-        if key == "required" and isinstance(value, list) and len(value) == 0:
-            continue
+        # Skip invalid or empty required values. Bedrock requires an array
+        # when this field is present, and Kiro rejects empty arrays.
+        if key == "required":
+            if not isinstance(value, list) or len(value) == 0:
+                continue
         
         # Skip additionalProperties - Kiro API doesn't support it
         if key == "additionalProperties":

--- a/tests/unit/test_converters_core.py
+++ b/tests/unit/test_converters_core.py
@@ -2620,6 +2620,51 @@ class TestSanitizeJsonSchema:
         assert "required" not in result
         assert result["type"] == "object"
         assert result["properties"] == {}
+
+    def test_removes_null_required_value(self):
+        """
+        What it does: Verifies removal of null required value.
+        Purpose: Ensure required: None is removed from schema.
+
+        Bedrock rejects tool schemas with required: null because required must
+        be an array when present.
+        """
+        print("Setup: Schema with null required...")
+        schema = {
+            "type": "object",
+            "properties": {},
+            "required": None
+        }
+
+        print("Action: Sanitizing schema...")
+        result = sanitize_json_schema(schema)
+
+        print(f"Result: {result}")
+        print("Checking that required is removed...")
+        assert "required" not in result
+        assert result["type"] == "object"
+        assert result["properties"] == {}
+
+    def test_removes_non_array_required_value(self):
+        """
+        What it does: Verifies removal of non-array required value.
+        Purpose: Ensure invalid required values are removed from schema.
+        """
+        print("Setup: Schema with non-array required...")
+        schema = {
+            "type": "object",
+            "properties": {},
+            "required": "location"
+        }
+
+        print("Action: Sanitizing schema...")
+        result = sanitize_json_schema(schema)
+
+        print(f"Result: {result}")
+        print("Checking that required is removed...")
+        assert "required" not in result
+        assert result["type"] == "object"
+        assert result["properties"] == {}
     
     def test_preserves_non_empty_required_array(self):
         """
@@ -2711,6 +2756,31 @@ class TestSanitizeJsonSchema:
         nested = result["properties"]["nested"]
         assert "required" not in nested
         assert "additionalProperties" not in nested
+
+    def test_recursively_removes_null_required_value(self):
+        """
+        What it does: Verifies recursive removal of null required values.
+        Purpose: Ensure nested schemas with required: None are sanitized.
+        """
+        print("Setup: Schema with nested null required...")
+        schema = {
+            "type": "object",
+            "properties": {
+                "nested": {
+                    "type": "object",
+                    "properties": {},
+                    "required": None
+                }
+            }
+        }
+
+        print("Action: Sanitizing schema...")
+        result = sanitize_json_schema(schema)
+
+        print(f"Result: {result}")
+        print("Checking nested object...")
+        nested = result["properties"]["nested"]
+        assert "required" not in nested
     
     def test_sanitizes_items_in_lists(self):
         """
@@ -3500,6 +3570,29 @@ class TestConvertToolsToKiroFormat:
         schema = result[0]["toolSpecification"]["inputSchema"]["json"]
         assert "required" not in schema
         assert "additionalProperties" not in schema
+
+    def test_sanitizes_null_required_in_input_schema(self):
+        """
+        What it does: Verifies null required values are removed from input schema.
+        Purpose: Ensure Bedrock receives a valid tool inputSchema.
+        """
+        print("Setup: Tool with null required...")
+        tools = [UnifiedTool(
+            name="test_tool",
+            description="Test",
+            input_schema={
+                "type": "object",
+                "properties": {},
+                "required": None
+            }
+        )]
+
+        print("Action: Converting tools...")
+        result = convert_tools_to_kiro_format(tools)
+
+        print(f"Result: {result}")
+        schema = result[0]["toolSpecification"]["inputSchema"]["json"]
+        assert "required" not in schema
 
 
 # ==================================================================================================


### PR DESCRIPTION
## Summary
- remove invalid `required` values from sanitized JSON schemas
- keep non-empty `required` arrays unchanged
- add regression coverage for null and non-array `required` values, including tool input schema conversion

## Root Cause
Bedrock rejects tool schemas when `inputSchema.json.required` is present but not an array. The gateway already removed empty arrays for Kiro compatibility, but `required: null` passed through unchanged and triggered `TOOL_SCHEMA_INVALID`.

## Validation
- `.venv/bin/python -m pytest tests/unit/test_converters_core.py::TestSanitizeJsonSchema tests/unit/test_converters_core.py::TestConvertToolsToKiroFormat -q`
- `.venv/bin/python -m pytest tests/unit/test_converters_core.py -q`

Note: `.venv/bin/python -m pytest tests/unit -q` currently reaches 1598 passing tests and then fails 79 route tests during TestClient startup because this local checkout has no `credentials.json`; those failures are unrelated to this schema sanitizer change.
