### PR TITLE
fix: handle profileArn runtime endpoint regressions (#168, #173)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,14 @@ PROXY_API_KEY="my-super-secret-password-123"
 # Example: Your SSO is in eu-west-1 but Q API only works in eu-central-1
 # KIRO_API_REGION="eu-central-1"
 
+# Use legacy q.amazonaws.com endpoint instead of runtime.kiro.dev
+# Set to "true" ONLY for Builder ID (free tier) accounts that have no profileArn.
+# Since May 2026, runtime.kiro.dev requires profileArn for all requests.
+# Builder ID accounts have no profileArn and no API to discover one.
+# This is a compatibility fallback, not the preferred default.
+# See: https://github.com/jwadow/kiro-gateway/issues/168
+# KIRO_USE_LEGACY_ENDPOINT="false"
+
 # ===========================================
 # SERVER SETTINGS
 # ===========================================

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Made with ❤️ by [@Jwadow](https://github.com/jwadow)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.100+-green.svg)](https://fastapi.tiangolo.com/)
 [![Sponsor](https://img.shields.io/badge/💖_Sponsor-Support_Development-ff69b4)](#-support-the-project)
 
-*Use Claude models from Kiro with Claude Code, OpenCode, OpenClaw, Claw Code, Codex app, Cursor, Cline, Roo Code, Kilo Code, Obsidian, OpenAI SDK, LangChain, Continue and other OpenAI or Anthropic compatible tools*
+_Use Claude models from Kiro with Claude Code, OpenCode, OpenClaw, Claw Code, Codex app, Cursor, Cline, Roo Code, Kilo Code, Obsidian, OpenAI SDK, LangChain, Continue and other OpenAI or Anthropic compatible tools_
 
 [Models](#-supported-models) • [Features](#-features) • [Quick Start](#-quick-start) • [Configuration](#%EF%B8%8F-configuration) • [💖 Sponsor](#-support-the-project)
 
@@ -49,27 +49,28 @@ Made with ❤️ by [@Jwadow](https://github.com/jwadow)
 
 ## ✨ Features
 
-| Feature | Description |
-|---------|-------------|
-| 🔌 **OpenAI-compatible API** | Works with any OpenAI-compatible tool |
-| 🔌 **Anthropic-compatible API** | Native `/v1/messages` endpoint |
-| 🔀 **Multi-Account Support** | Intelligent failover between multiple accounts |
-| 🌐 **VPN/Proxy Support** | HTTP/SOCKS5 proxy for restricted networks |
-| 🧠 **Extended Thinking** | Reasoning is exclusive to our project |
-| 👁️ **Vision Support** | Send images to model |
-| 🔍 **Web Search** | Search the web for current information |
-| 🛠️ **Tool Calling** | Supports function calling |
-| 💬 **Full message history** | Passes complete conversation context |
-| 📡 **Streaming** | Full SSE streaming support |
-| 🔄 **Retry Logic** | Automatic retries on errors (403, 429, 5xx) |
-| 📋 **Extended model list** | Including versioned models |
-| 🔐 **Smart token management** | Automatic refresh before expiration |
+| Feature                         | Description                                    |
+| ------------------------------- | ---------------------------------------------- |
+| 🔌 **OpenAI-compatible API**    | Works with any OpenAI-compatible tool          |
+| 🔌 **Anthropic-compatible API** | Native `/v1/messages` endpoint                 |
+| 🔀 **Multi-Account Support**    | Intelligent failover between multiple accounts |
+| 🌐 **VPN/Proxy Support**        | HTTP/SOCKS5 proxy for restricted networks      |
+| 🧠 **Extended Thinking**        | Reasoning is exclusive to our project          |
+| 👁️ **Vision Support**           | Send images to model                           |
+| 🔍 **Web Search**               | Search the web for current information         |
+| 🛠️ **Tool Calling**             | Supports function calling                      |
+| 💬 **Full message history**     | Passes complete conversation context           |
+| 📡 **Streaming**                | Full SSE streaming support                     |
+| 🔄 **Retry Logic**              | Automatic retries on errors (403, 429, 5xx)    |
+| 📋 **Extended model list**      | Including versioned models                     |
+| 🔐 **Smart token management**   | Automatic refresh before expiration            |
 
 ---
 
 ## 🚀 Quick Start
 
 **Choose your deployment method:**
+
 - 🐍 **Native Python** - Full control, easy debugging
 - 🐳 **Docker** - Isolated environment, easy deployment → [jump to Docker](#-docker-deployment)
 
@@ -116,6 +117,7 @@ The server will be available at `http://localhost:8000`
 Specify the path to the credentials file:
 
 Works with:
+
 - **Kiro IDE** (standard) - for personal accounts
 - **Enterprise** - for corporate accounts with SSO
 
@@ -137,7 +139,7 @@ PROXY_API_KEY="my-super-secret-password-123"
   "expiresAt": "2025-01-12T23:00:00.000Z",
   "profileArn": "arn:aws:codewhisperer:us-east-1:...",
   "region": "us-east-1",
-  "clientIdHash": "abc123..."  // Optional: for corporate SSO setups
+  "clientIdHash": "abc123..." // Optional: for corporate SSO setups
 }
 ```
 
@@ -204,7 +206,6 @@ The gateway automatically detects the authentication type based on the credentia
 
 - **Kiro Desktop Auth** (default): Used when `clientId` and `clientSecret` are NOT present
   - Endpoint: `https://prod.{region}.auth.desktop.kiro.dev/refreshToken`
-  
 - **AWS SSO (OIDC)**: Used when `clientId` and `clientSecret` ARE present
   - Endpoint: `https://oidc.{region}.amazonaws.com/token`
 
@@ -229,12 +230,13 @@ PROXY_API_KEY="my-super-secret-password-123"
 <details>
 <summary>📄 Database locations</summary>
 
-| CLI Tool | Database Path |
-|----------|---------------|
-| kiro-cli | `~/.local/share/kiro-cli/data.sqlite3` |
+| CLI Tool               | Database Path                          |
+| ---------------------- | -------------------------------------- |
+| kiro-cli               | `~/.local/share/kiro-cli/data.sqlite3` |
 | amazon-q-developer-cli | `~/.local/share/amazon-q/data.sqlite3` |
 
 The gateway reads credentials from the `auth_kv` table which stores:
+
 - `kirocli:odic:token` or `codewhisperer:odic:token` — access token, refresh token, expiration
 - `kirocli:odic:device-registration` or `codewhisperer:odic:device-registration` — client ID and secret
 
@@ -245,10 +247,12 @@ Both key formats are supported for compatibility with different kiro-cli version
 ### Getting Credentials
 
 **For Kiro IDE users:**
+
 - Log in to Kiro IDE and use Option 1 above (JSON credentials file)
 - The credentials file is created automatically after login
 
 **For Kiro CLI users:**
+
 - Log in with `kiro-cli login` and use Option 3 or Option 4 above
 - No manual token extraction needed!
 
@@ -256,6 +260,7 @@ Both key formats are supported for compatibility with different kiro-cli version
 <summary>🔧 Advanced: Manual token extraction</summary>
 
 If you need to manually extract the refresh token (e.g., for debugging), you can intercept Kiro IDE traffic:
+
 - Look for requests to: `prod.us-east-1.auth.desktop.kiro.dev/refreshToken`
 
 </details>
@@ -281,6 +286,7 @@ ACCOUNT_SYSTEM=true
 ```
 
 **What happens:**
+
 - On first startup, your credentials from `.env` are automatically migrated to `credentials.json` (one-time)
 - After that, all account and region settings from `.env` are ignored
 - Account management only through `credentials.json`
@@ -289,6 +295,7 @@ ACCOUNT_SYSTEM=true
 <summary>📄 Configuration Examples</summary>
 
 **Single account:**
+
 ```json
 [
   {
@@ -299,6 +306,7 @@ ACCOUNT_SYSTEM=true
 ```
 
 **Multiple accounts:**
+
 ```json
 [
   {
@@ -318,6 +326,7 @@ ACCOUNT_SYSTEM=true
 ```
 
 **Folder with files:**
+
 ```json
 [
   {
@@ -382,6 +391,7 @@ docker run -d \
 <summary>🔹 Using Credentials File</summary>
 
 **Linux/macOS:**
+
 ```bash
 docker run -d \
   -p 8000:8000 \
@@ -393,6 +403,7 @@ docker run -d \
 ```
 
 **Windows (PowerShell):**
+
 ```powershell
 docker run -d `
   -p 8000:8000 `
@@ -421,13 +432,13 @@ Edit `docker-compose.yml` and uncomment volume mounts for your OS:
 ```yaml
 volumes:
   # Kiro IDE credentials (choose your OS)
-  - ~/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro              # Linux/macOS
+  - ~/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro # Linux/macOS
   # - ${USERPROFILE}/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro  # Windows
-  
+
   # kiro-cli database (choose your OS)
-  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Linux/macOS
+  - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli # Linux/macOS
   # - ${USERPROFILE}/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Windows
-  
+
   # Debug logs (optional)
   - ./debug_logs:/app/debug_logs
 ```
@@ -486,16 +497,17 @@ VPN_PROXY_URL=192.168.1.100:8080
 
 ### When You Need This
 
-| Situation | Solution |
-|-----------|----------|
-| Connection timeouts to AWS | Use VPN/proxy to route traffic |
-| Corporate network restrictions | Configure your company's proxy |
-| Regional connectivity issues | Use a VPN service with proxy support |
-| Privacy requirements | Route through your own proxy server |
+| Situation                      | Solution                             |
+| ------------------------------ | ------------------------------------ |
+| Connection timeouts to AWS     | Use VPN/proxy to route traffic       |
+| Corporate network restrictions | Configure your company's proxy       |
+| Regional connectivity issues   | Use a VPN service with proxy support |
+| Privacy requirements           | Route through your own proxy server  |
 
 ### Popular VPN Software with Proxy Support
 
 Most VPN clients provide a local proxy server you can use:
+
 - **Sing-box** — Modern VPN client with HTTP/SOCKS5 proxy
 - **Clash** — Usually runs on `http://127.0.0.1:7890`
 - **V2Ray** — Configurable SOCKS5/HTTP proxy
@@ -510,13 +522,13 @@ Leave `VPN_PROXY_URL` empty (default) if you don't need proxy support.
 
 ### Endpoints
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/` | GET | Health check |
-| `/health` | GET | Detailed health check |
-| `/v1/models` | GET | List available models |
-| `/v1/chat/completions` | POST | OpenAI Chat Completions API |
-| `/v1/messages` | POST | Anthropic Messages API |
+| Endpoint               | Method | Description                 |
+| ---------------------- | ------ | --------------------------- |
+| `/`                    | GET    | Health check                |
+| `/health`              | GET    | Detailed health check       |
+| `/v1/models`           | GET    | List available models       |
+| `/v1/chat/completions` | POST   | OpenAI Chat Completions API |
+| `/v1/messages`         | POST   | Anthropic Messages API      |
 
 ---
 
@@ -741,24 +753,24 @@ DEBUG_MODE=errors
 
 ### Debug Modes
 
-| Mode | Description | Use Case |
-|------|-------------|----------|
-| `off` | Disabled (default) | Production |
+| Mode     | Description                                   | Use Case                            |
+| -------- | --------------------------------------------- | ----------------------------------- |
+| `off`    | Disabled (default)                            | Production                          |
 | `errors` | Save logs only for failed requests (4xx, 5xx) | **Recommended for troubleshooting** |
-| `all` | Save logs for every request | Development/debugging |
+| `all`    | Save logs for every request                   | Development/debugging               |
 
 ### Debug Files
 
 When enabled, requests are logged to the `debug_logs/` folder:
 
-| File | Description |
-|------|-------------|
-| `request_body.json` | Incoming request from client (OpenAI format) |
-| `kiro_request_body.json` | Request sent to Kiro API |
-| `response_stream_raw.txt` | Raw stream from Kiro |
-| `response_stream_modified.txt` | Transformed stream (OpenAI format) |
-| `app_logs.txt` | Application logs for the request |
-| `error_info.json` | Error details (only on errors) |
+| File                           | Description                                  |
+| ------------------------------ | -------------------------------------------- |
+| `request_body.json`            | Incoming request from client (OpenAI format) |
+| `kiro_request_body.json`       | Request sent to Kiro API                     |
+| `response_stream_raw.txt`      | Raw stream from Kiro                         |
+| `response_stream_modified.txt` | Transformed stream (OpenAI format)           |
+| `app_logs.txt`                 | Application logs for the request             |
+| `error_info.json`              | Error details (only on errors)               |
 
 ---
 
@@ -800,11 +812,30 @@ KIRO_API_REGION="eu-central-1"
 
 ---
 
+**Error: "profileArn is required for this request"**
+
+Since May 2026, `runtime.kiro.dev` requires `profileArn` for all requests. If you are using a Builder ID (free tier) account that has no profileArn, switch to the legacy endpoint:
+
+```env
+KIRO_USE_LEGACY_ENDPOINT="true"
+```
+
+This is a compatibility fallback. Accounts with a valid profileArn (from credentials.json or Kiro IDE) should keep the default (`false`).
+
+---
+
+**Error: MCP web_search returns 400**
+
+The MCP endpoint at `runtime.kiro.dev/mcp` also requires `profileArn`. Ensure your credentials.json includes a `profile_arn` field, or set `PROFILE_ARN` in your `.env`. If you are a Builder ID user without profileArn, use the legacy endpoint fallback above.
+
+---
+
 ## 📜 License
 
 This project is licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0)**.
 
 This means:
+
 - ✅ You can use, modify, and distribute this software
 - ✅ You can use it for commercial purposes
 - ⚠️ **You must disclose source code** when you distribute the software
@@ -820,6 +851,7 @@ AGPL-3.0 ensures that improvements to this software benefit the entire community
 ### Contributor License Agreement (CLA)
 
 By submitting a contribution to this project, you agree to the terms of our [Contributor License Agreement (CLA)](CLA.md). This ensures that:
+
 - You have the right to submit the contribution
 - You grant the maintainer rights to use and relicense your contribution
 - The project remains legally protected
@@ -846,13 +878,13 @@ Every contribution helps keep this project alive and growing
 
 ### 🪙 Or send crypto
 
-| Currency | Network | Address |
-|:--------:|:-------:|:--------|
-| **USDT** | TRC20 | `TSVtgRc9pkC1UgcbVeijBHjFmpkYHDRu26` |
-| **BTC** | Bitcoin | `12GZqxqpcBsqJ4Vf1YreLqwoMGvzBPgJq6` |
-| **ETH** | Ethereum | `0xc86eab3bba3bbaf4eb5b5fff8586f1460f1fd395` |
-| **SOL** | Solana | `9amykF7KibZmdaw66a1oqYJyi75fRqgdsqnG66AK3jvh` |
-| **TON** | TON | `UQBVh8T1H3GI7gd7b-_PPNnxHYYxptrcCVf3qQk5v41h3QTM` |
+| Currency | Network  | Address                                            |
+| :------: | :------: | :------------------------------------------------- |
+| **USDT** |  TRC20   | `TSVtgRc9pkC1UgcbVeijBHjFmpkYHDRu26`               |
+| **BTC**  | Bitcoin  | `12GZqxqpcBsqJ4Vf1YreLqwoMGvzBPgJq6`               |
+| **ETH**  | Ethereum | `0xc86eab3bba3bbaf4eb5b5fff8586f1460f1fd395`       |
+| **SOL**  |  Solana  | `9amykF7KibZmdaw66a1oqYJyi75fRqgdsqnG66AK3jvh`     |
+| **TON**  |   TON    | `UQBVh8T1H3GI7gd7b-_PPNnxHYYxptrcCVf3qQk5v41h3QTM` |
 
 </div>
 

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -37,44 +37,45 @@ load_dotenv()
 def _get_raw_env_value(var_name: str, env_file: str = ".env") -> Optional[str]:
     """
     Read variable value from .env file without processing escape sequences.
-    
+
     This is necessary for correct handling of Windows paths where backslashes
     (e.g., D:\\Projects\\file.json) may be incorrectly interpreted
     as escape sequences (\\a -> bell, \\n -> newline, etc.).
-    
+
     Args:
         var_name: Environment variable name
         env_file: Path to .env file (default ".env")
-    
+
     Returns:
         Raw variable value or None if not found
     """
     env_path = Path(env_file)
     if not env_path.exists():
         return None
-    
+
     try:
         # Read file as-is, without interpretation
         content = env_path.read_text(encoding="utf-8")
-        
+
         # Search for variable considering different formats:
         # VAR="value" or VAR='value' or VAR=value
         # Pattern captures value with or without quotes
         pattern = rf'^{re.escape(var_name)}=(["\']?)(.+?)\1\s*$'
-        
+
         for line in content.splitlines():
             line = line.strip()
             if line.startswith("#") or not line:
                 continue
-            
+
             match = re.match(pattern, line)
             if match:
                 # Return value as-is, without processing escape sequences
                 return match.group(2)
     except Exception:
         pass
-    
+
     return None
+
 
 # ==================================================================================================
 # Server Settings
@@ -149,40 +150,65 @@ REGION: str = os.getenv("KIRO_REGION", "us-east-1")
 # Path to credentials file (optional, alternative to .env)
 # Read directly from .env to avoid escape sequence issues on Windows
 # (e.g., \a in path D:\Projects\adolf is interpreted as bell character)
-_raw_creds_file = _get_raw_env_value("KIRO_CREDS_FILE") or os.getenv("KIRO_CREDS_FILE", "")
+_raw_creds_file = _get_raw_env_value("KIRO_CREDS_FILE") or os.getenv(
+    "KIRO_CREDS_FILE", ""
+)
 # Normalize path for cross-platform compatibility
 KIRO_CREDS_FILE: str = str(Path(_raw_creds_file)) if _raw_creds_file else ""
 
 # Path to kiro-cli SQLite database (optional, for AWS SSO OIDC authentication)
 # Default location: ~/.local/share/kiro-cli/data.sqlite3 (Linux/macOS)
 # or ~/.local/share/amazon-q/data.sqlite3 (amazon-q-developer-cli)
-_raw_cli_db_file = _get_raw_env_value("KIRO_CLI_DB_FILE") or os.getenv("KIRO_CLI_DB_FILE", "")
+_raw_cli_db_file = _get_raw_env_value("KIRO_CLI_DB_FILE") or os.getenv(
+    "KIRO_CLI_DB_FILE", ""
+)
 KIRO_CLI_DB_FILE: str = str(Path(_raw_cli_db_file)) if _raw_cli_db_file else ""
 
 # Disable SQLite write-back (read-only mode)
 # When enabled, gateway will only read from kiro-cli database without modifying it.
 # Useful when kiro-cli is actively managing tokens and you don't want gateway to interfere.
 # Default: false (write-back enabled)
-SQLITE_READONLY: bool = os.getenv("SQLITE_READONLY", "false").lower() in ("true", "1", "yes")
+SQLITE_READONLY: bool = os.getenv("SQLITE_READONLY", "false").lower() in (
+    "true",
+    "1",
+    "yes",
+)
 
 # ==================================================================================================
 # Kiro API URL Templates
 # ==================================================================================================
 
 # URL for token refresh (Kiro Desktop Auth)
-KIRO_REFRESH_URL_TEMPLATE: str = "https://prod.{region}.auth.desktop.kiro.dev/refreshToken"
+KIRO_REFRESH_URL_TEMPLATE: str = (
+    "https://prod.{region}.auth.desktop.kiro.dev/refreshToken"
+)
 
 # URL for token refresh (AWS SSO OIDC - used by kiro-cli)
 AWS_SSO_OIDC_URL_TEMPLATE: str = "https://oidc.{region}.amazonaws.com/token"
+
+# Use legacy q.amazonaws.com endpoint instead of runtime.kiro.dev
+# Set to true for Builder ID (free tier) accounts that have no profileArn
+# See: https://github.com/jwadow/kiro-gateway/issues/168
+KIRO_USE_LEGACY_ENDPOINT: bool = os.getenv(
+    "KIRO_USE_LEGACY_ENDPOINT", "false"
+).lower() in ("true", "1", "yes")
 
 # Host for main API (generateAssistantResponse)
 # Universal endpoint for all regions (us-east-1, eu-central-1, etc.)
 # See: https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/security-data-perimeter.html
 # Fixed in issue #58 - codewhisperer.{region}.amazonaws.com doesn't exist for non-us-east-1 regions
-KIRO_API_HOST_TEMPLATE: str = "https://runtime.{region}.kiro.dev"
+KIRO_API_HOST_TEMPLATE: str = (
+    "https://q.{region}.amazonaws.com"
+    if KIRO_USE_LEGACY_ENDPOINT
+    else "https://runtime.{region}.kiro.dev"
+)
 
 # Host for Q API (ListAvailableModels)
-KIRO_Q_HOST_TEMPLATE: str = "https://runtime.{region}.kiro.dev"
+KIRO_Q_HOST_TEMPLATE: str = (
+    "https://q.{region}.amazonaws.com"
+    if KIRO_USE_LEGACY_ENDPOINT
+    else "https://runtime.{region}.kiro.dev"
+)
 
 # ==================================================================================================
 # Token Settings
@@ -318,7 +344,9 @@ DEFAULT_MAX_INPUT_TOKENS: int = 200000
 # Maximum length of tool description in characters.
 # Descriptions longer than this limit will be moved to system prompt.
 # Set to 0 to disable (not recommended - will cause Kiro API errors).
-TOOL_DESCRIPTION_MAX_LENGTH: int = int(os.getenv("TOOL_DESCRIPTION_MAX_LENGTH", "10000"))
+TOOL_DESCRIPTION_MAX_LENGTH: int = int(
+    os.getenv("TOOL_DESCRIPTION_MAX_LENGTH", "10000")
+)
 
 # ==================================================================================================
 # Truncation Recovery Settings
@@ -330,7 +358,11 @@ TOOL_DESCRIPTION_MAX_LENGTH: int = int(os.getenv("TOOL_DESCRIPTION_MAX_LENGTH", 
 # - For content: synthetic user message notifying about truncation
 # This helps the model understand and adapt to Kiro API limitations
 # Default: true (enabled)
-TRUNCATION_RECOVERY: bool = os.getenv("TRUNCATION_RECOVERY", "true").lower() in ("true", "1", "yes")
+TRUNCATION_RECOVERY: bool = os.getenv("TRUNCATION_RECOVERY", "true").lower() in (
+    "true",
+    "1",
+    "yes",
+)
 
 # ==================================================================================================
 # Logging Settings
@@ -388,16 +420,17 @@ def _warn_timeout_configuration():
     """
     Print warning if timeout configuration is suboptimal.
     Called at application startup.
-    
+
     FIRST_TOKEN_TIMEOUT should be less than STREAMING_READ_TIMEOUT:
     - FIRST_TOKEN_TIMEOUT: time to wait for model to START responding
     - STREAMING_READ_TIMEOUT: time to wait BETWEEN chunks during streaming
     """
     if FIRST_TOKEN_TIMEOUT >= STREAMING_READ_TIMEOUT:
         import sys
+
         YELLOW = "\033[93m"
         RESET = "\033[0m"
-        
+
         warning_text = f"""
 {YELLOW}⚠️  WARNING: Suboptimal timeout configuration detected.
     
@@ -415,6 +448,7 @@ def _warn_timeout_configuration():
 """
         print(warning_text, file=sys.stderr)
 
+
 # ==================================================================================================
 # Fake Reasoning Settings (Extended Thinking via Tag Injection)
 # ==================================================================================================
@@ -431,7 +465,13 @@ def _warn_timeout_configuration():
 # Default: true (enabled) - provides premium experience out of the box
 _FAKE_REASONING_RAW: str = os.getenv("FAKE_REASONING", "").lower()
 # Default is True - if env var is not set or empty, enable fake reasoning
-FAKE_REASONING_ENABLED: bool = _FAKE_REASONING_RAW not in ("false", "0", "no", "disabled", "off")
+FAKE_REASONING_ENABLED: bool = _FAKE_REASONING_RAW not in (
+    "false",
+    "0",
+    "no",
+    "disabled",
+    "off",
+)
 
 # Maximum thinking length in tokens (default budget when client doesn't specify).
 # This value is injected into the request as <max_thinking_length>{value}</max_thinking_length>
@@ -460,8 +500,15 @@ FAKE_REASONING_BUDGET_CAP: int = int(os.getenv("FAKE_REASONING_BUDGET_CAP", "100
 # - "strip_tags": Remove tags but keep thinking content in regular content
 #
 # Default: "as_reasoning_content"
-_FAKE_REASONING_HANDLING_RAW: str = os.getenv("FAKE_REASONING_HANDLING", "as_reasoning_content").lower()
-if _FAKE_REASONING_HANDLING_RAW in ("as_reasoning_content", "remove", "pass", "strip_tags"):
+_FAKE_REASONING_HANDLING_RAW: str = os.getenv(
+    "FAKE_REASONING_HANDLING", "as_reasoning_content"
+).lower()
+if _FAKE_REASONING_HANDLING_RAW in (
+    "as_reasoning_content",
+    "remove",
+    "pass",
+    "strip_tags",
+):
     FAKE_REASONING_HANDLING: str = _FAKE_REASONING_HANDLING_RAW
 else:
     FAKE_REASONING_HANDLING: str = "as_reasoning_content"
@@ -469,13 +516,20 @@ else:
 # List of opening tags to detect thinking blocks.
 # The parser will look for any of these tags at the start of the response.
 # Order matters - first match wins.
-FAKE_REASONING_OPEN_TAGS: List[str] = ["<thinking>", "<think>", "<reasoning>", "<thought>"]
+FAKE_REASONING_OPEN_TAGS: List[str] = [
+    "<thinking>",
+    "<think>",
+    "<reasoning>",
+    "<thought>",
+]
 
 # Maximum size of initial buffer for tag detection (characters).
 # If no thinking tag is found within this limit, content is treated as regular response.
 # Lower values = faster first token, but may miss tags with leading whitespace.
 # Default: 30 characters (enough for longest tag + some whitespace)
-FAKE_REASONING_INITIAL_BUFFER_SIZE: int = int(os.getenv("FAKE_REASONING_INITIAL_BUFFER_SIZE", "20"))
+FAKE_REASONING_INITIAL_BUFFER_SIZE: int = int(
+    os.getenv("FAKE_REASONING_INITIAL_BUFFER_SIZE", "20")
+)
 
 
 # ==================================================================================================
@@ -489,7 +543,11 @@ KIRO_MAX_PAYLOAD_BYTES: int = int(os.getenv("KIRO_MAX_PAYLOAD_BYTES", "600000"))
 # Auto-trim payload when over limit (default: false - disabled)
 # Enable this if you use many tools (30+) and hit "Improperly formed request" errors
 # When false, returns a clear error instead of trimming
-AUTO_TRIM_PAYLOAD: bool = os.getenv("AUTO_TRIM_PAYLOAD", "false").lower() in ("true", "1", "yes")
+AUTO_TRIM_PAYLOAD: bool = os.getenv("AUTO_TRIM_PAYLOAD", "false").lower() in (
+    "true",
+    "1",
+    "yes",
+)
 
 # ==================================================================================================
 # WebSearch Settings (MCP Tool Emulation)
@@ -500,7 +558,11 @@ AUTO_TRIM_PAYLOAD: bool = os.getenv("AUTO_TRIM_PAYLOAD", "false").lower() in ("t
 # Model decides whether to use it or not
 #
 # Note: Native Anthropic server-side tools (Path A) work ALWAYS, regardless of this setting
-WEB_SEARCH_ENABLED: bool = os.getenv("WEB_SEARCH_ENABLED", "true").lower() in ("true", "1", "yes")
+WEB_SEARCH_ENABLED: bool = os.getenv("WEB_SEARCH_ENABLED", "true").lower() in (
+    "true",
+    "1",
+    "yes",
+)
 
 # ==================================================================================================
 # Account System Settings
@@ -509,7 +571,11 @@ WEB_SEARCH_ENABLED: bool = os.getenv("WEB_SEARCH_ENABLED", "true").lower() in ("
 # Enable account system with failover (default: false)
 # When false: uses first account without failover (legacy mode)
 # When true: enables full failover loop with Circuit Breaker
-ACCOUNT_SYSTEM: bool = os.getenv("ACCOUNT_SYSTEM", "false").lower() in ("true", "1", "yes")
+ACCOUNT_SYSTEM: bool = os.getenv("ACCOUNT_SYSTEM", "false").lower() in (
+    "true",
+    "1",
+    "yes",
+)
 
 # Path to credentials configuration file
 ACCOUNTS_CONFIG_FILE: str = os.getenv("ACCOUNTS_CONFIG_FILE", "credentials.json")
@@ -529,12 +595,16 @@ ACCOUNT_RECOVERY_TIMEOUT: int = int(os.getenv("ACCOUNT_RECOVERY_TIMEOUT", "60"))
 
 # Maximum backoff multiplier (cap for exponential backoff)
 # With BASE=60s and MAX=1440, maximum cooldown is 60 * 1440 = 86400s = 1 day
-ACCOUNT_MAX_BACKOFF_MULTIPLIER: float = float(os.getenv("ACCOUNT_MAX_BACKOFF_MULTIPLIER", "1440.0"))
+ACCOUNT_MAX_BACKOFF_MULTIPLIER: float = float(
+    os.getenv("ACCOUNT_MAX_BACKOFF_MULTIPLIER", "1440.0")
+)
 
 # Probabilistic retry chance for "broken" accounts (0.0 - 1.0)
 # Even if account is broken and timeout hasn't passed, try with this probability
 # Default: 0.1 (10% chance) - prevents permanent "stuck" state
-ACCOUNT_PROBABILISTIC_RETRY_CHANCE: float = float(os.getenv("ACCOUNT_PROBABILISTIC_RETRY_CHANCE", "0.1"))
+ACCOUNT_PROBABILISTIC_RETRY_CHANCE: float = float(
+    os.getenv("ACCOUNT_PROBABILISTIC_RETRY_CHANCE", "0.1")
+)
 
 # ==================================================================================================
 # Account Cache Settings
@@ -557,7 +627,9 @@ STATE_SAVE_INTERVAL_SECONDS: int = int(os.getenv("STATE_SAVE_INTERVAL_SECONDS", 
 
 APP_VERSION: str = "2.4.dev.13"
 APP_TITLE: str = "Kiro Gateway"
-APP_DESCRIPTION: str = "Proxy gateway for Kiro API (Amazon Q Developer / AWS CodeWhisperer). OpenAI and Anthropic compatible. Made by @jwadow"
+APP_DESCRIPTION: str = (
+    "Proxy gateway for Kiro API (Amazon Q Developer / AWS CodeWhisperer). OpenAI and Anthropic compatible. Made by @jwadow"
+)
 
 
 def get_kiro_refresh_url(region: str) -> str:
@@ -578,4 +650,3 @@ def get_kiro_api_host(region: str) -> str:
 def get_kiro_q_host(region: str) -> str:
     """Return Q API host for the specified region."""
     return KIRO_Q_HOST_TEMPLATE.format(region=region)
-

--- a/kiro/mcp_tools.py
+++ b/kiro/mcp_tools.py
@@ -40,6 +40,7 @@ import httpx
 from fastapi.responses import JSONResponse, StreamingResponse
 from loguru import logger
 
+from kiro.config import PROFILE_ARN
 from kiro.tokenizer import count_message_tokens, count_tokens
 
 # Import debug_logger
@@ -53,45 +54,46 @@ except ImportError:
 # ID Generation
 # ==================================================================================================
 
+
 def generate_random_id(length: int) -> str:
     """
     Generate random alphanumeric string.
-    
+
     Args:
         length: Length of string to generate
-    
+
     Returns:
         Random string of specified length
-    
+
     Example:
         >>> generate_random_id(22)
         'aBcD1234567890XyZ12345'
     """
-    return ''.join(random.choices(string.ascii_letters + string.digits, k=length))
+    return "".join(random.choices(string.ascii_letters + string.digits, k=length))
 
 
 # ==================================================================================================
 # MCP API Functions
 # ==================================================================================================
 
+
 async def call_kiro_mcp_api(
-    query: str,
-    auth_manager
+    query: str, auth_manager
 ) -> Tuple[Optional[str], Optional[Dict]]:
     """
     Call Kiro MCP API for web_search.
-    
+
     URL: {auth_manager.q_host}/mcp
     Headers: Authorization, x-amzn-codewhisperer-optout, Content-Type
     Timeout: 60 seconds
-    
+
     Args:
         query: Search query
         auth_manager: KiroAuthManager instance
-    
+
     Returns:
         Tuple of (tool_use_id, results_dict) or (None, None) on error
-    
+
     MCP Request Format:
         {
             "id": "web_search_tooluse_{22random}_{timestamp}_{8random}",
@@ -102,7 +104,7 @@ async def call_kiro_mcp_api(
                 "arguments": {"query": "..."}
             }
         }
-    
+
     MCP Response Format:
         {
             "id": "web_search_tooluse_...",
@@ -115,7 +117,7 @@ async def call_kiro_mcp_api(
                 "isError": false
             }
         }
-    
+
     CRITICAL: result.content[0].text is a JSON STRING, not a dict!
     """
     # Generate IDs
@@ -124,70 +126,78 @@ async def call_kiro_mcp_api(
     random_8 = generate_random_id(8)
     request_id = f"web_search_tooluse_{random_22}_{timestamp}_{random_8}"
     tool_use_id = f"srvtoolu_{uuid.uuid4().hex[:32]}"
-    
+
     # Build MCP request
     mcp_request = {
         "id": request_id,
         "jsonrpc": "2.0",
         "method": "tools/call",
-        "params": {
-            "name": "web_search",
-            "arguments": {"query": query}
-        }
+        "params": {"name": "web_search", "arguments": {"query": query}},
     }
-    
+
+    # profileArn is required by runtime.kiro.dev/mcp endpoint (issue #173)
+    profile_arn = auth_manager.profile_arn or PROFILE_ARN
+    if profile_arn:
+        mcp_request["profileArn"] = profile_arn
+
     # Log MCP request
     try:
-        mcp_request_json = json.dumps(mcp_request, ensure_ascii=False, indent=2).encode('utf-8')
+        mcp_request_json = json.dumps(mcp_request, ensure_ascii=False, indent=2).encode(
+            "utf-8"
+        )
         if debug_logger:
             debug_logger.log_raw_chunk(b"[MCP REQUEST]\n" + mcp_request_json)
     except Exception as e:
         logger.warning(f"Failed to log MCP request: {e}")
-    
+
     try:
         token = await auth_manager.get_access_token()
-        
+
         # EXACT headers from architecture
         headers = {
             "Authorization": f"Bearer {token}",
             "x-amzn-codewhisperer-optout": "false",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
-        
+
         mcp_url = f"{auth_manager.q_host}/mcp"
         logger.debug(f"Calling MCP API: {mcp_url}")
-        
+
         async with httpx.AsyncClient(timeout=60.0) as client:
             response = await client.post(mcp_url, json=mcp_request, headers=headers)
-            
+
             if response.status_code != 200:
                 logger.error(f"MCP API error: {response.status_code}")
                 return None, None
-            
+
             mcp_response = response.json()
-            
+
             # Log MCP response
             try:
-                mcp_response_json = json.dumps(mcp_response, ensure_ascii=False, indent=2).encode('utf-8')
+                mcp_response_json = json.dumps(
+                    mcp_response, ensure_ascii=False, indent=2
+                ).encode("utf-8")
                 if debug_logger:
                     debug_logger.log_raw_chunk(b"[MCP RESPONSE]\n" + mcp_response_json)
             except Exception as e:
                 logger.warning(f"Failed to log MCP response: {e}")
-            
+
             # DEBUG: Log full MCP response to see what we actually got
             # logger.debug(f"MCP API full response: {json.dumps(mcp_response, ensure_ascii=False)}")
-            
+
             if "error" in mcp_response and mcp_response["error"] is not None:
                 logger.error(f"MCP API returned error: {mcp_response['error']}")
                 return None, None
-            
+
             # Parse results: result.content[0].text is JSON STRING (CRITICAL!)
-            result_text = mcp_response.get("result", {}).get("content", [{}])[0].get("text", "{}")
+            result_text = (
+                mcp_response.get("result", {}).get("content", [{}])[0].get("text", "{}")
+            )
             results = json.loads(result_text)  # Parse JSON string to dict
-            
+
             logger.debug(f"MCP API returned {results.get('totalResults', 0)} results")
             return tool_use_id, results
-            
+
     except httpx.TimeoutException as e:
         logger.error(f"MCP API timeout: {e}")
         return None, None
@@ -205,24 +215,24 @@ async def call_kiro_mcp_api(
 def generate_search_summary(query: str, results: Dict) -> str:
     """
     Generate human-readable summary from search results wrapped in XML tags.
-    
+
     Wraps results in <web_search>...</web_search> tags to visually distinguish
     tool output from model's own text. Returns FULL snippets without truncation
     so the model has complete information.
-    
+
     Format per result:
     - Title
     - Published date (converted from milliseconds timestamp)
     - URL
     - Full snippet (no truncation)
-    
+
     Args:
         query: Original search query
         results: Parsed MCP response (dict with "results" key)
-    
+
     Returns:
         Formatted summary text wrapped in XML tags with full snippets
-    
+
     Example:
         '<web_search>\nSearch results for "Python tutorials":\n\n
         1. Title: **Learn Python - Official Tutorial**\n
@@ -233,17 +243,17 @@ def generate_search_summary(query: str, results: Dict) -> str:
     """
     # Start with opening tag
     summary = f'\n<web_search>\nSearch results for "{query}":\n\n'
-    
+
     if results and "results" in results:
         for i, result in enumerate(results["results"], 1):
             title = result.get("title", "Untitled")
             url = result.get("url", "")
             snippet = result.get("snippet", "")
             published_date_ms = result.get("publishedDate")
-            
+
             # Format: Title
             summary += f"{i}. Title: **{title}**\n"
-            
+
             # Format: Published date (convert from milliseconds timestamp)
             if published_date_ms:
                 try:
@@ -255,22 +265,22 @@ def generate_search_summary(query: str, results: Dict) -> str:
                 except (ValueError, OSError):
                     # Invalid timestamp - skip date
                     pass
-            
+
             # Format: URL
             if url:
                 summary += f"   URL: {url}\n"
-            
+
             # Format: Snippet (NO truncation - model needs full information)
             if snippet:
                 summary += f"   {snippet}\n"
-            
+
             summary += "\n"
     else:
         summary += "No results found.\n"
-    
+
     # Close with closing tag
     summary += "</web_search>\n"
-    
+
     return summary
 
 
@@ -278,16 +288,13 @@ def generate_search_summary(query: str, results: Dict) -> str:
 # SSE Emulation (Anthropic Format)
 # ==================================================================================================
 
+
 async def generate_anthropic_web_search_sse(
-    model: str,
-    query: str,
-    tool_use_id: str,
-    results: Dict,
-    input_tokens: int
+    model: str, query: str, tool_use_id: str, results: Dict, input_tokens: int
 ):
     """
     Generate Anthropic SSE stream for web_search response.
-    
+
     Emulates 11 events (EXACT structure from architecture):
     1. message_start - with usage (input_tokens)
     2. content_block_start - server_tool_use
@@ -300,229 +307,236 @@ async def generate_anthropic_web_search_sse(
     N+1. content_block_stop - text
     N+2. message_delta - stop_reason + output_tokens
     N+3. message_stop
-    
+
     Args:
         model: Model name
         query: Search query
         tool_use_id: Tool use ID
         results: Search results dict
         input_tokens: Input token count
-    
+
     Yields:
         SSE formatted strings
     """
     from kiro.streaming_anthropic import format_sse_event
-    
+
     message_id = f"msg_{uuid.uuid4().hex[:24]}"
     summary = generate_search_summary(query, results)
-    
+
     # Count output tokens WITHOUT Claude correction (MCP API response, not model generation)
     output_tokens = count_tokens(summary, apply_claude_correction=False)
-    
+
     # Event 1: message_start
-    yield format_sse_event("message_start", {
-        "type": "message_start",
-        "message": {
-            "id": message_id,
-            "type": "message",
-            "role": "assistant",
-            "model": model,
-            "content": [],
-            "stop_reason": None,
-            "usage": {"input_tokens": input_tokens, "output_tokens": 0}
-        }
-    })
-    
+    yield format_sse_event(
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": message_id,
+                "type": "message",
+                "role": "assistant",
+                "model": model,
+                "content": [],
+                "stop_reason": None,
+                "usage": {"input_tokens": input_tokens, "output_tokens": 0},
+            },
+        },
+    )
+
     # Event 2: content_block_start (server_tool_use)
-    yield format_sse_event("content_block_start", {
-        "type": "content_block_start",
-        "index": 0,
-        "content_block": {
-            "id": tool_use_id,
-            "type": "server_tool_use",
-            "name": "web_search",
-            "input": {}
-        }
-    })
-    
+    yield format_sse_event(
+        "content_block_start",
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "id": tool_use_id,
+                "type": "server_tool_use",
+                "name": "web_search",
+                "input": {},
+            },
+        },
+    )
+
     # Event 3: content_block_delta (input_json_delta)
-    yield format_sse_event("content_block_delta", {
-        "type": "content_block_delta",
-        "index": 0,
-        "delta": {
-            "type": "input_json_delta",
-            "partial_json": json.dumps({"query": query})
-        }
-    })
-    
+    yield format_sse_event(
+        "content_block_delta",
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+                "type": "input_json_delta",
+                "partial_json": json.dumps({"query": query}),
+            },
+        },
+    )
+
     # Event 4: content_block_stop (server_tool_use)
-    yield format_sse_event("content_block_stop", {
-        "type": "content_block_stop",
-        "index": 0
-    })
-    
+    yield format_sse_event(
+        "content_block_stop", {"type": "content_block_stop", "index": 0}
+    )
+
     # Event 5: content_block_start (web_search_tool_result)
     search_content = []
     for r in results.get("results", []):
-        search_content.append({
-            "type": "web_search_result",
-            "title": r.get("title", ""),
-            "url": r.get("url", ""),
-            "encrypted_content": r.get("snippet", ""),
-            "page_age": None
-        })
-    
-    yield format_sse_event("content_block_start", {
-        "type": "content_block_start",
-        "index": 1,
-        "content_block": {
-            "type": "web_search_tool_result",
-            "tool_use_id": tool_use_id,
-            "content": search_content
-        }
-    })
-    
+        search_content.append(
+            {
+                "type": "web_search_result",
+                "title": r.get("title", ""),
+                "url": r.get("url", ""),
+                "encrypted_content": r.get("snippet", ""),
+                "page_age": None,
+            }
+        )
+
+    yield format_sse_event(
+        "content_block_start",
+        {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+                "type": "web_search_tool_result",
+                "tool_use_id": tool_use_id,
+                "content": search_content,
+            },
+        },
+    )
+
     # Event 6: content_block_stop (web_search_tool_result)
-    yield format_sse_event("content_block_stop", {
-        "type": "content_block_stop",
-        "index": 1
-    })
-    
+    yield format_sse_event(
+        "content_block_stop", {"type": "content_block_stop", "index": 1}
+    )
+
     # Event 7: content_block_start (text)
-    yield format_sse_event("content_block_start", {
-        "type": "content_block_start",
-        "index": 2,
-        "content_block": {"type": "text", "text": ""}
-    })
-    
+    yield format_sse_event(
+        "content_block_start",
+        {
+            "type": "content_block_start",
+            "index": 2,
+            "content_block": {"type": "text", "text": ""},
+        },
+    )
+
     # Events 8-N: content_block_delta (text_delta) - stream summary in chunks
     chunk_size = 100
     for i in range(0, len(summary), chunk_size):
-        chunk = summary[i:i + chunk_size]
-        yield format_sse_event("content_block_delta", {
-            "type": "content_block_delta",
-            "index": 2,
-            "delta": {"type": "text_delta", "text": chunk}
-        })
-    
+        chunk = summary[i : i + chunk_size]
+        yield format_sse_event(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": 2,
+                "delta": {"type": "text_delta", "text": chunk},
+            },
+        )
+
     # Event N+1: content_block_stop (text)
-    yield format_sse_event("content_block_stop", {
-        "type": "content_block_stop",
-        "index": 2
-    })
-    
+    yield format_sse_event(
+        "content_block_stop", {"type": "content_block_stop", "index": 2}
+    )
+
     # Event N+2: message_delta
-    yield format_sse_event("message_delta", {
-        "type": "message_delta",
-        "delta": {"stop_reason": "end_turn", "stop_sequence": None},
-        "usage": {"output_tokens": output_tokens}
-    })
-    
+    yield format_sse_event(
+        "message_delta",
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": output_tokens},
+        },
+    )
+
     # Event N+3: message_stop
-    yield format_sse_event("message_stop", {
-        "type": "message_stop"
-    })
+    yield format_sse_event("message_stop", {"type": "message_stop"})
 
 
 # ==================================================================================================
 # SSE Emulation (OpenAI Format)
 # ==================================================================================================
 
+
 async def generate_openai_web_search_sse(
-    model: str,
-    query: str,
-    tool_use_id: str,
-    results: Dict,
-    input_tokens: int
+    model: str, query: str, tool_use_id: str, results: Dict, input_tokens: int
 ):
     """
     Generate OpenAI SSE stream for web_search response.
-    
+
     CRITICAL: OpenAI format is COMPLETELY different from Anthropic:
     - data: {...} WITHOUT event: prefix
     - choices[0].delta structure
     - finish_reason instead of stop_reason
     - chat.completion.chunk object type
-    
+
     Emulates server-side execution: returns summary directly as content,
     WITHOUT tool_calls flow (model doesn't call tool, MCP API already executed).
-    
+
     Args:
         model: Model name
         query: Search query
         tool_use_id: Tool use ID (not used in OpenAI format)
         results: Search results dict
         input_tokens: Input token count
-    
+
     Yields:
         SSE formatted strings (OpenAI format)
-    
+
     Example OpenAI SSE:
         data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1234567890,"model":"claude-sonnet-4","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}
-        
+
         data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1234567890,"model":"claude-sonnet-4","choices":[{"index":0,"delta":{"content":"Here"},"finish_reason":null}]}
-        
+
         data: [DONE]
     """
     from kiro.utils import generate_completion_id
-    
+
     completion_id = generate_completion_id()
     created_time = int(time.time())
     summary = generate_search_summary(query, results)
-    
+
     # Count output tokens WITHOUT Claude correction (MCP API response, not model generation)
     output_tokens = count_tokens(summary, apply_claude_correction=False)
-    
+
     # Chunk 1: role
     chunk = {
         "id": completion_id,
         "object": "chat.completion.chunk",
         "created": created_time,
         "model": model,
-        "choices": [{
-            "index": 0,
-            "delta": {"role": "assistant"},
-            "finish_reason": None
-        }]
+        "choices": [
+            {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}
+        ],
     }
     yield f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
-    
+
     # Chunks 2-N: content (stream summary in chunks)
     chunk_size = 100
     for i in range(0, len(summary), chunk_size):
-        content_chunk = summary[i:i + chunk_size]
+        content_chunk = summary[i : i + chunk_size]
         chunk = {
             "id": completion_id,
             "object": "chat.completion.chunk",
             "created": created_time,
             "model": model,
-            "choices": [{
-                "index": 0,
-                "delta": {"content": content_chunk},
-                "finish_reason": None
-            }]
+            "choices": [
+                {"index": 0, "delta": {"content": content_chunk}, "finish_reason": None}
+            ],
         }
         yield f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
-    
+
     # Chunk N+1: finish_reason + usage
     chunk = {
         "id": completion_id,
         "object": "chat.completion.chunk",
         "created": created_time,
         "model": model,
-        "choices": [{
-            "index": 0,
-            "delta": {},
-            "finish_reason": "stop"
-        }],
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
         "usage": {
             "prompt_tokens": input_tokens,
             "completion_tokens": output_tokens,
-            "total_tokens": input_tokens + output_tokens
-        }
+            "total_tokens": input_tokens + output_tokens,
+        },
     }
     yield f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
-    
+
     # Final: [DONE]
     yield "data: [DONE]\n\n"
 
@@ -531,33 +545,34 @@ async def generate_openai_web_search_sse(
 # Path A: Native Anthropic Handler
 # ==================================================================================================
 
+
 def extract_query_from_messages(messages, api_format: str) -> Optional[str]:
     """
     Extract search query from first user message.
-    
+
     IMPORTANT: messages is a list of Pydantic models, NOT dicts.
     Use hasattr() and getattr() to access fields.
-    
+
     LIMITATION: Extracts query only from the FIRST message (single-turn).
     This is acceptable for web_search use case.
-    
+
     Args:
         messages: List of messages from request (Pydantic models)
         api_format: "anthropic" or "openai"
-    
+
     Returns:
         Search query string or None
     """
     if not messages:
         return None
-    
+
     first_msg = messages[0]
-    
+
     # Extract content (Pydantic model - always use hasattr/getattr)
-    content = getattr(first_msg, 'content', None)
+    content = getattr(first_msg, "content", None)
     if content is None:
         return None
-    
+
     # Convert to text
     if isinstance(content, str):
         text = content
@@ -566,7 +581,7 @@ def extract_query_from_messages(messages, api_format: str) -> Optional[str]:
         text_parts = []
         for block in content:
             # Handle both Pydantic models and dicts
-            if hasattr(block, 'type') and hasattr(block, 'text'):
+            if hasattr(block, "type") and hasattr(block, "text"):
                 # Pydantic model (TextContentBlock)
                 if block.type == "text":
                     text_parts.append(block.text)
@@ -576,35 +591,32 @@ def extract_query_from_messages(messages, api_format: str) -> Optional[str]:
         text = "".join(text_parts)
     else:
         return None
-    
+
     # Remove prefix if present (some clients add this)
     prefix = "Perform a web search for the query: "
     if text.startswith(prefix):
-        query = text[len(prefix):]
+        query = text[len(prefix) :]
     else:
         query = text
-    
+
     return query.strip() if query.strip() else None
 
 
 async def handle_native_web_search(
-    request,
-    request_data,
-    auth_manager,
-    api_format: str = "anthropic"
+    request, request_data, auth_manager, api_format: str = "anthropic"
 ):
     """
     Handle native Anthropic web_search (Path A).
-    
+
     This function bypasses /generateAssistantResponse entirely.
     Direct MCP API call → SSE emulation → return to client.
-    
+
     Args:
         request: FastAPI Request
         request_data: Validated request (AnthropicMessagesRequest or ChatCompletionRequest)
         auth_manager: KiroAuthManager instance
         api_format: "anthropic" or "openai"
-    
+
     Returns:
         StreamingResponse or JSONResponse
     """
@@ -617,16 +629,16 @@ async def handle_native_web_search(
                 "type": "error",
                 "error": {
                     "type": "invalid_request_error",
-                    "message": "Cannot extract search query from messages"
-                }
-            }
+                    "message": "Cannot extract search query from messages",
+                },
+            },
         )
-    
+
     logger.info(f"WebSearch query (Path A - native): {query}")
-    
+
     # Call MCP API
     tool_use_id, results = await call_kiro_mcp_api(query, auth_manager)
-    
+
     if results is None:
         return JSONResponse(
             status_code=500,
@@ -634,92 +646,90 @@ async def handle_native_web_search(
                 "type": "error",
                 "error": {
                     "type": "api_error",
-                    "message": "Web search failed. Please try again."
-                }
-            }
+                    "message": "Web search failed. Please try again.",
+                },
+            },
         )
-    
+
     # Count tokens WITHOUT Claude correction (MCP API, not model)
     input_tokens = count_message_tokens(
         [msg.model_dump() for msg in request_data.messages],
-        apply_claude_correction=False
+        apply_claude_correction=False,
     )
-    
+
     # Return response based on streaming mode and API format
     if request_data.stream:
         # Streaming mode - generate SSE
-        logger.debug(f"Returning streaming web_search response (api_format={api_format})")
-        
+        logger.debug(
+            f"Returning streaming web_search response (api_format={api_format})"
+        )
+
         if api_format == "openai":
             sse_generator = generate_openai_web_search_sse(
-                request_data.model,
-                query,
-                tool_use_id,
-                results,
-                input_tokens
+                request_data.model, query, tool_use_id, results, input_tokens
             )
         else:  # anthropic
             sse_generator = generate_anthropic_web_search_sse(
-                request_data.model,
-                query,
-                tool_use_id,
-                results,
-                input_tokens
+                request_data.model, query, tool_use_id, results, input_tokens
             )
-        
+
         return StreamingResponse(
             sse_generator,
             media_type="text/event-stream",
-            headers={"Cache-Control": "no-cache", "Connection": "keep-alive"}
+            headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
         )
     else:
         # Non-streaming mode - return full JSON
-        logger.debug(f"Returning non-streaming web_search response (api_format={api_format})")
+        logger.debug(
+            f"Returning non-streaming web_search response (api_format={api_format})"
+        )
         summary = generate_search_summary(query, results)
-        
+
         # Count output tokens WITHOUT Claude correction (MCP API response)
         output_tokens = count_tokens(summary, apply_claude_correction=False)
-        
+
         if api_format == "openai":
             # OpenAI format: chat.completion
             from kiro.utils import generate_completion_id
+
             completion_id = generate_completion_id()
             created_time = int(time.time())
-            
+
             full_response = {
                 "id": completion_id,
                 "object": "chat.completion",
                 "created": created_time,
                 "model": request_data.model,
-                "choices": [{
-                    "index": 0,
-                    "message": {
-                        "role": "assistant",
-                        "content": summary
-                    },
-                    "finish_reason": "stop"
-                }],
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": summary},
+                        "finish_reason": "stop",
+                    }
+                ],
                 "usage": {
                     "prompt_tokens": input_tokens,
                     "completion_tokens": output_tokens,
-                    "total_tokens": input_tokens + output_tokens
-                }
+                    "total_tokens": input_tokens + output_tokens,
+                },
             }
         else:  # anthropic
             # Anthropic format: message
             message_id = f"msg_{uuid.uuid4().hex[:24]}"
-            
+
             # Build search results content
             search_content = []
             for r in results.get("results", []):
-                search_content.append({
-                    "type": "web_search_result",
-                    "title": r.get("title", ""),
-                    "url": r.get("url", ""),
-                    "encrypted_content": r.get("snippet", ""),
-                    "page_age": None
-                })
-            
+                search_content.append(
+                    {
+                        "type": "web_search_result",
+                        "title": r.get("title", ""),
+                        "url": r.get("url", ""),
+                        "encrypted_content": r.get("snippet", ""),
+                        "page_age": None,
+                    }
+                )
+
             full_response = {
                 "id": message_id,
                 "type": "message",
@@ -729,25 +739,19 @@ async def handle_native_web_search(
                         "type": "server_tool_use",
                         "id": tool_use_id,
                         "name": "web_search",
-                        "input": {"query": query}
+                        "input": {"query": query},
                     },
                     {
                         "type": "web_search_tool_result",
                         "tool_use_id": tool_use_id,
-                        "content": search_content
+                        "content": search_content,
                     },
-                    {
-                        "type": "text",
-                        "text": summary
-                    }
+                    {"type": "text", "text": summary},
                 ],
                 "model": request_data.model,
                 "stop_reason": "end_turn",
                 "stop_sequence": None,
-                "usage": {
-                    "input_tokens": input_tokens,
-                    "output_tokens": output_tokens
-                }
+                "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
             }
-        
+
         return JSONResponse(content=full_response)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -12,279 +12,301 @@ from unittest.mock import patch
 
 class TestLogLevelConfig:
     """Tests for LOG_LEVEL configuration."""
-    
+
     def test_default_log_level_is_info(self):
         """
         What it does: Verifies that LOG_LEVEL defaults to INFO.
         Purpose: Ensure that INFO is used when no environment variable is set.
-        
+
         Note: This test verifies the config.py code logic, not the actual
         value from the .env file. We mock os.getenv to simulate
         the absence of the environment variable.
         """
         print("Setup: Mocking os.getenv for LOG_LEVEL...")
-        
+
         # Create a mock that returns None for LOG_LEVEL (simulating missing variable)
         original_getenv = os.getenv
-        
+
         def mock_getenv(key, default=None):
             if key == "LOG_LEVEL":
                 print(f"os.getenv('{key}') -> None (mocked)")
                 return default  # Return default, simulating missing variable
             return original_getenv(key, default)
-        
-        with patch.object(os, 'getenv', side_effect=mock_getenv):
+
+        with patch.object(os, "getenv", side_effect=mock_getenv):
             # Reload config module with mocked getenv
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             print(f"Comparing: Expected 'INFO', Got '{config_module.LOG_LEVEL}'")
             assert config_module.LOG_LEVEL == "INFO"
-        
+
         # Restore module with real values
         import importlib
         import kiro.config as config_module
+
         importlib.reload(config_module)
-    
+
     def test_log_level_from_environment(self):
         """
         What it does: Verifies loading LOG_LEVEL from environment variable.
         Purpose: Ensure that the value from environment is used.
         """
         print("Setup: Setting LOG_LEVEL=DEBUG...")
-        
+
         with patch.dict(os.environ, {"LOG_LEVEL": "DEBUG"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             print(f"Comparing: Expected 'DEBUG', Got '{config_module.LOG_LEVEL}'")
             assert config_module.LOG_LEVEL == "DEBUG"
-    
+
     def test_log_level_uppercase_conversion(self):
         """
         What it does: Verifies LOG_LEVEL conversion to uppercase.
         Purpose: Ensure that lowercase value is converted to uppercase.
         """
         print("Setup: Setting LOG_LEVEL=warning (lowercase)...")
-        
+
         with patch.dict(os.environ, {"LOG_LEVEL": "warning"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             print(f"Comparing: Expected 'WARNING', Got '{config_module.LOG_LEVEL}'")
             assert config_module.LOG_LEVEL == "WARNING"
-    
+
     def test_log_level_trace(self):
         """
         What it does: Verifies setting LOG_LEVEL=TRACE.
         Purpose: Ensure that TRACE level is supported.
         """
         print("Setup: Setting LOG_LEVEL=TRACE...")
-        
+
         with patch.dict(os.environ, {"LOG_LEVEL": "TRACE"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             assert config_module.LOG_LEVEL == "TRACE"
-    
+
     def test_log_level_error(self):
         """
         What it does: Verifies setting LOG_LEVEL=ERROR.
         Purpose: Ensure that ERROR level is supported.
         """
         print("Setup: Setting LOG_LEVEL=ERROR...")
-        
+
         with patch.dict(os.environ, {"LOG_LEVEL": "ERROR"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             assert config_module.LOG_LEVEL == "ERROR"
-    
+
     def test_log_level_critical(self):
         """
         What it does: Verifies setting LOG_LEVEL=CRITICAL.
         Purpose: Ensure that CRITICAL level is supported.
         """
         print("Setup: Setting LOG_LEVEL=CRITICAL...")
-        
+
         with patch.dict(os.environ, {"LOG_LEVEL": "CRITICAL"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             assert config_module.LOG_LEVEL == "CRITICAL"
 
 
 class TestToolDescriptionMaxLengthConfig:
     """Tests for TOOL_DESCRIPTION_MAX_LENGTH configuration."""
-    
+
     def test_default_tool_description_max_length(self):
         """
         What it does: Verifies the default value for TOOL_DESCRIPTION_MAX_LENGTH.
         Purpose: Ensure that 10000 is used by default.
         """
         print("Setup: Removing TOOL_DESCRIPTION_MAX_LENGTH from environment...")
-        
+
         with patch.dict(os.environ, {}, clear=False):
             if "TOOL_DESCRIPTION_MAX_LENGTH" in os.environ:
                 del os.environ["TOOL_DESCRIPTION_MAX_LENGTH"]
-            
+
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
-            print(f"TOOL_DESCRIPTION_MAX_LENGTH: {config_module.TOOL_DESCRIPTION_MAX_LENGTH}")
+
+            print(
+                f"TOOL_DESCRIPTION_MAX_LENGTH: {config_module.TOOL_DESCRIPTION_MAX_LENGTH}"
+            )
             assert config_module.TOOL_DESCRIPTION_MAX_LENGTH == 10000
-    
+
     def test_tool_description_max_length_from_environment(self):
         """
         What it does: Verifies loading TOOL_DESCRIPTION_MAX_LENGTH from environment.
         Purpose: Ensure that the value from environment is used.
         """
         print("Setup: Setting TOOL_DESCRIPTION_MAX_LENGTH=5000...")
-        
+
         with patch.dict(os.environ, {"TOOL_DESCRIPTION_MAX_LENGTH": "5000"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
-            print(f"TOOL_DESCRIPTION_MAX_LENGTH: {config_module.TOOL_DESCRIPTION_MAX_LENGTH}")
+
+            print(
+                f"TOOL_DESCRIPTION_MAX_LENGTH: {config_module.TOOL_DESCRIPTION_MAX_LENGTH}"
+            )
             assert config_module.TOOL_DESCRIPTION_MAX_LENGTH == 5000
-    
+
     def test_tool_description_max_length_zero_disables(self):
         """
         What it does: Verifies that 0 disables the feature.
         Purpose: Ensure that TOOL_DESCRIPTION_MAX_LENGTH=0 works.
         """
         print("Setup: Setting TOOL_DESCRIPTION_MAX_LENGTH=0...")
-        
+
         with patch.dict(os.environ, {"TOOL_DESCRIPTION_MAX_LENGTH": "0"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
-            print(f"TOOL_DESCRIPTION_MAX_LENGTH: {config_module.TOOL_DESCRIPTION_MAX_LENGTH}")
+
+            print(
+                f"TOOL_DESCRIPTION_MAX_LENGTH: {config_module.TOOL_DESCRIPTION_MAX_LENGTH}"
+            )
             assert config_module.TOOL_DESCRIPTION_MAX_LENGTH == 0
 
 
 class TestTimeoutConfigurationWarning:
     """Tests for _warn_timeout_configuration() function."""
-    
+
     def test_no_warning_when_first_token_less_than_streaming(self, capsys):
         """
         What it does: Verifies that warning is NOT shown with correct configuration.
         Purpose: Ensure that no warning when FIRST_TOKEN_TIMEOUT < STREAMING_READ_TIMEOUT.
         """
         print("Setup: FIRST_TOKEN_TIMEOUT=15, STREAMING_READ_TIMEOUT=300...")
-        
-        with patch.dict(os.environ, {
-            "FIRST_TOKEN_TIMEOUT": "15",
-            "STREAMING_READ_TIMEOUT": "300"
-        }):
+
+        with patch.dict(
+            os.environ, {"FIRST_TOKEN_TIMEOUT": "15", "STREAMING_READ_TIMEOUT": "300"}
+        ):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             # Call the warning function
             config_module._warn_timeout_configuration()
-            
+
             captured = capsys.readouterr()
             print(f"Captured stderr: {captured.err}")
-            
+
             # Warning should NOT be shown
             assert "WARNING" not in captured.err
             assert "Suboptimal timeout configuration" not in captured.err
-    
+
     def test_warning_when_first_token_equals_streaming(self, capsys):
         """
         What it does: Verifies that warning is shown when timeouts are equal.
         Purpose: Ensure that warning when FIRST_TOKEN_TIMEOUT == STREAMING_READ_TIMEOUT.
         """
         print("Setup: FIRST_TOKEN_TIMEOUT=300, STREAMING_READ_TIMEOUT=300...")
-        
-        with patch.dict(os.environ, {
-            "FIRST_TOKEN_TIMEOUT": "300",
-            "STREAMING_READ_TIMEOUT": "300"
-        }):
+
+        with patch.dict(
+            os.environ, {"FIRST_TOKEN_TIMEOUT": "300", "STREAMING_READ_TIMEOUT": "300"}
+        ):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             # Call the warning function
             config_module._warn_timeout_configuration()
-            
+
             captured = capsys.readouterr()
             print(f"Captured stderr: {captured.err}")
-            
+
             # Warning SHOULD be shown
-            assert "WARNING" in captured.err or "Suboptimal timeout configuration" in captured.err
-    
+            assert (
+                "WARNING" in captured.err
+                or "Suboptimal timeout configuration" in captured.err
+            )
+
     def test_warning_when_first_token_greater_than_streaming(self, capsys):
         """
         What it does: Verifies that warning is shown when FIRST_TOKEN > STREAMING.
         Purpose: Ensure that warning when FIRST_TOKEN_TIMEOUT > STREAMING_READ_TIMEOUT.
         """
         print("Setup: FIRST_TOKEN_TIMEOUT=500, STREAMING_READ_TIMEOUT=300...")
-        
-        with patch.dict(os.environ, {
-            "FIRST_TOKEN_TIMEOUT": "500",
-            "STREAMING_READ_TIMEOUT": "300"
-        }):
+
+        with patch.dict(
+            os.environ, {"FIRST_TOKEN_TIMEOUT": "500", "STREAMING_READ_TIMEOUT": "300"}
+        ):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             # Call the warning function
             config_module._warn_timeout_configuration()
-            
+
             captured = capsys.readouterr()
             print(f"Captured stderr: {captured.err}")
-            
+
             # Warning SHOULD be shown
-            assert "WARNING" in captured.err or "Suboptimal timeout configuration" in captured.err
+            assert (
+                "WARNING" in captured.err
+                or "Suboptimal timeout configuration" in captured.err
+            )
             # Verify that timeout values are mentioned in warning
             assert "500" in captured.err
             assert "300" in captured.err
-    
+
     def test_warning_contains_recommendation(self, capsys):
         """
         What it does: Verifies that warning contains a recommendation.
         Purpose: Ensure that user receives useful information.
         """
         print("Setup: FIRST_TOKEN_TIMEOUT=400, STREAMING_READ_TIMEOUT=300...")
-        
-        with patch.dict(os.environ, {
-            "FIRST_TOKEN_TIMEOUT": "400",
-            "STREAMING_READ_TIMEOUT": "300"
-        }):
+
+        with patch.dict(
+            os.environ, {"FIRST_TOKEN_TIMEOUT": "400", "STREAMING_READ_TIMEOUT": "300"}
+        ):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             # Call the warning function
             config_module._warn_timeout_configuration()
-            
+
             captured = capsys.readouterr()
             print(f"Captured stderr: {captured.err}")
-            
+
             # Warning should contain recommendation
             assert "Recommendation" in captured.err or "LESS than" in captured.err
 
 
 class TestAwsSsoOidcUrlConfig:
     """Tests for AWS SSO OIDC URL configuration."""
-    
+
     def test_aws_sso_oidc_url_template_exists(self):
         """
         What it does: Verifies that AWS_SSO_OIDC_URL_TEMPLATE constant exists.
@@ -293,16 +315,17 @@ class TestAwsSsoOidcUrlConfig:
         print("Setup: Importing config module...")
         import importlib
         import kiro.config as config_module
+
         importlib.reload(config_module)
-        
+
         print("Verification: AWS_SSO_OIDC_URL_TEMPLATE exists...")
-        assert hasattr(config_module, 'AWS_SSO_OIDC_URL_TEMPLATE')
-        
+        assert hasattr(config_module, "AWS_SSO_OIDC_URL_TEMPLATE")
+
         print(f"AWS_SSO_OIDC_URL_TEMPLATE: {config_module.AWS_SSO_OIDC_URL_TEMPLATE}")
         assert "oidc" in config_module.AWS_SSO_OIDC_URL_TEMPLATE
         assert "amazonaws.com" in config_module.AWS_SSO_OIDC_URL_TEMPLATE
         assert "{region}" in config_module.AWS_SSO_OIDC_URL_TEMPLATE
-    
+
     def test_get_aws_sso_oidc_url_returns_correct_url(self):
         """
         What it does: Verifies that get_aws_sso_oidc_url returns correct URL.
@@ -310,15 +333,15 @@ class TestAwsSsoOidcUrlConfig:
         """
         print("Setup: Importing get_aws_sso_oidc_url...")
         from kiro.config import get_aws_sso_oidc_url
-        
+
         print("Action: Calling get_aws_sso_oidc_url('us-east-1')...")
         url = get_aws_sso_oidc_url("us-east-1")
-        
+
         print(f"Verification: URL is correct...")
         expected = "https://oidc.us-east-1.amazonaws.com/token"
         print(f"Comparing: Expected '{expected}', Got '{url}'")
         assert url == expected
-    
+
     def test_get_aws_sso_oidc_url_with_different_regions(self):
         """
         What it does: Verifies URL generation for different regions.
@@ -326,14 +349,14 @@ class TestAwsSsoOidcUrlConfig:
         """
         print("Setup: Importing get_aws_sso_oidc_url...")
         from kiro.config import get_aws_sso_oidc_url
-        
+
         test_cases = [
             ("us-east-1", "https://oidc.us-east-1.amazonaws.com/token"),
             ("eu-west-1", "https://oidc.eu-west-1.amazonaws.com/token"),
             ("ap-southeast-1", "https://oidc.ap-southeast-1.amazonaws.com/token"),
             ("us-west-2", "https://oidc.us-west-2.amazonaws.com/token"),
         ]
-        
+
         for region, expected in test_cases:
             print(f"Action: Calling get_aws_sso_oidc_url('{region}')...")
             url = get_aws_sso_oidc_url(region)
@@ -343,127 +366,134 @@ class TestAwsSsoOidcUrlConfig:
 
 class TestServerHostConfig:
     """Tests for SERVER_HOST configuration."""
-    
+
     def test_default_server_host_is_0_0_0_0(self):
         """
         What it does: Verifies that SERVER_HOST defaults to 0.0.0.0.
         Purpose: Ensure that 0.0.0.0 (all interfaces) is used when no environment variable is set.
         """
         print("Setup: Removing SERVER_HOST from environment...")
-        
+
         with patch.dict(os.environ, {}, clear=False):
             if "SERVER_HOST" in os.environ:
                 del os.environ["SERVER_HOST"]
-            
+
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_HOST: {config_module.SERVER_HOST}")
             print(f"DEFAULT_SERVER_HOST: {config_module.DEFAULT_SERVER_HOST}")
             print(f"Comparing: Expected '0.0.0.0', Got '{config_module.SERVER_HOST}'")
             assert config_module.SERVER_HOST == "0.0.0.0"
             assert config_module.DEFAULT_SERVER_HOST == "0.0.0.0"
-    
+
     def test_server_host_from_environment(self):
         """
         What it does: Verifies loading SERVER_HOST from environment variable.
         Purpose: Ensure that the value from environment is used.
         """
         print("Setup: Setting SERVER_HOST=127.0.0.1...")
-        
+
         with patch.dict(os.environ, {"SERVER_HOST": "127.0.0.1"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_HOST: {config_module.SERVER_HOST}")
             print(f"Comparing: Expected '127.0.0.1', Got '{config_module.SERVER_HOST}'")
             assert config_module.SERVER_HOST == "127.0.0.1"
-    
+
     def test_server_host_custom_value(self):
         """
         What it does: Verifies setting SERVER_HOST to a custom IP address.
         Purpose: Ensure that any valid IP address can be used.
         """
         print("Setup: Setting SERVER_HOST=192.168.1.100...")
-        
+
         with patch.dict(os.environ, {"SERVER_HOST": "192.168.1.100"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_HOST: {config_module.SERVER_HOST}")
             assert config_module.SERVER_HOST == "192.168.1.100"
 
 
 class TestServerPortConfig:
     """Tests for SERVER_PORT configuration."""
-    
+
     def test_default_server_port_is_8000(self):
         """
         What it does: Verifies that SERVER_PORT defaults to 8000.
         Purpose: Ensure that 8000 is used when no environment variable is set.
         """
         print("Setup: Removing SERVER_PORT from environment...")
-        
+
         with patch.dict(os.environ, {}, clear=False):
             if "SERVER_PORT" in os.environ:
                 del os.environ["SERVER_PORT"]
-            
+
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_PORT: {config_module.SERVER_PORT}")
             print(f"DEFAULT_SERVER_PORT: {config_module.DEFAULT_SERVER_PORT}")
             print(f"Comparing: Expected 8000, Got {config_module.SERVER_PORT}")
             assert config_module.SERVER_PORT == 8000
             assert config_module.DEFAULT_SERVER_PORT == 8000
-    
+
     def test_server_port_from_environment(self):
         """
         What it does: Verifies loading SERVER_PORT from environment variable.
         Purpose: Ensure that the value from environment is used.
         """
         print("Setup: Setting SERVER_PORT=9000...")
-        
+
         with patch.dict(os.environ, {"SERVER_PORT": "9000"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_PORT: {config_module.SERVER_PORT}")
             print(f"Comparing: Expected 9000, Got {config_module.SERVER_PORT}")
             assert config_module.SERVER_PORT == 9000
-    
+
     def test_server_port_custom_value(self):
         """
         What it does: Verifies setting SERVER_PORT to a custom port number.
         Purpose: Ensure that any valid port number can be used.
         """
         print("Setup: Setting SERVER_PORT=3000...")
-        
+
         with patch.dict(os.environ, {"SERVER_PORT": "3000"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_PORT: {config_module.SERVER_PORT}")
             assert config_module.SERVER_PORT == 3000
-    
+
     def test_server_port_is_integer(self):
         """
         What it does: Verifies that SERVER_PORT is converted to integer.
         Purpose: Ensure that string from environment is converted to int.
         """
         print("Setup: Setting SERVER_PORT=8080 (as string)...")
-        
+
         with patch.dict(os.environ, {"SERVER_PORT": "8080"}):
             import importlib
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_PORT: {config_module.SERVER_PORT}")
             print(f"Type: {type(config_module.SERVER_PORT)}")
             assert isinstance(config_module.SERVER_PORT, int)
@@ -472,7 +502,7 @@ class TestServerPortConfig:
 
 class TestKiroCliDbFileConfig:
     """Tests for KIRO_CLI_DB_FILE configuration."""
-    
+
     def test_kiro_cli_db_file_config_exists(self):
         """
         What it does: Verifies that KIRO_CLI_DB_FILE constant exists.
@@ -481,15 +511,16 @@ class TestKiroCliDbFileConfig:
         print("Setup: Importing config module...")
         import importlib
         import kiro.config as config_module
+
         importlib.reload(config_module)
-        
+
         print("Verification: KIRO_CLI_DB_FILE exists...")
-        assert hasattr(config_module, 'KIRO_CLI_DB_FILE')
-        
+        assert hasattr(config_module, "KIRO_CLI_DB_FILE")
+
         print(f"KIRO_CLI_DB_FILE: '{config_module.KIRO_CLI_DB_FILE}'")
         # Default should be empty string
         assert isinstance(config_module.KIRO_CLI_DB_FILE, str)
-    
+
     def test_kiro_cli_db_file_from_environment(self):
         """
         What it does: Verifies loading KIRO_CLI_DB_FILE from environment variable.
@@ -498,17 +529,18 @@ class TestKiroCliDbFileConfig:
         print("Setup: Importing config module...")
         import importlib
         import kiro.config as config_module
-        
+
         # Test that KIRO_CLI_DB_FILE is loaded and is a string
         print(f"KIRO_CLI_DB_FILE: {config_module.KIRO_CLI_DB_FILE}")
         assert isinstance(config_module.KIRO_CLI_DB_FILE, str)
-        
+
         # If value is set (not empty), verify it's a normalized path
         if config_module.KIRO_CLI_DB_FILE:
             # Path should be normalized (no raw ~ or forward slashes on Windows)
             assert not config_module.KIRO_CLI_DB_FILE.startswith("~")
             # Should be a valid path string (contains path separators or is absolute)
             from pathlib import Path
+
             path = Path(config_module.KIRO_CLI_DB_FILE)
             # Path should be constructable (doesn't raise exception)
             assert str(path) == config_module.KIRO_CLI_DB_FILE
@@ -516,7 +548,7 @@ class TestKiroCliDbFileConfig:
 
 class TestFallbackModelsConfig:
     """Tests for FALLBACK_MODELS configuration."""
-    
+
     def test_fallback_models_exists(self):
         """
         What it does: Verifies that FALLBACK_MODELS constant exists.
@@ -525,14 +557,15 @@ class TestFallbackModelsConfig:
         print("Setup: Importing config module...")
         import importlib
         import kiro.config as config_module
+
         importlib.reload(config_module)
-        
+
         print("Verification: FALLBACK_MODELS exists...")
-        assert hasattr(config_module, 'FALLBACK_MODELS')
-        
+        assert hasattr(config_module, "FALLBACK_MODELS")
+
         print(f"FALLBACK_MODELS type: {type(config_module.FALLBACK_MODELS)}")
         assert isinstance(config_module.FALLBACK_MODELS, list)
-    
+
     def test_fallback_models_not_empty(self):
         """
         What it does: Verifies that FALLBACK_MODELS contains at least one model.
@@ -540,11 +573,11 @@ class TestFallbackModelsConfig:
         """
         print("Setup: Importing FALLBACK_MODELS...")
         from kiro.config import FALLBACK_MODELS
-        
+
         print(f"FALLBACK_MODELS length: {len(FALLBACK_MODELS)}")
         print(f"Comparing: Expected > 0, Got {len(FALLBACK_MODELS)}")
         assert len(FALLBACK_MODELS) > 0
-    
+
     def test_fallback_models_structure(self):
         """
         What it does: Verifies that each fallback model has required modelId field.
@@ -552,23 +585,23 @@ class TestFallbackModelsConfig:
         """
         print("Setup: Importing FALLBACK_MODELS...")
         from kiro.config import FALLBACK_MODELS
-        
+
         print(f"Action: Checking structure of {len(FALLBACK_MODELS)} models...")
         for i, model in enumerate(FALLBACK_MODELS):
             print(f"Checking model {i}: {model}")
-            
+
             print(f"  Verification: model is dict...")
             assert isinstance(model, dict), f"Model {i} is not a dict"
-            
+
             print(f"  Verification: model has 'modelId'...")
             assert "modelId" in model, f"Model {i} missing 'modelId'"
-            
+
             print(f"  Verification: modelId is string...")
             assert isinstance(model["modelId"], str), f"Model {i} modelId is not string"
-            
+
             print(f"  Verification: modelId is not empty...")
             assert len(model["modelId"]) > 0, f"Model {i} modelId is empty"
-    
+
     def test_fallback_models_contain_claude_models(self):
         """
         What it does: Verifies that fallback models include Claude models.
@@ -576,14 +609,14 @@ class TestFallbackModelsConfig:
         """
         print("Setup: Importing FALLBACK_MODELS...")
         from kiro.config import FALLBACK_MODELS
-        
+
         model_ids = [m["modelId"] for m in FALLBACK_MODELS]
         print(f"Model IDs in fallback list: {model_ids}")
-        
+
         print("Verification: Contains at least one Claude model...")
         has_claude = any("claude" in mid.lower() for mid in model_ids)
         assert has_claude, "No Claude models in fallback list"
-    
+
     def test_fallback_models_use_dot_format(self):
         """
         What it does: Verifies that model IDs use dot format (e.g., claude-4.5).
@@ -591,12 +624,12 @@ class TestFallbackModelsConfig:
         """
         print("Setup: Importing FALLBACK_MODELS...")
         from kiro.config import FALLBACK_MODELS
-        
+
         print("Action: Checking model ID format...")
         for model in FALLBACK_MODELS:
             model_id = model["modelId"]
             print(f"Checking: {model_id}")
-            
+
             # If model has version number, it should use dot format
             if any(char.isdigit() for char in model_id):
                 # Check for patterns like "4.5" or "4-5"
@@ -608,7 +641,7 @@ class TestFallbackModelsConfig:
 
 class TestFallbackModelsIntegration:
     """Integration tests for FALLBACK_MODELS with ModelResolver."""
-    
+
     @pytest.mark.asyncio
     async def test_fallback_models_work_with_model_resolver(self):
         """
@@ -620,17 +653,17 @@ class TestFallbackModelsIntegration:
         from kiro.config import FALLBACK_MODELS
         from kiro.cache import ModelInfoCache
         from kiro.model_resolver import ModelResolver
-        
+
         # Simulate DNS failure scenario - populate cache with fallback models
         cache = ModelInfoCache()
         await cache.update(FALLBACK_MODELS)
-        
+
         print(f"Cache populated with {cache.size} fallback models")
         print(f"Model IDs in cache: {cache.get_all_model_ids()}")
-        
+
         # Create resolver
         resolver = ModelResolver(cache=cache, hidden_models={})
-        
+
         print("\nAction: Testing normalization with dash format...")
         # Test that dash format (claude-opus-4-5) is normalized and found
         test_cases = [
@@ -638,27 +671,33 @@ class TestFallbackModelsIntegration:
             ("claude-sonnet-4-5", "claude-sonnet-4.5"),  # Dash → Dot
             ("claude-haiku-4-5", "claude-haiku-4.5"),  # Dash → Dot
         ]
-        
+
         for input_name, expected_normalized in test_cases:
             print(f"\n  Testing: {input_name} → {expected_normalized}")
             resolution = resolver.resolve(input_name)
-            
+
             print(f"    Resolution source: {resolution.source}")
             print(f"    Normalized: {resolution.normalized}")
             print(f"    Internal ID: {resolution.internal_id}")
             print(f"    Is verified: {resolution.is_verified}")
-            
+
             # Verify normalization happened
-            print(f"    Comparing normalized: Expected '{expected_normalized}', Got '{resolution.normalized}'")
+            print(
+                f"    Comparing normalized: Expected '{expected_normalized}', Got '{resolution.normalized}'"
+            )
             assert resolution.normalized == expected_normalized
-            
+
             # Verify model was found in cache (not passthrough)
             print(f"    Comparing source: Expected 'cache', Got '{resolution.source}'")
-            assert resolution.source == "cache", f"Model {input_name} should be found in fallback cache"
-            
-            print(f"    Comparing is_verified: Expected True, Got {resolution.is_verified}")
+            assert (
+                resolution.source == "cache"
+            ), f"Model {input_name} should be found in fallback cache"
+
+            print(
+                f"    Comparing is_verified: Expected True, Got {resolution.is_verified}"
+            )
             assert resolution.is_verified is True
-    
+
     @pytest.mark.asyncio
     async def test_fallback_models_appear_in_available_models(self):
         """
@@ -669,23 +708,25 @@ class TestFallbackModelsIntegration:
         from kiro.config import FALLBACK_MODELS
         from kiro.cache import ModelInfoCache
         from kiro.model_resolver import ModelResolver
-        
+
         cache = ModelInfoCache()
         await cache.update(FALLBACK_MODELS)
-        
+
         resolver = ModelResolver(cache=cache, hidden_models={})
-        
+
         print("Action: Getting available models...")
         available = resolver.get_available_models()
-        
+
         print(f"Available models: {available}")
-        print(f"Comparing length: Expected {len(FALLBACK_MODELS)}, Got {len(available)}")
+        print(
+            f"Comparing length: Expected {len(FALLBACK_MODELS)}, Got {len(available)}"
+        )
         assert len(available) == len(FALLBACK_MODELS)
-        
+
         # Verify all fallback models are present
         fallback_ids = {m["modelId"] for m in FALLBACK_MODELS}
         available_set = set(available)
-        
+
         print(f"Comparing sets: Expected {fallback_ids}, Got {available_set}")
         assert fallback_ids == available_set
 
@@ -694,9 +735,10 @@ class TestFallbackModelsIntegration:
 # Tests for WebSearch Configuration
 # ==================================================================================================
 
+
 class TestWebSearchConfig:
     """Tests for WebSearch configuration (WEB_SEARCH_ENABLED)."""
-    
+
     def test_web_search_enabled_default_true(self, monkeypatch):
         """
         What it does: Verifies WEB_SEARCH_ENABLED defaults to true.
@@ -704,15 +746,18 @@ class TestWebSearchConfig:
         """
         print("Setup: Removing WEB_SEARCH_ENABLED from environment...")
         monkeypatch.delenv("WEB_SEARCH_ENABLED", raising=False)
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
         import kiro.config as config_module
+
         reload(config_module)
-        
-        print(f"Comparing WEB_SEARCH_ENABLED: Expected True, Got {config_module.WEB_SEARCH_ENABLED}")
+
+        print(
+            f"Comparing WEB_SEARCH_ENABLED: Expected True, Got {config_module.WEB_SEARCH_ENABLED}"
+        )
         assert config_module.WEB_SEARCH_ENABLED is True
-    
+
     def test_web_search_enabled_false(self, monkeypatch):
         """
         What it does: Verifies WEB_SEARCH_ENABLED=false disables auto-injection.
@@ -720,15 +765,18 @@ class TestWebSearchConfig:
         """
         print("Setup: Setting WEB_SEARCH_ENABLED=false...")
         monkeypatch.setenv("WEB_SEARCH_ENABLED", "false")
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
         import kiro.config as config_module
+
         reload(config_module)
-        
-        print(f"Comparing WEB_SEARCH_ENABLED: Expected False, Got {config_module.WEB_SEARCH_ENABLED}")
+
+        print(
+            f"Comparing WEB_SEARCH_ENABLED: Expected False, Got {config_module.WEB_SEARCH_ENABLED}"
+        )
         assert config_module.WEB_SEARCH_ENABLED is False
-    
+
     def test_web_search_enabled_true(self, monkeypatch):
         """
         What it does: Verifies WEB_SEARCH_ENABLED=true enables auto-injection.
@@ -736,15 +784,18 @@ class TestWebSearchConfig:
         """
         print("Setup: Setting WEB_SEARCH_ENABLED=true...")
         monkeypatch.setenv("WEB_SEARCH_ENABLED", "true")
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
         import kiro.config as config_module
+
         reload(config_module)
-        
-        print(f"Comparing WEB_SEARCH_ENABLED: Expected True, Got {config_module.WEB_SEARCH_ENABLED}")
+
+        print(
+            f"Comparing WEB_SEARCH_ENABLED: Expected True, Got {config_module.WEB_SEARCH_ENABLED}"
+        )
         assert config_module.WEB_SEARCH_ENABLED is True
-    
+
     def test_web_search_enabled_numeric_values(self, monkeypatch):
         """
         What it does: Verifies numeric values (1/0) work for WEB_SEARCH_ENABLED.
@@ -752,21 +803,26 @@ class TestWebSearchConfig:
         """
         print("Setup: Testing WEB_SEARCH_ENABLED=1...")
         monkeypatch.setenv("WEB_SEARCH_ENABLED", "1")
-        
+
         from importlib import reload
         import kiro.config as config_module
+
         reload(config_module)
-        
-        print(f"Comparing WEB_SEARCH_ENABLED: Expected True, Got {config_module.WEB_SEARCH_ENABLED}")
+
+        print(
+            f"Comparing WEB_SEARCH_ENABLED: Expected True, Got {config_module.WEB_SEARCH_ENABLED}"
+        )
         assert config_module.WEB_SEARCH_ENABLED is True
-        
+
         print("Setup: Testing WEB_SEARCH_ENABLED=0...")
         monkeypatch.setenv("WEB_SEARCH_ENABLED", "0")
         reload(config_module)
-        
-        print(f"Comparing WEB_SEARCH_ENABLED: Expected False, Got {config_module.WEB_SEARCH_ENABLED}")
+
+        print(
+            f"Comparing WEB_SEARCH_ENABLED: Expected False, Got {config_module.WEB_SEARCH_ENABLED}"
+        )
         assert config_module.WEB_SEARCH_ENABLED is False
-    
+
     def test_web_search_enabled_yes_value(self, monkeypatch):
         """
         What it does: Verifies WEB_SEARCH_ENABLED=yes enables auto-injection.
@@ -774,15 +830,18 @@ class TestWebSearchConfig:
         """
         print("Setup: Setting WEB_SEARCH_ENABLED=yes...")
         monkeypatch.setenv("WEB_SEARCH_ENABLED", "yes")
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
         import kiro.config as config_module
+
         reload(config_module)
-        
-        print(f"Comparing WEB_SEARCH_ENABLED: Expected True, Got {config_module.WEB_SEARCH_ENABLED}")
+
+        print(
+            f"Comparing WEB_SEARCH_ENABLED: Expected True, Got {config_module.WEB_SEARCH_ENABLED}"
+        )
         assert config_module.WEB_SEARCH_ENABLED is True
-    
+
     def test_web_search_enabled_case_insensitive(self, monkeypatch):
         """
         What it does: Verifies WEB_SEARCH_ENABLED is case-insensitive.
@@ -790,19 +849,24 @@ class TestWebSearchConfig:
         """
         print("Setup: Testing WEB_SEARCH_ENABLED=TRUE...")
         monkeypatch.setenv("WEB_SEARCH_ENABLED", "TRUE")
-        
+
         from importlib import reload
         import kiro.config as config_module
+
         reload(config_module)
-        
-        print(f"Comparing WEB_SEARCH_ENABLED: Expected True, Got {config_module.WEB_SEARCH_ENABLED}")
+
+        print(
+            f"Comparing WEB_SEARCH_ENABLED: Expected True, Got {config_module.WEB_SEARCH_ENABLED}"
+        )
         assert config_module.WEB_SEARCH_ENABLED is True
-        
+
         print("Setup: Testing WEB_SEARCH_ENABLED=FALSE...")
         monkeypatch.setenv("WEB_SEARCH_ENABLED", "FALSE")
         reload(config_module)
-        
-        print(f"Comparing WEB_SEARCH_ENABLED: Expected False, Got {config_module.WEB_SEARCH_ENABLED}")
+
+        print(
+            f"Comparing WEB_SEARCH_ENABLED: Expected False, Got {config_module.WEB_SEARCH_ENABLED}"
+        )
         assert config_module.WEB_SEARCH_ENABLED is False
 
 
@@ -810,38 +874,43 @@ class TestWebSearchConfig:
 # Tests for Account System Configuration
 # ==================================================================================================
 
+
 class TestAccountSystemConfig:
     """Tests for Account System configuration constants."""
-    
+
     def test_account_system_default_false(self):
         """
         What it does: Verifies ACCOUNT_SYSTEM defaults to false.
         Purpose: Ensure legacy mode is default (backward compatibility).
         """
         print("Setup: Mocking os.getenv for ACCOUNT_SYSTEM...")
-        
+
         original_getenv = os.getenv
-        
+
         def mock_getenv(key, default=None):
             if key == "ACCOUNT_SYSTEM":
                 print(f"os.getenv('{key}') -> None (mocked)")
                 return default  # Return default, simulating missing variable
             return original_getenv(key, default)
-        
-        with patch.object(os, 'getenv', side_effect=mock_getenv):
+
+        with patch.object(os, "getenv", side_effect=mock_getenv):
             print("Action: Reloading config module...")
             from importlib import reload
             import kiro.config as config_module
+
             reload(config_module)
-            
-            print(f"Comparing ACCOUNT_SYSTEM: Expected False, Got {config_module.ACCOUNT_SYSTEM}")
+
+            print(
+                f"Comparing ACCOUNT_SYSTEM: Expected False, Got {config_module.ACCOUNT_SYSTEM}"
+            )
             assert config_module.ACCOUNT_SYSTEM is False
-        
+
         # Restore module with real values
         from importlib import reload
         import kiro.config as config_module
+
         reload(config_module)
-    
+
     def test_account_system_enabled(self, monkeypatch):
         """
         What it does: Verifies ACCOUNT_SYSTEM=true enables account system.
@@ -849,15 +918,18 @@ class TestAccountSystemConfig:
         """
         print("Setup: Setting ACCOUNT_SYSTEM=true...")
         monkeypatch.setenv("ACCOUNT_SYSTEM", "true")
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
         import kiro.config as config_module
+
         reload(config_module)
-        
-        print(f"Comparing ACCOUNT_SYSTEM: Expected True, Got {config_module.ACCOUNT_SYSTEM}")
+
+        print(
+            f"Comparing ACCOUNT_SYSTEM: Expected True, Got {config_module.ACCOUNT_SYSTEM}"
+        )
         assert config_module.ACCOUNT_SYSTEM is True
-    
+
     def test_accounts_config_file_default(self, monkeypatch):
         """
         What it does: Verifies ACCOUNTS_CONFIG_FILE defaults to credentials.json.
@@ -865,15 +937,18 @@ class TestAccountSystemConfig:
         """
         print("Setup: Removing ACCOUNTS_CONFIG_FILE from environment...")
         monkeypatch.delenv("ACCOUNTS_CONFIG_FILE", raising=False)
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
         import kiro.config as config_module
+
         reload(config_module)
-        
-        print(f"Comparing ACCOUNTS_CONFIG_FILE: Expected 'credentials.json', Got '{config_module.ACCOUNTS_CONFIG_FILE}'")
+
+        print(
+            f"Comparing ACCOUNTS_CONFIG_FILE: Expected 'credentials.json', Got '{config_module.ACCOUNTS_CONFIG_FILE}'"
+        )
         assert config_module.ACCOUNTS_CONFIG_FILE == "credentials.json"
-    
+
     def test_accounts_state_file_default(self, monkeypatch):
         """
         What it does: Verifies ACCOUNTS_STATE_FILE defaults to state.json.
@@ -881,15 +956,18 @@ class TestAccountSystemConfig:
         """
         print("Setup: Removing ACCOUNTS_STATE_FILE from environment...")
         monkeypatch.delenv("ACCOUNTS_STATE_FILE", raising=False)
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
         import kiro.config as config_module
+
         reload(config_module)
-        
-        print(f"Comparing ACCOUNTS_STATE_FILE: Expected 'state.json', Got '{config_module.ACCOUNTS_STATE_FILE}'")
+
+        print(
+            f"Comparing ACCOUNTS_STATE_FILE: Expected 'state.json', Got '{config_module.ACCOUNTS_STATE_FILE}'"
+        )
         assert config_module.ACCOUNTS_STATE_FILE == "state.json"
-    
+
     def test_account_recovery_timeout_default(self, monkeypatch):
         """
         What it does: Verifies ACCOUNT_RECOVERY_TIMEOUT defaults to 60 seconds.
@@ -897,15 +975,18 @@ class TestAccountSystemConfig:
         """
         print("Setup: Removing ACCOUNT_RECOVERY_TIMEOUT from environment...")
         monkeypatch.delenv("ACCOUNT_RECOVERY_TIMEOUT", raising=False)
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
         import kiro.config as config_module
+
         reload(config_module)
-        
-        print(f"Comparing ACCOUNT_RECOVERY_TIMEOUT: Expected 60, Got {config_module.ACCOUNT_RECOVERY_TIMEOUT}")
+
+        print(
+            f"Comparing ACCOUNT_RECOVERY_TIMEOUT: Expected 60, Got {config_module.ACCOUNT_RECOVERY_TIMEOUT}"
+        )
         assert config_module.ACCOUNT_RECOVERY_TIMEOUT == 60
-    
+
     def test_account_max_backoff_multiplier_default(self, monkeypatch):
         """
         What it does: Verifies ACCOUNT_MAX_BACKOFF_MULTIPLIER defaults to 1440.0.
@@ -913,15 +994,18 @@ class TestAccountSystemConfig:
         """
         print("Setup: Removing ACCOUNT_MAX_BACKOFF_MULTIPLIER from environment...")
         monkeypatch.delenv("ACCOUNT_MAX_BACKOFF_MULTIPLIER", raising=False)
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
         import kiro.config as config_module
+
         reload(config_module)
-        
-        print(f"Comparing ACCOUNT_MAX_BACKOFF_MULTIPLIER: Expected 1440.0, Got {config_module.ACCOUNT_MAX_BACKOFF_MULTIPLIER}")
+
+        print(
+            f"Comparing ACCOUNT_MAX_BACKOFF_MULTIPLIER: Expected 1440.0, Got {config_module.ACCOUNT_MAX_BACKOFF_MULTIPLIER}"
+        )
         assert config_module.ACCOUNT_MAX_BACKOFF_MULTIPLIER == 1440.0
-    
+
     def test_account_probabilistic_retry_chance_default(self, monkeypatch):
         """
         What it does: Verifies ACCOUNT_PROBABILISTIC_RETRY_CHANCE defaults to 0.1.
@@ -929,15 +1013,18 @@ class TestAccountSystemConfig:
         """
         print("Setup: Removing ACCOUNT_PROBABILISTIC_RETRY_CHANCE from environment...")
         monkeypatch.delenv("ACCOUNT_PROBABILISTIC_RETRY_CHANCE", raising=False)
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
         import kiro.config as config_module
+
         reload(config_module)
-        
-        print(f"Comparing ACCOUNT_PROBABILISTIC_RETRY_CHANCE: Expected 0.1, Got {config_module.ACCOUNT_PROBABILISTIC_RETRY_CHANCE}")
+
+        print(
+            f"Comparing ACCOUNT_PROBABILISTIC_RETRY_CHANCE: Expected 0.1, Got {config_module.ACCOUNT_PROBABILISTIC_RETRY_CHANCE}"
+        )
         assert config_module.ACCOUNT_PROBABILISTIC_RETRY_CHANCE == 0.1
-    
+
     def test_account_cache_ttl_default(self, monkeypatch):
         """
         What it does: Verifies ACCOUNT_CACHE_TTL defaults to 43200 seconds (12 hours).
@@ -945,15 +1032,18 @@ class TestAccountSystemConfig:
         """
         print("Setup: Removing ACCOUNT_CACHE_TTL from environment...")
         monkeypatch.delenv("ACCOUNT_CACHE_TTL", raising=False)
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
         import kiro.config as config_module
+
         reload(config_module)
-        
-        print(f"Comparing ACCOUNT_CACHE_TTL: Expected 43200, Got {config_module.ACCOUNT_CACHE_TTL}")
+
+        print(
+            f"Comparing ACCOUNT_CACHE_TTL: Expected 43200, Got {config_module.ACCOUNT_CACHE_TTL}"
+        )
         assert config_module.ACCOUNT_CACHE_TTL == 43200
-    
+
     def test_state_save_interval_seconds_default(self, monkeypatch):
         """
         What it does: Verifies STATE_SAVE_INTERVAL_SECONDS defaults to 10 seconds.
@@ -961,11 +1051,139 @@ class TestAccountSystemConfig:
         """
         print("Setup: Removing STATE_SAVE_INTERVAL_SECONDS from environment...")
         monkeypatch.delenv("STATE_SAVE_INTERVAL_SECONDS", raising=False)
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
         import kiro.config as config_module
+
         reload(config_module)
-        
-        print(f"Comparing STATE_SAVE_INTERVAL_SECONDS: Expected 10, Got {config_module.STATE_SAVE_INTERVAL_SECONDS}")
+
+        print(
+            f"Comparing STATE_SAVE_INTERVAL_SECONDS: Expected 10, Got {config_module.STATE_SAVE_INTERVAL_SECONDS}"
+        )
         assert config_module.STATE_SAVE_INTERVAL_SECONDS == 10
+
+
+# ==================================================================================================
+# Tests for Legacy Endpoint Configuration (Issue #168)
+# ==================================================================================================
+
+
+class TestLegacyEndpointConfig:
+    """Tests for KIRO_USE_LEGACY_ENDPOINT configuration."""
+
+    def test_legacy_endpoint_default_false(self, monkeypatch):
+        """
+        What it does: Verifies KIRO_USE_LEGACY_ENDPOINT defaults to false.
+        Purpose: Ensure runtime.kiro.dev is default endpoint.
+        """
+        print("Setup: Removing KIRO_USE_LEGACY_ENDPOINT from environment...")
+        monkeypatch.delenv("KIRO_USE_LEGACY_ENDPOINT", raising=False)
+
+        print("Action: Reloading config module...")
+        from importlib import reload
+        import kiro.config as config_module
+
+        reload(config_module)
+
+        print(
+            f"Comparing KIRO_USE_LEGACY_ENDPOINT: Expected False, Got {config_module.KIRO_USE_LEGACY_ENDPOINT}"
+        )
+        assert config_module.KIRO_USE_LEGACY_ENDPOINT is False
+        assert "runtime" in config_module.KIRO_API_HOST_TEMPLATE
+        assert "runtime" in config_module.KIRO_Q_HOST_TEMPLATE
+
+    def test_legacy_endpoint_enabled(self, monkeypatch):
+        """
+        What it does: Verifies legacy endpoint activates q.amazonaws.com.
+        Purpose: Regression test for issue #168 - Builder ID fallback.
+        """
+        print("Setup: Setting KIRO_USE_LEGACY_ENDPOINT=true...")
+        monkeypatch.setenv("KIRO_USE_LEGACY_ENDPOINT", "true")
+
+        print("Action: Reloading config module...")
+        from importlib import reload
+        import kiro.config as config_module
+
+        reload(config_module)
+
+        print(
+            f"Comparing KIRO_USE_LEGACY_ENDPOINT: Expected True, Got {config_module.KIRO_USE_LEGACY_ENDPOINT}"
+        )
+        assert config_module.KIRO_USE_LEGACY_ENDPOINT is True
+        assert "q.{region}.amazonaws.com" in config_module.KIRO_API_HOST_TEMPLATE
+        assert "q.{region}.amazonaws.com" in config_module.KIRO_Q_HOST_TEMPLATE
+
+    def test_legacy_endpoint_numeric_value(self, monkeypatch):
+        """
+        What it does: Verifies KIRO_USE_LEGACY_ENDPOINT accepts "1" as true.
+        Purpose: Ensure numeric boolean values work.
+        """
+        print("Setup: Setting KIRO_USE_LEGACY_ENDPOINT=1...")
+        monkeypatch.setenv("KIRO_USE_LEGACY_ENDPOINT", "1")
+
+        print("Action: Reloading config module...")
+        from importlib import reload
+        import kiro.config as config_module
+
+        reload(config_module)
+
+        print(
+            f"Comparing KIRO_USE_LEGACY_ENDPOINT: Expected True, Got {config_module.KIRO_USE_LEGACY_ENDPOINT}"
+        )
+        assert config_module.KIRO_USE_LEGACY_ENDPOINT is True
+        assert "q.{region}.amazonaws.com" in config_module.KIRO_API_HOST_TEMPLATE
+
+    def test_get_kiro_api_host_with_legacy(self, monkeypatch):
+        """
+        What it does: Verifies get_kiro_api_host returns correct URL with legacy flag.
+        Purpose: Ensure helper function respects legacy endpoint template.
+        """
+        print("Setup: Setting KIRO_USE_LEGACY_ENDPOINT=true...")
+        monkeypatch.setenv("KIRO_USE_LEGACY_ENDPOINT", "true")
+
+        print("Action: Reloading config module...")
+        from importlib import reload
+        import kiro.config as config_module
+
+        reload(config_module)
+
+        result = config_module.get_kiro_api_host("us-east-1")
+        print(f"Comparing get_kiro_api_host result: {result}")
+        assert result == "https://q.us-east-1.amazonaws.com"
+
+    def test_get_kiro_q_host_with_legacy(self, monkeypatch):
+        """
+        What it does: Verifies get_kiro_q_host returns correct URL with legacy flag.
+        Purpose: Ensure Q host helper also respects legacy endpoint template.
+        """
+        print("Setup: Setting KIRO_USE_LEGACY_ENDPOINT=true...")
+        monkeypatch.setenv("KIRO_USE_LEGACY_ENDPOINT", "true")
+
+        print("Action: Reloading config module...")
+        from importlib import reload
+        import kiro.config as config_module
+
+        reload(config_module)
+
+        result = config_module.get_kiro_q_host("us-east-1")
+        print(f"Comparing get_kiro_q_host result: {result}")
+        assert result == "https://q.us-east-1.amazonaws.com"
+
+    def test_get_kiro_api_host_default_runtime(self, monkeypatch):
+        """
+        What it does: Verifies get_kiro_api_host returns runtime.kiro.dev by default.
+        Purpose: Ensure default behavior unchanged for non-Builder-ID users.
+        """
+        print("Setup: Removing KIRO_USE_LEGACY_ENDPOINT...")
+        monkeypatch.delenv("KIRO_USE_LEGACY_ENDPOINT", raising=False)
+
+        print("Action: Reloading config module...")
+        from importlib import reload
+        import kiro.config as config_module
+
+        reload(config_module)
+
+        result = config_module.get_kiro_api_host("us-east-1")
+        print(f"Comparing get_kiro_api_host result: {result}")
+        assert result == "https://runtime.us-east-1.kiro.dev"

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -416,6 +416,58 @@ class TestCallKiroMCPAPI:
         print(f"Checking profileArn fallback: {request_body.get('profileArn')}")
         assert request_body["profileArn"] == env_arn
 
+    @pytest.mark.asyncio
+    async def test_mcp_api_uses_auth_manager_q_host_for_url(self, mock_auth_manager):
+        """
+        What it does: Verifies MCP URL is derived from auth_manager.q_host.
+        Purpose: Proves legacy endpoint flag (which changes q_host via config) affects MCP.
+        """
+        print("Setup: Checking MCP URL uses auth_manager.q_host...")
+        query = "test"
+
+        mock_response_data = {
+            "id": "test",
+            "jsonrpc": "2.0",
+            "result": {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps({"results": [], "totalResults": 0}),
+                    }
+                ],
+                "isError": False,
+            },
+        }
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value=mock_response_data)
+
+        mock_post = AsyncMock(return_value=mock_response)
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value.post = mock_post
+
+        # Verify with default q_host (runtime.kiro.dev)
+        print(f"auth_manager.q_host = {mock_auth_manager.q_host}")
+        with patch("kiro.mcp_tools.httpx.AsyncClient", return_value=mock_client):
+            await call_kiro_mcp_api(query, mock_auth_manager)
+
+        call_args = mock_post.call_args
+        called_url = (
+            call_args.kwargs.get("url") or call_args[0][0]
+            if call_args[0]
+            else call_args.kwargs.get("url")
+        )
+        # post is called with url as positional arg
+        actual_url = (
+            mock_post.call_args[0][0]
+            if mock_post.call_args[0]
+            else mock_post.call_args.kwargs.get("url")
+        )
+        print(f"MCP URL called: {actual_url}")
+        assert actual_url == f"{mock_auth_manager.q_host}/mcp"
+        assert "runtime" in actual_url or "amazonaws" in actual_url
+
 
 # ==================================================================================================
 # Tests for Search Summary Generation

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -24,7 +24,7 @@ from kiro.mcp_tools import (
     extract_query_from_messages,
     handle_native_web_search,
     generate_anthropic_web_search_sse,
-    generate_openai_web_search_sse
+    generate_openai_web_search_sse,
 )
 
 
@@ -32,55 +32,58 @@ from kiro.mcp_tools import (
 # Tests for ID Generation
 # ==================================================================================================
 
+
 class TestIDGeneration:
     """Tests for random ID generation."""
-    
+
     def test_generate_random_id_length(self):
         """
         What it does: Verifies ID generation with exact length.
         Purpose: Ensure generate_random_id returns correct length.
         """
         print("Setup: Generating IDs of different lengths...")
-        
+
         print("Action: Generate ID of length 22...")
         id_22 = generate_random_id(22)
         print(f"Comparing length: Expected 22, Got {len(id_22)}")
         assert len(id_22) == 22
-        
+
         print("Action: Generate ID of length 8...")
         id_8 = generate_random_id(8)
         print(f"Comparing length: Expected 8, Got {len(id_8)}")
         assert len(id_8) == 8
-        
+
         print("Action: Generate ID of length 100...")
         id_100 = generate_random_id(100)
         print(f"Comparing length: Expected 100, Got {len(id_100)}")
         assert len(id_100) == 100
-    
+
     def test_generate_random_id_alphanumeric(self):
         """
         What it does: Verifies ID contains only alphanumeric characters.
         Purpose: Ensure no special characters in generated IDs.
         """
         print("Setup: Generating large ID to test character set...")
-        
+
         print("Action: Generate ID of length 1000...")
         random_id = generate_random_id(1000)
-        
+
         print(f"Checking if alphanumeric: {random_id[:50]}...")
         assert random_id.isalnum()
-    
+
     def test_generate_random_id_uniqueness(self):
         """
         What it does: Verifies IDs are unique (probabilistically).
         Purpose: Ensure randomness works correctly.
         """
         print("Setup: Generating multiple IDs...")
-        
+
         print("Action: Generate 100 IDs of length 22...")
         ids = [generate_random_id(22) for _ in range(100)]
-        
-        print(f"Comparing uniqueness: Generated {len(ids)} IDs, unique: {len(set(ids))}")
+
+        print(
+            f"Comparing uniqueness: Generated {len(ids)} IDs, unique: {len(set(ids))}"
+        )
         assert len(set(ids)) == len(ids)  # All should be unique
 
 
@@ -88,9 +91,10 @@ class TestIDGeneration:
 # Tests for MCP API Call
 # ==================================================================================================
 
+
 class TestCallKiroMCPAPI:
     """Tests for MCP API calls."""
-    
+
     @pytest.mark.asyncio
     async def test_mcp_api_success(self, mock_auth_manager):
         """
@@ -99,54 +103,58 @@ class TestCallKiroMCPAPI:
         """
         print("Setup: Mocking successful MCP API response...")
         query = "Python tutorials"
-        
+
         # Mock MCP response (CRITICAL: result.content[0].text is JSON STRING)
         mock_response_data = {
             "id": "web_search_tooluse_abc123_1234567890_xyz",
             "jsonrpc": "2.0",
             "result": {
-                "content": [{
-                    "type": "text",
-                    "text": json.dumps({
-                        "results": [
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
                             {
-                                "title": "Python Tutorial",
-                                "url": "https://python.org",
-                                "snippet": "Learn Python programming",
-                                "publishedDate": 1700000000000
+                                "results": [
+                                    {
+                                        "title": "Python Tutorial",
+                                        "url": "https://python.org",
+                                        "snippet": "Learn Python programming",
+                                        "publishedDate": 1700000000000,
+                                    }
+                                ],
+                                "totalResults": 1,
+                                "query": "Python tutorials",
                             }
-                        ],
-                        "totalResults": 1,
-                        "query": "Python tutorials"
-                    })
-                }],
-                "isError": False
-            }
+                        ),
+                    }
+                ],
+                "isError": False,
+            },
         }
-        
+
         # Mock httpx.AsyncClient - CRITICAL: json() must be async
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_response_data)
-        
+
         mock_post = AsyncMock(return_value=mock_response)
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value.post = mock_post
-        
+
         print("Action: Calling call_kiro_mcp_api...")
         with patch("kiro.mcp_tools.httpx.AsyncClient", return_value=mock_client):
             tool_use_id, results = await call_kiro_mcp_api(query, mock_auth_manager)
-        
+
         print(f"Comparing tool_use_id: Got '{tool_use_id}'")
         assert tool_use_id is not None
         assert tool_use_id.startswith("srvtoolu_")
-        
+
         print(f"Comparing results: Got {results}")
         assert results is not None
         assert results["totalResults"] == 1
         assert results["results"][0]["title"] == "Python Tutorial"
         assert results["results"][0]["url"] == "https://python.org"
-    
+
     @pytest.mark.asyncio
     async def test_mcp_api_error_response(self, mock_auth_manager):
         """
@@ -155,30 +163,32 @@ class TestCallKiroMCPAPI:
         """
         print("Setup: Mocking MCP API error response...")
         query = "test"
-        
+
         # Mock error response
         mock_response_data = {
             "id": "web_search_tooluse_abc123_1234567890_xyz",
             "jsonrpc": "2.0",
-            "error": {"code": -32600, "message": "Invalid request"}
+            "error": {"code": -32600, "message": "Invalid request"},
         }
-        
+
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_response_data)
-        
+
         mock_post = AsyncMock(return_value=mock_response)
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value.post = mock_post
-        
+
         print("Action: Calling call_kiro_mcp_api...")
         with patch("kiro.mcp_tools.httpx.AsyncClient", return_value=mock_client):
             tool_use_id, results = await call_kiro_mcp_api(query, mock_auth_manager)
-        
-        print(f"Comparing result: Expected (None, None), Got ({tool_use_id}, {results})")
+
+        print(
+            f"Comparing result: Expected (None, None), Got ({tool_use_id}, {results})"
+        )
         assert tool_use_id is None
         assert results is None
-    
+
     @pytest.mark.asyncio
     async def test_mcp_api_http_error(self, mock_auth_manager):
         """
@@ -187,22 +197,24 @@ class TestCallKiroMCPAPI:
         """
         print("Setup: Mocking HTTP 500 error...")
         query = "test"
-        
+
         mock_response = Mock()
         mock_response.status_code = 500
-        
+
         mock_post = AsyncMock(return_value=mock_response)
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value.post = mock_post
-        
+
         print("Action: Calling call_kiro_mcp_api...")
         with patch("kiro.mcp_tools.httpx.AsyncClient", return_value=mock_client):
             tool_use_id, results = await call_kiro_mcp_api(query, mock_auth_manager)
-        
-        print(f"Comparing result: Expected (None, None), Got ({tool_use_id}, {results})")
+
+        print(
+            f"Comparing result: Expected (None, None), Got ({tool_use_id}, {results})"
+        )
         assert tool_use_id is None
         assert results is None
-    
+
     @pytest.mark.asyncio
     async def test_mcp_api_timeout(self, mock_auth_manager):
         """
@@ -211,21 +223,23 @@ class TestCallKiroMCPAPI:
         """
         print("Setup: Mocking timeout exception...")
         query = "test"
-        
+
         import httpx
-        
+
         mock_post = AsyncMock(side_effect=httpx.TimeoutException("Timeout"))
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value.post = mock_post
-        
+
         print("Action: Calling call_kiro_mcp_api...")
         with patch("kiro.mcp_tools.httpx.AsyncClient", return_value=mock_client):
             tool_use_id, results = await call_kiro_mcp_api(query, mock_auth_manager)
-        
-        print(f"Comparing result: Expected (None, None), Got ({tool_use_id}, {results})")
+
+        print(
+            f"Comparing result: Expected (None, None), Got ({tool_use_id}, {results})"
+        )
         assert tool_use_id is None
         assert results is None
-    
+
     @pytest.mark.asyncio
     async def test_mcp_api_json_decode_error(self, mock_auth_manager):
         """
@@ -234,31 +248,183 @@ class TestCallKiroMCPAPI:
         """
         print("Setup: Mocking malformed JSON response...")
         query = "test"
-        
+
         mock_response = Mock()
         mock_response.status_code = 200
-        mock_response.json = Mock(side_effect=json.JSONDecodeError("Invalid JSON", "", 0))
-        
+        mock_response.json = Mock(
+            side_effect=json.JSONDecodeError("Invalid JSON", "", 0)
+        )
+
         mock_post = AsyncMock(return_value=mock_response)
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value.post = mock_post
-        
+
         print("Action: Calling call_kiro_mcp_api...")
         with patch("kiro.mcp_tools.httpx.AsyncClient", return_value=mock_client):
             tool_use_id, results = await call_kiro_mcp_api(query, mock_auth_manager)
-        
-        print(f"Comparing result: Expected (None, None), Got ({tool_use_id}, {results})")
+
+        print(
+            f"Comparing result: Expected (None, None), Got ({tool_use_id}, {results})"
+        )
         assert tool_use_id is None
         assert results is None
+
+    @pytest.mark.asyncio
+    async def test_mcp_api_includes_profile_arn_when_available(self, mock_auth_manager):
+        """
+        What it does: Verifies profileArn is included in MCP request body.
+        Purpose: Regression test for issue #173 - runtime.kiro.dev/mcp requires profileArn.
+        """
+        print("Setup: Mocking MCP API with auth_manager that has profile_arn...")
+        query = "test query"
+
+        mock_response_data = {
+            "id": "test",
+            "jsonrpc": "2.0",
+            "result": {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps({"results": [], "totalResults": 0}),
+                    }
+                ],
+                "isError": False,
+            },
+        }
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value=mock_response_data)
+
+        mock_post = AsyncMock(return_value=mock_response)
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value.post = mock_post
+
+        print("Action: Calling call_kiro_mcp_api with profile_arn set...")
+        with patch("kiro.mcp_tools.httpx.AsyncClient", return_value=mock_client):
+            await call_kiro_mcp_api(query, mock_auth_manager)
+
+        # Verify the request body includes profileArn
+        call_args = mock_post.call_args
+        request_body = call_args.kwargs.get("json") or call_args[1].get("json")
+        print(f"Checking profileArn in request body: {request_body.get('profileArn')}")
+        assert "profileArn" in request_body
+        assert (
+            request_body["profileArn"]
+            == "arn:aws:codewhisperer:us-east-1:123456789:profile/test"
+        )
+
+    @pytest.mark.asyncio
+    async def test_mcp_api_no_profile_arn_when_missing(self):
+        """
+        What it does: Verifies MCP request omits profileArn when not available.
+        Purpose: Ensure Builder ID accounts (no profileArn) don't send empty string.
+        """
+        print("Setup: Creating auth_manager without profile_arn...")
+        from kiro.auth import KiroAuthManager
+        from datetime import datetime, timezone
+
+        manager = KiroAuthManager(
+            refresh_token="test_token", profile_arn=None, region="us-east-1"
+        )
+        manager._access_token = "test_access_token"
+        manager._expires_at = datetime.now(timezone.utc).replace(year=2099)
+
+        query = "test query"
+
+        mock_response_data = {
+            "id": "test",
+            "jsonrpc": "2.0",
+            "result": {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps({"results": [], "totalResults": 0}),
+                    }
+                ],
+                "isError": False,
+            },
+        }
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value=mock_response_data)
+
+        mock_post = AsyncMock(return_value=mock_response)
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value.post = mock_post
+
+        print("Action: Calling call_kiro_mcp_api without profile_arn...")
+        with patch("kiro.mcp_tools.httpx.AsyncClient", return_value=mock_client):
+            with patch("kiro.mcp_tools.PROFILE_ARN", ""):
+                await call_kiro_mcp_api(query, manager)
+
+        # Verify profileArn is NOT in request body
+        call_args = mock_post.call_args
+        request_body = call_args.kwargs.get("json") or call_args[1].get("json")
+        print(f"Checking profileArn absent: {'profileArn' not in request_body}")
+        assert "profileArn" not in request_body
+
+    @pytest.mark.asyncio
+    async def test_mcp_api_falls_back_to_env_profile_arn(self):
+        """
+        What it does: Verifies MCP uses PROFILE_ARN env when auth_manager has none.
+        Purpose: Ensure env fallback works for accounts with externally configured profileArn.
+        """
+        print("Setup: Creating auth_manager without profile_arn but env set...")
+        from kiro.auth import KiroAuthManager
+        from datetime import datetime, timezone
+
+        manager = KiroAuthManager(
+            refresh_token="test_token", profile_arn=None, region="us-east-1"
+        )
+        manager._access_token = "test_access_token"
+        manager._expires_at = datetime.now(timezone.utc).replace(year=2099)
+
+        query = "test query"
+
+        mock_response_data = {
+            "id": "test",
+            "jsonrpc": "2.0",
+            "result": {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps({"results": [], "totalResults": 0}),
+                    }
+                ],
+                "isError": False,
+            },
+        }
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value=mock_response_data)
+
+        mock_post = AsyncMock(return_value=mock_response)
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value.post = mock_post
+
+        env_arn = "arn:aws:codewhisperer:us-east-1:999999:profile/ENV_FALLBACK"
+        print(f"Action: Calling with PROFILE_ARN env = {env_arn}...")
+        with patch("kiro.mcp_tools.httpx.AsyncClient", return_value=mock_client):
+            with patch("kiro.mcp_tools.PROFILE_ARN", env_arn):
+                await call_kiro_mcp_api(query, manager)
+
+        call_args = mock_post.call_args
+        request_body = call_args.kwargs.get("json") or call_args[1].get("json")
+        print(f"Checking profileArn fallback: {request_body.get('profileArn')}")
+        assert request_body["profileArn"] == env_arn
 
 
 # ==================================================================================================
 # Tests for Search Summary Generation
 # ==================================================================================================
 
+
 class TestGenerateSearchSummary:
     """Tests for search summary formatting."""
-    
+
     def test_generate_summary_with_results(self):
         """
         What it does: Verifies summary formatting with results.
@@ -272,38 +438,38 @@ class TestGenerateSearchSummary:
                     "title": "Python.org",
                     "url": "https://python.org",
                     "snippet": "Official Python website with tutorials",
-                    "publishedDate": 1700000000000
+                    "publishedDate": 1700000000000,
                 },
                 {
                     "title": "Python Tutorial",
                     "url": "https://docs.python.org",
                     "snippet": "Complete Python documentation",
-                    "publishedDate": None  # No date
-                }
+                    "publishedDate": None,  # No date
+                },
             ],
-            "totalResults": 2
+            "totalResults": 2,
         }
-        
+
         print("Action: Generating summary...")
         summary = generate_search_summary(query, results)
-        
+
         print(f"Checking XML tags...")
         assert "<web_search>" in summary
         assert "</web_search>" in summary
-        
+
         print(f"Checking query in summary...")
         assert "Python" in summary
-        
+
         print(f"Checking first result...")
         assert "Python.org" in summary
         assert "https://python.org" in summary
         assert "Official Python website with tutorials" in summary
-        
+
         print(f"Checking second result...")
         assert "Python Tutorial" in summary
         assert "https://docs.python.org" in summary
         assert "Complete Python documentation" in summary
-    
+
     def test_generate_summary_no_results(self):
         """
         What it does: Verifies summary with empty results list.
@@ -312,21 +478,21 @@ class TestGenerateSearchSummary:
         print("Setup: Creating empty results...")
         query = "nonexistent"
         results = {"results": [], "totalResults": 0}
-        
+
         print("Action: Generating summary...")
         summary = generate_search_summary(query, results)
-        
+
         print(f"Checking XML tags...")
         assert "<web_search>" in summary
         assert "</web_search>" in summary
-        
+
         print(f"Checking query in summary...")
         assert "nonexistent" in summary
-        
+
         print(f"Summary content: {repr(summary)}")
         # Empty results list produces empty content between tags (no "No results found")
         assert "Search results for" in summary
-    
+
     def test_generate_summary_malformed_results(self):
         """
         What it does: Verifies handling of malformed results.
@@ -335,13 +501,13 @@ class TestGenerateSearchSummary:
         print("Setup: Creating malformed results...")
         query = "test"
         results = {"invalid": "structure"}
-        
+
         print("Action: Generating summary...")
         summary = generate_search_summary(query, results)
-        
+
         print(f"Checking for 'No results found'...")
         assert "No results found" in summary
-    
+
     def test_generate_summary_date_formatting(self):
         """
         What it does: Verifies date formatting from milliseconds timestamp.
@@ -351,22 +517,24 @@ class TestGenerateSearchSummary:
         query = "test"
         # 1700000000000 ms = 2023-11-14 22:13:20 UTC
         results = {
-            "results": [{
-                "title": "Test",
-                "url": "https://test.com",
-                "snippet": "Test snippet",
-                "publishedDate": 1700000000000
-            }],
-            "totalResults": 1
+            "results": [
+                {
+                    "title": "Test",
+                    "url": "https://test.com",
+                    "snippet": "Test snippet",
+                    "publishedDate": 1700000000000,
+                }
+            ],
+            "totalResults": 1,
         }
-        
+
         print("Action: Generating summary...")
         summary = generate_search_summary(query, results)
-        
+
         print(f"Checking date format...")
         # Should contain formatted date like "14 Nov 2023"
         assert "Nov 2023" in summary or "Ноя 2023" in summary  # Depends on locale
-    
+
     def test_generate_summary_full_snippet_no_truncation(self):
         """
         What it does: Verifies snippets are NOT truncated.
@@ -376,18 +544,20 @@ class TestGenerateSearchSummary:
         query = "test"
         long_snippet = "A" * 1000  # 1000 characters
         results = {
-            "results": [{
-                "title": "Test",
-                "url": "https://test.com",
-                "snippet": long_snippet,
-                "publishedDate": None
-            }],
-            "totalResults": 1
+            "results": [
+                {
+                    "title": "Test",
+                    "url": "https://test.com",
+                    "snippet": long_snippet,
+                    "publishedDate": None,
+                }
+            ],
+            "totalResults": 1,
         }
-        
+
         print("Action: Generating summary...")
         summary = generate_search_summary(query, results)
-        
+
         print(f"Checking snippet is NOT truncated...")
         assert long_snippet in summary
         assert len(long_snippet) == 1000  # Full length preserved
@@ -397,9 +567,10 @@ class TestGenerateSearchSummary:
 # Tests for Query Extraction
 # ==================================================================================================
 
+
 class TestExtractQueryFromMessages:
     """Tests for query extraction from messages."""
-    
+
     def test_extract_query_anthropic_string_content(self):
         """
         What it does: Extracts query from Anthropic string content.
@@ -407,14 +578,17 @@ class TestExtractQueryFromMessages:
         """
         print("Setup: Creating Anthropic message with string content...")
         from kiro.models_anthropic import AnthropicMessage
-        messages = [AnthropicMessage(role="user", content="Search for Python tutorials")]
-        
+
+        messages = [
+            AnthropicMessage(role="user", content="Search for Python tutorials")
+        ]
+
         print("Action: Extracting query...")
         query = extract_query_from_messages(messages, "anthropic")
-        
+
         print(f"Comparing query: Expected 'Search for Python tutorials', Got '{query}'")
         assert query == "Search for Python tutorials"
-    
+
     def test_extract_query_anthropic_list_content(self):
         """
         What it does: Extracts query from Anthropic list content.
@@ -422,17 +596,20 @@ class TestExtractQueryFromMessages:
         """
         print("Setup: Creating Anthropic message with list content...")
         from kiro.models_anthropic import AnthropicMessage, TextContentBlock
-        messages = [AnthropicMessage(
-            role="user",
-            content=[TextContentBlock(type="text", text="Python tutorials")]
-        )]
-        
+
+        messages = [
+            AnthropicMessage(
+                role="user",
+                content=[TextContentBlock(type="text", text="Python tutorials")],
+            )
+        ]
+
         print("Action: Extracting query...")
         query = extract_query_from_messages(messages, "anthropic")
-        
+
         print(f"Comparing query: Expected 'Python tutorials', Got '{query}'")
         assert query == "Python tutorials"
-    
+
     def test_extract_query_with_prefix(self):
         """
         What it does: Removes 'Perform a web search for the query:' prefix.
@@ -440,17 +617,19 @@ class TestExtractQueryFromMessages:
         """
         print("Setup: Creating message with prefix...")
         from kiro.models_anthropic import AnthropicMessage
-        messages = [AnthropicMessage(
-            role="user",
-            content="Perform a web search for the query: Python"
-        )]
-        
+
+        messages = [
+            AnthropicMessage(
+                role="user", content="Perform a web search for the query: Python"
+            )
+        ]
+
         print("Action: Extracting query...")
         query = extract_query_from_messages(messages, "anthropic")
-        
+
         print(f"Comparing query: Expected 'Python', Got '{query}'")
         assert query == "Python"
-    
+
     def test_extract_query_empty_messages(self):
         """
         What it does: Handles empty messages list.
@@ -458,38 +637,47 @@ class TestExtractQueryFromMessages:
         """
         print("Setup: Creating empty messages list...")
         messages = []
-        
+
         print("Action: Extracting query...")
         query = extract_query_from_messages(messages, "anthropic")
-        
+
         print(f"Comparing query: Expected None, Got {query}")
         assert query is None
-    
+
     def test_extract_query_no_text_content(self):
         """
         What it does: Handles messages without text content.
         Purpose: Ensure None is returned for non-text messages.
         """
         print("Setup: Creating message with image content...")
-        from kiro.models_anthropic import AnthropicMessage, ImageContentBlock, Base64ImageSource
-        messages = [AnthropicMessage(
-            role="user",
-            content=[ImageContentBlock(
-                type="image",
-                source=Base64ImageSource(
-                    type="base64",
-                    media_type="image/png",
-                    data="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-                )
-            )]
-        )]
-        
+        from kiro.models_anthropic import (
+            AnthropicMessage,
+            ImageContentBlock,
+            Base64ImageSource,
+        )
+
+        messages = [
+            AnthropicMessage(
+                role="user",
+                content=[
+                    ImageContentBlock(
+                        type="image",
+                        source=Base64ImageSource(
+                            type="base64",
+                            media_type="image/png",
+                            data="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+                        ),
+                    )
+                ],
+            )
+        ]
+
         print("Action: Extracting query...")
         query = extract_query_from_messages(messages, "anthropic")
-        
+
         print(f"Comparing query: Expected None or empty, Got '{query}'")
         assert query is None or query == ""
-    
+
     def test_extract_query_multiple_text_blocks(self):
         """
         What it does: Concatenates multiple text blocks.
@@ -497,17 +685,20 @@ class TestExtractQueryFromMessages:
         """
         print("Setup: Creating message with multiple text blocks...")
         from kiro.models_anthropic import AnthropicMessage, TextContentBlock
-        messages = [AnthropicMessage(
-            role="user",
-            content=[
-                TextContentBlock(type="text", text="Search for "),
-                TextContentBlock(type="text", text="Python tutorials")
-            ]
-        )]
-        
+
+        messages = [
+            AnthropicMessage(
+                role="user",
+                content=[
+                    TextContentBlock(type="text", text="Search for "),
+                    TextContentBlock(type="text", text="Python tutorials"),
+                ],
+            )
+        ]
+
         print("Action: Extracting query...")
         query = extract_query_from_messages(messages, "anthropic")
-        
+
         print(f"Comparing query: Expected 'Search for Python tutorials', Got '{query}'")
         assert query == "Search for Python tutorials"
 
@@ -516,9 +707,10 @@ class TestExtractQueryFromMessages:
 # Tests for SSE Emulation
 # ==================================================================================================
 
+
 class TestAnthropicSSEEmulation:
     """Tests for Anthropic SSE stream generation."""
-    
+
     @pytest.mark.asyncio
     async def test_generate_anthropic_sse_structure(self):
         """
@@ -530,26 +722,30 @@ class TestAnthropicSSEEmulation:
         query = "Python"
         tool_use_id = "srvtoolu_test123"
         results = {
-            "results": [{"title": "Test", "url": "https://test.com", "snippet": "Test"}],
-            "totalResults": 1
+            "results": [
+                {"title": "Test", "url": "https://test.com", "snippet": "Test"}
+            ],
+            "totalResults": 1,
         }
         input_tokens = 100
-        
+
         print("Action: Generating SSE stream...")
         events = []
-        async for event in generate_anthropic_web_search_sse(model, query, tool_use_id, results, input_tokens):
+        async for event in generate_anthropic_web_search_sse(
+            model, query, tool_use_id, results, input_tokens
+        ):
             events.append(event)
-        
+
         print(f"Comparing event count: Got {len(events)} events")
         assert len(events) >= 11  # At least 11 events (may have more text_delta chunks)
-        
+
         print("Checking event types...")
         event_types = []
         for event in events:
             if "event:" in event:
                 event_type = event.split("event:")[1].split("\n")[0].strip()
                 event_types.append(event_type)
-        
+
         print(f"Event types: {event_types}")
         assert "message_start" in event_types
         assert "content_block_start" in event_types
@@ -561,7 +757,7 @@ class TestAnthropicSSEEmulation:
 
 class TestOpenAISSEEmulation:
     """Tests for OpenAI SSE stream generation."""
-    
+
     @pytest.mark.asyncio
     async def test_generate_openai_sse_structure(self):
         """
@@ -573,30 +769,34 @@ class TestOpenAISSEEmulation:
         query = "Python"
         tool_use_id = "srvtoolu_test123"
         results = {
-            "results": [{"title": "Test", "url": "https://test.com", "snippet": "Test"}],
-            "totalResults": 1
+            "results": [
+                {"title": "Test", "url": "https://test.com", "snippet": "Test"}
+            ],
+            "totalResults": 1,
         }
         input_tokens = 100
-        
+
         print("Action: Generating SSE stream...")
         chunks = []
-        async for chunk in generate_openai_web_search_sse(model, query, tool_use_id, results, input_tokens):
+        async for chunk in generate_openai_web_search_sse(
+            model, query, tool_use_id, results, input_tokens
+        ):
             chunks.append(chunk)
-        
+
         print(f"Comparing chunk count: Got {len(chunks)} chunks")
         assert len(chunks) >= 3  # At least: role, content chunks, finish + [DONE]
-        
+
         print("Checking for [DONE] marker...")
         assert any("[DONE]" in chunk for chunk in chunks)
-        
+
         print("Checking for role delta (flexible matching)...")
         assert any('"role"' in chunk and '"assistant"' in chunk for chunk in chunks)
-        
+
         print("Checking for finish_reason (flexible matching)...")
         assert any('"finish_reason"' in chunk and '"stop"' in chunk for chunk in chunks)
-        
+
         print("Checking for data: prefix...")
         assert any(chunk.startswith("data:") for chunk in chunks)
-        
+
         print("Checking for usage information...")
         assert any('"usage"' in chunk for chunk in chunks)


### PR DESCRIPTION
## Summary

Fixes the runtime.kiro.dev/profileArn regression affecting Builder ID/free-tier users and MCP web_search requests.

## Changes

- Include `profileArn` in MCP web_search request bodies when available (closes #173)
- Add `KIRO_USE_LEGACY_ENDPOINT` compatibility fallback for Builder ID accounts (#168)
- Add 10 regression tests for MCP profileArn handling and endpoint config behavior
- Document legacy endpoint fallback and troubleshooting guidance in README and .env.example

## Issues

Fixes #173.
Updates #168 with a documented compatibility workaround.

## Root Cause

Since May 15 2026, `runtime.kiro.dev` requires `profileArn` for ALL account types:
1. MCP `/mcp` endpoint never included `profileArn` in request body → 400 error
2. Builder ID (free tier) accounts have no `profileArn` and no API to discover one → all requests fail

## Verification

```bash
./venv/Scripts/python.exe -m pytest tests/unit/ -v
# Result: 1683 passed, 0 failed, 3 warnings (pre-existing)
```

## Notes

- The legacy endpoint fallback (`KIRO_USE_LEGACY_ENDPOINT=true`) is a compatibility bridge for Builder ID users, not the preferred default.
- MCP endpoint URL is derived from `auth_manager.q_host` which respects the legacy flag automatically.
- No secrets are logged in any affected path.