### PR TITLE
[codex] accept claude code server tool history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ requests/
 .pytest_cache/
 .coverage
 htmlcov/
+
+# Local Codex Python env cache
+.codex-python-env.local.json

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -92,6 +92,54 @@ class ToolReferenceContentBlock(BaseModel):
     model_config = {"extra": "allow"}
 
 
+class ServerToolUseContentBlock(BaseModel):
+    """
+    Server-side tool use content block returned by Anthropic.
+
+    Claude Code can include these blocks in assistant history after native
+    tools such as web_search run. Kiro Gateway accepts them for history
+    compatibility but does not forward them as Kiro tool calls.
+    """
+
+    type: Literal["server_tool_use"] = "server_tool_use"
+    id: str
+    name: str
+    input: Dict[str, Any] = Field(default_factory=dict)
+
+    model_config = {"extra": "allow"}
+
+
+class WebSearchResultBlock(BaseModel):
+    """
+    Individual web search result block from Anthropic server-side tools.
+    """
+
+    type: Literal["web_search_result"] = "web_search_result"
+    title: Optional[str] = None
+    url: Optional[str] = None
+    encrypted_content: Optional[str] = None
+    page_age: Optional[str] = None
+
+    model_config = {"extra": "allow"}
+
+
+class WebSearchToolResultContentBlock(BaseModel):
+    """
+    Server-side web search result block returned by Anthropic.
+
+    These blocks appear in Claude Code conversation history paired with
+    server_tool_use blocks. They are accepted to preserve compatibility and
+    ignored by Kiro conversion because Kiro cannot replay Anthropic-native
+    server tool results.
+    """
+
+    type: Literal["web_search_tool_result"] = "web_search_tool_result"
+    tool_use_id: str
+    content: Union[str, List[Union[WebSearchResultBlock, Dict[str, Any]]]]
+
+    model_config = {"extra": "allow"}
+
+
 class ToolResultContentBlock(BaseModel):
     """
     Tool result content block in Anthropic format.
@@ -103,7 +151,18 @@ class ToolResultContentBlock(BaseModel):
     type: Literal["tool_result"] = "tool_result"
     tool_use_id: str
     content: Optional[
-        Union[str, List[Union["TextContentBlock", "ImageContentBlock", "ToolReferenceContentBlock"]]]
+        Union[
+            str,
+            List[
+                Union[
+                    "TextContentBlock",
+                    "ImageContentBlock",
+                    "ToolReferenceContentBlock",
+                    WebSearchResultBlock,
+                    Dict[str, Any],
+                ]
+            ],
+        ]
     ] = None
     is_error: Optional[bool] = None
 
@@ -170,6 +229,8 @@ ContentBlock = Union[
     ToolUseContentBlock,
     ToolResultContentBlock,
     ToolReferenceContentBlock,
+    ServerToolUseContentBlock,
+    WebSearchToolResultContentBlock,
 ]
 
 

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -22,6 +22,9 @@ from kiro.models_anthropic import (
     ToolUseContentBlock,
     ToolResultContentBlock,
     ToolReferenceContentBlock,
+    ServerToolUseContentBlock,
+    WebSearchResultBlock,
+    WebSearchToolResultContentBlock,
     # Image models
     Base64ImageSource,
     URLImageSource,
@@ -1052,6 +1055,83 @@ class TestToolReferenceContentBlock:
 
         print(f"Comparing type: Expected 'tool_reference', Got '{block.type}'")
         assert block.type == "tool_reference"
+
+
+# ==================================================================================================
+# Tests for server-side tool history blocks
+# ==================================================================================================
+
+class TestServerToolHistoryBlocks:
+    """Tests for Anthropic server-side tool history blocks."""
+
+    def test_server_tool_use_content_block(self):
+        """
+        What it does: Verifies server_tool_use blocks from Claude Code history are accepted.
+        Purpose: Prevent 422 validation errors when native web_search history is replayed.
+        """
+        block = ServerToolUseContentBlock(
+            id="srvtoolu_123",
+            name="web_search",
+            input={"query": "latest release"},
+        )
+
+        assert block.type == "server_tool_use"
+        assert block.name == "web_search"
+        assert block.input["query"] == "latest release"
+
+    def test_web_search_tool_result_content_block(self):
+        """
+        What it does: Verifies web_search_tool_result blocks from Claude Code history are accepted.
+        Purpose: Prevent 422 validation errors when server-side search results are replayed.
+        """
+        block = WebSearchToolResultContentBlock(
+            tool_use_id="srvtoolu_123",
+            content=[
+                WebSearchResultBlock(
+                    title="Releases",
+                    url="https://github.com/example/project/releases",
+                    encrypted_content="opaque",
+                )
+            ],
+        )
+
+        assert block.type == "web_search_tool_result"
+        assert block.tool_use_id == "srvtoolu_123"
+        assert block.content[0].type == "web_search_result"
+
+    def test_anthropic_message_accepts_claude_code_server_tool_history(self):
+        """
+        What it does: Verifies Claude Code can replay thinking, server_tool_use, and web_search results.
+        Purpose: Match the history shape that previously failed with messages.N.content string_type.
+        """
+        message = AnthropicMessage(
+            role="assistant",
+            content=[
+                {"type": "thinking", "thinking": "Need to search.", "signature": ""},
+                {
+                    "id": "srvtoolu_123",
+                    "type": "server_tool_use",
+                    "name": "web_search",
+                    "input": {"query": "CLI Proxy API releases"},
+                },
+                {
+                    "type": "web_search_tool_result",
+                    "tool_use_id": "srvtoolu_123",
+                    "content": [
+                        {
+                            "type": "web_search_result",
+                            "title": "Releases",
+                            "url": "https://github.com/router-for-me/CLIProxyAPI/releases",
+                            "encrypted_content": "opaque",
+                        }
+                    ],
+                },
+                {"type": "text", "text": "Search completed."},
+            ],
+        )
+
+        assert message.role == "assistant"
+        assert len(message.content) == 4
 
 
 # ==================================================================================================

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -527,6 +527,56 @@ class TestMessagesContentBlocks:
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
+    def test_accepts_claude_code_server_tool_history(self, test_client, valid_proxy_api_key):
+        """
+        What it does: Verifies Claude Code server-side tool history blocks are accepted.
+        Purpose: Ensure Anthropic request validation allows server_tool_use and web_search_tool_result blocks.
+        """
+        print("Action: POST /v1/messages with Claude Code server tool history...")
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-4-5",
+                "max_tokens": 1024,
+                "messages": [
+                    {"role": "user", "content": "Search the latest release notes."},
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "thinking",
+                                "thinking": "Need to search the web.",
+                                "signature": "",
+                            },
+                            {
+                                "type": "server_tool_use",
+                                "id": "srvtoolu_123",
+                                "name": "web_search",
+                                "input": {"query": "latest release notes"},
+                            },
+                            {
+                                "type": "web_search_tool_result",
+                                "tool_use_id": "srvtoolu_123",
+                                "content": [
+                                    {
+                                        "type": "web_search_result",
+                                        "title": "Release Notes",
+                                        "url": "https://example.com/releases",
+                                        "encrypted_content": "opaque",
+                                    }
+                                ],
+                            },
+                            {"type": "text", "text": "Search completed."},
+                        ],
+                    },
+                ],
+            },
+        )
+
+        print(f"Status: {response.status_code}")
+        assert response.status_code != 422
+
 
 # =============================================================================
 # Tests for /v1/messages tool use


### PR DESCRIPTION
## Summary
- Accept Claude Code server-side tool history blocks in Anthropic request models.
- Preserve `thinking`, `server_tool_use`, and `web_search_tool_result` blocks during `/v1/messages` validation.
- Add route-level coverage for the Anthropic ingress path.

## Why
Claude Code history can replay Anthropic-native server tool blocks that previously failed request validation with 422 errors.

## Validation
- `python -m pytest tests/unit/test_models_anthropic.py -v`
- `python -m pytest tests/unit/test_routes_anthropic.py -v`