### PR TITLE
feat(codex): Add /v1/responses API endpoint

### DIFF
--- a/kiro/__init__.py
+++ b/kiro/__init__.py
@@ -61,6 +61,7 @@ from kiro.config import (
 # Models
 from kiro.models_openai import (
     ChatCompletionRequest,
+    ResponsesRequest,
     ChatMessage,
     OpenAIModel,
     ModelList,
@@ -84,6 +85,10 @@ from kiro.streaming_openai import (
     stream_kiro_to_openai,
     collect_stream_response,
 )
+from kiro.streaming_responses import (
+    stream_kiro_to_responses,
+    collect_responses_response,
+)
 
 # Exceptions
 from kiro.exceptions import (
@@ -94,43 +99,46 @@ from kiro.exceptions import (
 __all__ = [
     # Version
     "__version__",
-    
+
     # Main classes
     "KiroAuthManager",
     "ModelInfoCache",
     "KiroHttpClient",
     "ModelResolver",
     "router",
-    
+
     # Configuration
     "PROXY_API_KEY",
     "REGION",
     "HIDDEN_MODELS",
     "APP_VERSION",
-    
+
     # Model resolution
     "normalize_model_name",
     "get_model_id_for_kiro",
-    
+
     # Models
     "ChatCompletionRequest",
+    "ResponsesRequest",
     "ChatMessage",
     "OpenAIModel",
     "ModelList",
-    
+
     # Converters
     "build_kiro_payload",
     "extract_text_content",
     "merge_adjacent_messages",
-    
+
     # Parsers
     "AwsEventStreamParser",
     "parse_bracket_tool_calls",
-    
+
     # Streaming
     "stream_kiro_to_openai",
     "collect_stream_response",
-    
+    "stream_kiro_to_responses",
+    "collect_responses_response",
+
     # Exceptions
     "validation_exception_handler",
     "sanitize_validation_errors",

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -1030,9 +1030,31 @@ def ensure_assistant_before_tool_results(messages: List[UnifiedMessage]) -> Tupl
             )
             
             if not has_preceding_assistant:
-                # We cannot create a valid synthetic assistant message because we don't know
-                # the original tool name and arguments. Kiro API validates tool names.
-                # Convert tool_results to text to preserve context for the model.
+                # Search backwards for a matching assistant with tool_calls
+                # This handles cases where user messages are interleaved between
+                # function_call and function_call_output (e.g., Codex Responses API)
+                tool_result_ids = {tr.get('tool_use_id') for tr in msg.tool_results}
+                matching_idx = None
+                for idx in range(len(result) - 1, -1, -1):
+                    candidate = result[idx]
+                    if candidate.role == "assistant" and candidate.tool_calls:
+                        candidate_ids = {tc.get('id') for tc in candidate.tool_calls}
+                        if tool_result_ids & candidate_ids:
+                            matching_idx = idx
+                            break
+                
+                if matching_idx is not None:
+                    # Found matching assistant further back - reorder by inserting
+                    # the tool_result message right after the matching assistant
+                    logger.debug(
+                        f"Reordering {len(msg.tool_results)} tool_results to follow "
+                        f"matching assistant at position {matching_idx}. "
+                        f"Tool IDs: {[tr.get('tool_use_id', 'unknown') for tr in msg.tool_results]}"
+                    )
+                    result.insert(matching_idx + 1, msg)
+                    continue
+                
+                # No matching assistant found anywhere - convert to text
                 logger.debug(
                     f"Converting {len(msg.tool_results)} orphaned tool_results to text "
                     f"(no preceding assistant message with tool_calls). "

--- a/kiro/converters_openai.py
+++ b/kiro/converters_openai.py
@@ -29,13 +29,14 @@ Contains functions for:
 - Building Kiro payload from OpenAI requests
 """
 
+import json
 from typing import Any, Dict, List, Optional, Tuple
 
 from loguru import logger
 
 from kiro.config import HIDDEN_MODELS
 from kiro.model_resolver import get_model_id_for_kiro
-from kiro.models_openai import ChatMessage, ChatCompletionRequest, Tool
+from kiro.models_openai import ChatMessage, ChatCompletionRequest, ResponsesRequest, Tool
 
 # Import from core - reuse shared logic
 from kiro.converters_core import (
@@ -384,6 +385,224 @@ def extract_thinking_config_from_openai(request: ChatCompletionRequest) -> Think
     )
     
     return ThinkingConfig(enabled=True, budget_tokens=budget)
+
+
+# ==================================================================================================
+# Responses API Processing
+# ==================================================================================================
+
+def _extract_responses_content_text(content: Any) -> str:
+    """
+    Extract text from Responses API content blocks.
+
+    Args:
+        content: A string, content block, or list of content blocks.
+
+    Returns:
+        Extracted text content.
+    """
+    if isinstance(content, str):
+        return content
+
+    if isinstance(content, dict):
+        block_type = content.get("type")
+        if block_type in {"input_text", "output_text", "text"}:
+            return str(content.get("text", ""))
+        if "content" in content:
+            return _extract_responses_content_text(content.get("content"))
+        return extract_text_content(content)
+
+    if isinstance(content, list):
+        parts = [_extract_responses_content_text(item) for item in content]
+        return "\n".join(part for part in parts if part)
+
+    return extract_text_content(content)
+
+
+def _responses_tool_call_to_chat(item: Dict[str, Any]) -> ChatMessage:
+    """
+    Convert a Responses API function_call item to an assistant chat message.
+
+    Args:
+        item: Responses API output item with type ``function_call``.
+
+    Returns:
+        ChatMessage with an OpenAI-compatible tool_calls entry.
+    """
+    call_id = item.get("call_id") or item.get("id") or ""
+    arguments = item.get("arguments", "{}")
+    if not isinstance(arguments, str):
+        arguments = json.dumps(arguments, ensure_ascii=False)
+
+    return ChatMessage(
+        role="assistant",
+        content=None,
+        tool_calls=[{
+            "id": call_id,
+            "type": "function",
+            "function": {
+                "name": item.get("name", ""),
+                "arguments": arguments,
+            },
+        }],
+    )
+
+
+def _responses_function_output_to_chat(item: Dict[str, Any]) -> ChatMessage:
+    """
+    Convert a Responses API function_call_output item to a tool chat message.
+
+    Args:
+        item: Responses API input item with type ``function_call_output``.
+
+    Returns:
+        ChatMessage with role ``tool``.
+    """
+    output = item.get("output", "")
+    if not isinstance(output, str):
+        output = json.dumps(output, ensure_ascii=False)
+
+    return ChatMessage(
+        role="tool",
+        content=output,
+        tool_call_id=item.get("call_id") or item.get("id") or "",
+    )
+
+
+def _responses_message_to_chat(item: Dict[str, Any]) -> Optional[ChatMessage]:
+    """
+    Convert a Responses API message item to a chat message.
+
+    Args:
+        item: Responses API message-like item.
+
+    Returns:
+        ChatMessage if the item carries a supported role, otherwise None.
+    """
+    role = item.get("role")
+    if role not in {"system", "developer", "user", "assistant", "tool"}:
+        return None
+
+    chat_role = "system" if role == "developer" else role
+    content = _extract_responses_content_text(item.get("content", ""))
+
+    return ChatMessage(
+        role=chat_role,
+        content=content,
+        tool_call_id=item.get("tool_call_id") or item.get("call_id"),
+    )
+
+
+def convert_responses_request_to_chat(request_data: ResponsesRequest) -> ChatCompletionRequest:
+    """
+    Convert an OpenAI Responses API request to Chat Completions format.
+
+    Args:
+        request_data: Responses API request.
+
+    Returns:
+        Equivalent ChatCompletionRequest for the existing OpenAI converter path.
+
+    Raises:
+        ValueError: If no usable input messages can be produced.
+    """
+    messages: List[ChatMessage] = []
+
+    if request_data.instructions:
+        messages.append(ChatMessage(
+            role="system",
+            content=_extract_responses_content_text(request_data.instructions),
+        ))
+
+    if isinstance(request_data.input, str):
+        messages.append(ChatMessage(role="user", content=request_data.input))
+    elif isinstance(request_data.input, list):
+        for item in request_data.input:
+            if isinstance(item, str):
+                messages.append(ChatMessage(role="user", content=item))
+                continue
+
+            if not isinstance(item, dict):
+                messages.append(ChatMessage(role="user", content=extract_text_content(item)))
+                continue
+
+            item_type = item.get("type")
+            if item_type == "function_call":
+                messages.append(_responses_tool_call_to_chat(item))
+            elif item_type == "function_call_output":
+                messages.append(_responses_function_output_to_chat(item))
+            elif item_type in {"message", "input_message", "output_message"} or "role" in item:
+                chat_message = _responses_message_to_chat(item)
+                if chat_message is not None:
+                    messages.append(chat_message)
+            elif item_type in {"input_text", "output_text", "text"}:
+                messages.append(ChatMessage(role="user", content=_extract_responses_content_text(item)))
+            elif item_type == "reasoning":
+                logger.debug("Skipping Responses reasoning item while converting request history")
+            else:
+                logger.debug(f"Skipping unsupported Responses input item type: {item_type}")
+
+    if not messages:
+        raise ValueError("Responses request must include input text or at least one message item")
+
+    tools = None
+    if request_data.tools:
+        tools = []
+        for tool in request_data.tools:
+            if tool.get("type") != "function":
+                logger.debug(f"Skipping unsupported Responses tool type: {tool.get('type')}")
+                continue
+            tools.append(Tool(
+                type="function",
+                name=tool.get("name"),
+                description=tool.get("description"),
+                input_schema=tool.get("parameters"),
+            ))
+
+    reasoning_effort = None
+    if request_data.reasoning:
+        effort = request_data.reasoning.get("effort")
+        if effort in {"none", "minimal", "low", "medium", "high", "xhigh"}:
+            reasoning_effort = effort
+
+    return ChatCompletionRequest(
+        model=request_data.model,
+        messages=messages,
+        stream=request_data.stream,
+        temperature=request_data.temperature,
+        top_p=request_data.top_p,
+        max_tokens=request_data.max_output_tokens,
+        stop=request_data.stop,
+        tools=tools,
+        tool_choice=request_data.tool_choice,
+        parallel_tool_calls=request_data.parallel_tool_calls,
+        stream_options=request_data.stream_options,
+        user=request_data.user,
+        reasoning_effort=reasoning_effort,
+    )
+
+
+def build_kiro_payload_from_responses(
+    request_data: ResponsesRequest,
+    conversation_id: str,
+    profile_arn: str
+) -> dict:
+    """
+    Build a Kiro API payload from an OpenAI Responses API request.
+
+    Args:
+        request_data: Request in Responses API format.
+        conversation_id: Unique conversation ID.
+        profile_arn: AWS CodeWhisperer profile ARN.
+
+    Returns:
+        Payload dictionary for POST request to Kiro API.
+
+    Raises:
+        ValueError: If no usable input messages can be produced.
+    """
+    chat_request = convert_responses_request_to_chat(request_data)
+    return build_kiro_payload(chat_request, conversation_id, profile_arn)
 
 
 # ==================================================================================================

--- a/kiro/debug_middleware.py
+++ b/kiro/debug_middleware.py
@@ -46,6 +46,7 @@ from kiro.config import DEBUG_MODE
 # These are the main API endpoints that process user requests
 LOGGED_ENDPOINTS = frozenset({
     "/v1/chat/completions",  # OpenAI-compatible endpoint
+    "/v1/responses",         # OpenAI Responses-compatible endpoint
     "/v1/messages",          # Anthropic-compatible endpoint
 })
 
@@ -53,50 +54,50 @@ LOGGED_ENDPOINTS = frozenset({
 class DebugLoggerMiddleware(BaseHTTPMiddleware):
     """
     Middleware for initializing debug logging on API requests.
-    
+
     This middleware runs BEFORE Pydantic validation, which means it can
     capture the raw request body even for requests that fail validation.
-    
+
     The middleware only activates for API endpoints defined in LOGGED_ENDPOINTS.
     Health checks, documentation, and other endpoints are not logged.
-    
+
     Lifecycle:
     - prepare_new_request(): Called here (before validation)
     - log_request_body(): Called here (raw body from client)
     - log_kiro_request_body(): Called in route handlers (transformed payload)
     - flush_on_error() / discard_buffers(): Called in routes or exception handlers
     """
-    
+
     async def dispatch(self, request: Request, call_next) -> Response:
         """
         Process the request and initialize debug logging if needed.
-        
+
         Args:
             request: The incoming HTTP request
             call_next: The next middleware or route handler
-            
+
         Returns:
             The response from the next handler
         """
         # Skip logging for non-API endpoints (health, docs, etc.)
         if request.url.path not in LOGGED_ENDPOINTS:
             return await call_next(request)
-        
+
         # Skip if debug mode is disabled
         if DEBUG_MODE == "off":
             return await call_next(request)
-        
+
         # Import here to avoid circular imports and allow graceful degradation
         try:
             from kiro.debug_logger import debug_logger
         except ImportError:
             logger.warning("debug_logger not available, skipping debug logging")
             return await call_next(request)
-        
+
         # Initialize debug logging for this request
         # This sets up buffers and creates a loguru sink to capture app logs
         debug_logger.prepare_new_request()
-        
+
         # Read and log the raw request body
         # FastAPI caches the body after first read, so this is safe
         try:
@@ -105,12 +106,12 @@ class DebugLoggerMiddleware(BaseHTTPMiddleware):
                 debug_logger.log_request_body(body)
         except Exception as e:
             logger.warning(f"Failed to read request body for debug logging: {e}")
-        
+
         # Continue to validation and route handler
         # flush_on_error() or discard_buffers() will be called by:
         # - Route handlers (for successful requests and Kiro API errors)
         # - validation_exception_handler (for 422 validation errors)
         # - Generic exception handlers (for other errors)
         response = await call_next(request)
-        
+
         return response

--- a/kiro/models_openai.py
+++ b/kiro/models_openai.py
@@ -180,7 +180,67 @@ class ChatCompletionRequest(BaseModel):
     user: Optional[str] = None
     seed: Optional[int] = None
     parallel_tool_calls: Optional[bool] = None
-    
+
+    model_config = {"extra": "allow"}
+
+
+# ==================================================================================================
+# Models for /v1/responses endpoint
+# ==================================================================================================
+
+class ResponsesRequest(BaseModel):
+    """
+    Request for response generation in OpenAI Responses API format.
+
+    The Responses API accepts text or typed input items instead of the
+    Chat Completions ``messages`` array. This model intentionally keeps the
+    item schemas permissive so newer OpenAI clients can pass fields through
+    without failing validation at the gateway layer.
+
+    Attributes:
+        model: Model ID for generation.
+        input: Text, messages, function call outputs, or other response items.
+        instructions: Optional system/developer guidance.
+        stream: Use semantic Responses API streaming events.
+        tools: List of available tools in Responses API flat format.
+        tool_choice: Tool selection strategy.
+    """
+    model: str
+    input: Optional[Union[str, List[Any]]] = None
+    instructions: Optional[Union[str, List[Any]]] = None
+    stream: bool = False
+
+    # Generation parameters
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    max_output_tokens: Optional[int] = None
+    stop: Optional[Union[str, List[str]]] = None
+
+    # Tools (Responses API uses flat function tool definitions)
+    tools: Optional[List[Dict[str, Any]]] = None
+    tool_choice: Optional[Union[str, Dict[str, Any]]] = None
+    parallel_tool_calls: Optional[bool] = None
+
+    # Compatibility fields accepted by OpenAI Responses API.
+    background: Optional[bool] = None
+    conversation: Optional[Union[str, Dict[str, Any]]] = None
+    include: Optional[List[str]] = None
+    max_tool_calls: Optional[int] = None
+    metadata: Optional[Dict[str, Any]] = None
+    previous_response_id: Optional[str] = None
+    prompt: Optional[Dict[str, Any]] = None
+    prompt_cache_key: Optional[str] = None
+    prompt_cache_retention: Optional[str] = None
+    reasoning: Optional[Dict[str, Any]] = None
+    safety_identifier: Optional[str] = None
+    service_tier: Optional[str] = None
+    store: Optional[bool] = True
+    stream_options: Optional[Dict[str, Any]] = None
+    text: Optional[Dict[str, Any]] = None
+    top_logprobs: Optional[int] = None
+    truncation: Optional[str] = "disabled"
+    user: Optional[str] = None
+
     model_config = {"extra": "allow"}
 
 

--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -43,12 +43,14 @@ from kiro.models_openai import (
     OpenAIModel,
     ModelList,
     ChatCompletionRequest,
+    ResponsesRequest,
 )
 from kiro.auth import KiroAuthManager, AuthType
 from kiro.cache import ModelInfoCache
 from kiro.model_resolver import ModelResolver
-from kiro.converters_openai import build_kiro_payload
+from kiro.converters_openai import build_kiro_payload, convert_responses_request_to_chat
 from kiro.streaming_openai import stream_kiro_to_openai, collect_stream_response, stream_with_first_token_retry
+from kiro.streaming_responses import collect_responses_response, stream_kiro_to_responses
 from kiro.http_client import KiroHttpClient
 from kiro.utils import generate_conversation_id
 from kiro.config import WEB_SEARCH_ENABLED
@@ -609,12 +611,19 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
         # Make request to Kiro API (for both streaming and non-streaming modes)
         # Important: we wait for Kiro response BEFORE returning StreamingResponse,
         # so that 200 OK means Kiro accepted the request and started responding
-        response = await http_client.request_with_retry(
-            "POST",
-            url,
-            kiro_payload,
-            stream=True
-        )
+        try:
+            response = await http_client.request_with_retry(
+                "POST",
+                url,
+                kiro_payload,
+                stream=True
+            )
+        except HTTPException:
+            await http_client.close()
+            raise
+        except Exception:
+            await http_client.close()
+            raise
         
         if response.status_code != 200:
             try:
@@ -765,6 +774,312 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
         # Log access log for internal error
         logger.error(f"HTTP 500 - POST /v1/chat/completions - {str(e)[:100]}")
         # Flush debug logs on internal error ("errors" mode)
+        if debug_logger:
+            debug_logger.flush_on_error(500, str(e))
+        raise HTTPException(status_code=500, detail=f"Internal Server Error: {str(e)}")
+
+
+@router.post("/v1/responses", dependencies=[Depends(verify_api_key)])
+async def responses(request: Request, request_data: ResponsesRequest):
+    """
+    Responses endpoint - compatible with OpenAI Responses API.
+
+    Accepts Responses API input items and translates them to Kiro API through
+    the existing Chat Completions conversion path. Supports streaming semantic
+    Responses API SSE events and non-streaming response objects.
+
+    Args:
+        request: FastAPI Request for accessing app.state.
+        request_data: Request in OpenAI Responses API format.
+
+    Returns:
+        StreamingResponse for streaming mode.
+        JSONResponse for non-streaming mode.
+
+    Raises:
+        HTTPException: On validation or API errors.
+    """
+    logger.info(f"Request to /v1/responses (model={request_data.model}, stream={request_data.stream})")
+
+    try:
+        chat_request = convert_responses_request_to_chat(request_data)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    async def send_with_account(auth_manager, model_cache, account_id=None):
+        """Send a Responses request through a selected account."""
+        conversation_id = generate_conversation_id()
+        profile_arn_for_payload = auth_manager.profile_arn or PROFILE_ARN or ""
+
+        try:
+            kiro_payload = build_kiro_payload(
+                chat_request,
+                conversation_id,
+                profile_arn_for_payload
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+        try:
+            kiro_request_body = json.dumps(kiro_payload, ensure_ascii=False, indent=2).encode('utf-8')
+            if debug_logger:
+                debug_logger.log_kiro_request_body(kiro_request_body)
+        except Exception as e:
+            logger.warning(f"Failed to log Kiro request: {e}")
+
+        url = f"{auth_manager.api_host}/generateAssistantResponse"
+        if account_id:
+            logger.debug(f"Kiro API URL: {url} (account: {account_id})")
+        else:
+            logger.debug(f"Kiro API URL: {url}")
+
+        if request_data.stream:
+            http_client = KiroHttpClient(auth_manager, shared_client=None)
+        else:
+            shared_client = request.app.state.http_client
+            http_client = KiroHttpClient(auth_manager, shared_client=shared_client)
+
+        try:
+            response = await http_client.request_with_retry(
+                "POST",
+                url,
+                kiro_payload,
+                stream=True
+            )
+        except HTTPException:
+            await http_client.close()
+            raise
+        except Exception:
+            await http_client.close()
+            raise
+
+        messages_for_tokenizer = [msg.model_dump() for msg in chat_request.messages]
+        tools_for_tokenizer = [tool.model_dump() for tool in chat_request.tools] if chat_request.tools else None
+
+        if response.status_code == 200:
+            if request_data.stream:
+                async def stream_wrapper():
+                    streaming_error = None
+                    client_disconnected = False
+                    try:
+                        async for chunk in stream_kiro_to_responses(
+                            http_client.client,
+                            response,
+                            request_data.model,
+                            model_cache,
+                            auth_manager,
+                            request_messages=messages_for_tokenizer,
+                            request_tools=tools_for_tokenizer
+                        ):
+                            yield chunk
+                    except GeneratorExit:
+                        client_disconnected = True
+                        logger.debug("Client disconnected during Responses streaming")
+                    except Exception as e:
+                        streaming_error = e
+                        try:
+                            yield "data: [DONE]\n\n"
+                        except Exception:
+                            pass
+                        raise
+                    finally:
+                        await http_client.close()
+                        if streaming_error:
+                            error_type = type(streaming_error).__name__
+                            error_msg = str(streaming_error) if str(streaming_error) else "(empty message)"
+                            logger.error(f"HTTP 500 - POST /v1/responses (streaming) - [{error_type}] {error_msg[:100]}")
+                        elif client_disconnected:
+                            logger.info("HTTP 200 - POST /v1/responses (streaming) - client disconnected")
+                        else:
+                            logger.info("HTTP 200 - POST /v1/responses (streaming) - completed")
+                        if debug_logger:
+                            if streaming_error:
+                                debug_logger.flush_on_error(500, str(streaming_error))
+                            else:
+                                debug_logger.discard_buffers()
+
+                return StreamingResponse(stream_wrapper(), media_type="text/event-stream")
+
+            responses_response = await collect_responses_response(
+                http_client.client,
+                response,
+                request_data.model,
+                model_cache,
+                auth_manager,
+                request_messages=messages_for_tokenizer,
+                request_tools=tools_for_tokenizer
+            )
+
+            await http_client.close()
+            logger.info("HTTP 200 - POST /v1/responses (non-streaming) - completed")
+
+            if debug_logger:
+                debug_logger.discard_buffers()
+
+            return JSONResponse(content=responses_response)
+
+        try:
+            error_content = await response.aread()
+        except Exception:
+            error_content = b"Unknown error"
+
+        await http_client.close()
+        error_text = error_content.decode('utf-8', errors='replace')
+        error_reason = None
+        error_message = error_text
+
+        try:
+            error_json = json.loads(error_text)
+            from kiro.kiro_errors import enhance_kiro_error
+            error_info = enhance_kiro_error(error_json)
+            error_reason = error_info.reason
+            error_message = error_info.user_message
+            logger.debug(f"Original Kiro error: {error_info.original_message} (reason: {error_info.reason})")
+        except (json.JSONDecodeError, KeyError):
+            pass
+
+        return {
+            "status_code": response.status_code,
+            "message": error_message,
+            "reason": error_reason,
+        }
+
+    if request.app.state.account_system:
+        from kiro.account_errors import classify_error, ErrorType
+
+        account_manager = request.app.state.account_manager
+        all_accounts = list(account_manager._accounts.keys())
+        max_attempts = len(all_accounts) * 2
+        tried_accounts = set()
+        last_error_message = None
+        last_error_status = None
+
+        for _ in range(max_attempts):
+            account = await account_manager.get_next_account(
+                request_data.model,
+                exclude_accounts=tried_accounts
+            )
+
+            if account is None:
+                if len(all_accounts) == 1:
+                    raise HTTPException(
+                        status_code=last_error_status or 503,
+                        detail=last_error_message or "Account unavailable"
+                    )
+
+                detail = "No available accounts for this model."
+                if last_error_message:
+                    detail += f" Error from last account: {last_error_message}"
+                raise HTTPException(status_code=503, detail=detail)
+
+            tried_accounts.add(account.id)
+
+            try:
+                result = await send_with_account(account.auth_manager, account.model_cache, account.id)
+
+                if isinstance(result, (JSONResponse, StreamingResponse)):
+                    await account_manager.report_success(account.id, request_data.model)
+                    return result
+
+                last_error_status = result["status_code"]
+                last_error_message = result["message"]
+                error_type = classify_error(last_error_status, result["reason"])
+
+                await account_manager.report_failure(
+                    account.id,
+                    request_data.model,
+                    error_type,
+                    last_error_status,
+                    result["reason"]
+                )
+
+                if error_type == ErrorType.FATAL:
+                    logger.warning(f"HTTP {last_error_status} - POST /v1/responses - {last_error_message[:100]}")
+                    if debug_logger:
+                        debug_logger.flush_on_error(last_error_status, last_error_message)
+                    return JSONResponse(
+                        status_code=last_error_status,
+                        content={
+                            "error": {
+                                "message": last_error_message,
+                                "type": "kiro_api_error",
+                                "code": last_error_status,
+                            }
+                        }
+                    )
+
+                if len(all_accounts) == 1:
+                    break
+
+            except HTTPException as e:
+                if e.status_code in (502, 504):
+                    await account_manager.report_failure(
+                        account.id,
+                        request_data.model,
+                        ErrorType.RECOVERABLE,
+                        e.status_code,
+                        None
+                    )
+
+                    last_error_message = str(e.detail)
+                    last_error_status = e.status_code
+
+                    if len(all_accounts) == 1:
+                        break
+
+                    logger.warning(f"Network error on account {account.id}, trying next account")
+                    continue
+
+                logger.error(f"HTTP {e.status_code} - POST /v1/responses - {e.detail}")
+                if debug_logger:
+                    debug_logger.flush_on_error(e.status_code, str(e.detail))
+                raise
+
+        if len(all_accounts) == 1:
+            raise HTTPException(
+                status_code=last_error_status,
+                detail=last_error_message
+            )
+
+        detail = "All accounts failed after full circle."
+        if last_error_message:
+            detail += f" Error from last account: {last_error_message}"
+        raise HTTPException(status_code=503, detail=detail)
+
+    account = request.app.state.account_manager.get_first_account()
+    if not account.auth_manager:
+        logger.error("No initialized accounts available (legacy mode)")
+        raise HTTPException(503, "No initialized accounts available")
+
+    try:
+        result = await send_with_account(account.auth_manager, account.model_cache)
+        if isinstance(result, (JSONResponse, StreamingResponse)):
+            return result
+
+        logger.warning(f"HTTP {result['status_code']} - POST /v1/responses - {result['message'][:100]}")
+        if debug_logger:
+            debug_logger.flush_on_error(result["status_code"], result["message"])
+        return JSONResponse(
+            status_code=result["status_code"],
+            content={
+                "error": {
+                    "message": result["message"],
+                    "type": "kiro_api_error",
+                    "code": result["status_code"],
+                }
+            }
+        )
+
+    except HTTPException as e:
+        if e.status_code in (502, 504):
+            logger.warning("Network error (legacy mode, no failover available)")
+        logger.error(f"HTTP {e.status_code} - POST /v1/responses - {e.detail}")
+        if debug_logger:
+            debug_logger.flush_on_error(e.status_code, str(e.detail))
+        raise
+    except Exception as e:
+        logger.error(f"Internal error: {e}", exc_info=True)
+        logger.error(f"HTTP 500 - POST /v1/responses - {str(e)[:100]}")
         if debug_logger:
             debug_logger.flush_on_error(500, str(e))
         raise HTTPException(status_code=500, detail=f"Internal Server Error: {str(e)}")

--- a/kiro/streaming_responses.py
+++ b/kiro/streaming_responses.py
@@ -1,0 +1,401 @@
+# -*- coding: utf-8 -*-
+
+# Kiro Gateway
+# https://github.com/jwadow/kiro-gateway
+# Copyright (C) 2025 Jwadow
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Responses API formatting for Kiro streams.
+
+This module adapts the existing OpenAI chat-completion stream into the
+OpenAI Responses API object and semantic SSE event shape.
+"""
+
+import json
+import time
+import uuid
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional
+
+import httpx
+
+from kiro.streaming_openai import collect_stream_response, stream_kiro_to_openai
+
+if TYPE_CHECKING:
+    from kiro.auth import KiroAuthManager
+    from kiro.cache import ModelInfoCache
+
+
+def generate_response_id() -> str:
+    """
+    Generate an OpenAI Responses API-compatible response ID.
+
+    Returns:
+        ID in format ``resp_<uuid_hex>``.
+    """
+    return f"resp_{uuid.uuid4().hex}"
+
+
+def _usage_to_responses_usage(usage: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """
+    Convert Chat Completions usage fields to Responses API usage fields.
+
+    Args:
+        usage: OpenAI chat-completion usage dictionary.
+
+    Returns:
+        Responses API usage dictionary, or None if usage is absent.
+    """
+    if usage is None:
+        return None
+
+    input_tokens = int(usage.get("prompt_tokens", 0) or 0)
+    output_tokens = int(usage.get("completion_tokens", 0) or 0)
+    total_tokens = int(usage.get("total_tokens", input_tokens + output_tokens) or 0)
+
+    result = {
+        "input_tokens": input_tokens,
+        "input_tokens_details": {"cached_tokens": 0},
+        "output_tokens": output_tokens,
+        "output_tokens_details": {"reasoning_tokens": 0},
+        "total_tokens": total_tokens,
+    }
+
+    if "credits_used" in usage:
+        result["credits_used"] = usage["credits_used"]
+
+    return result
+
+
+def _message_output_item(text: str, item_id: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Build a Responses API message output item.
+
+    Args:
+        text: Assistant text content.
+        item_id: Optional stable item ID.
+
+    Returns:
+        Responses API output item.
+    """
+    return {
+        "id": item_id or f"msg_{uuid.uuid4().hex}",
+        "type": "message",
+        "status": "completed",
+        "role": "assistant",
+        "content": [{
+            "type": "output_text",
+            "text": text,
+            "annotations": [],
+        }],
+    }
+
+
+def _function_call_output_item(tool_call: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Build a Responses API function_call output item from a chat tool call.
+
+    Args:
+        tool_call: OpenAI chat-completion tool call.
+
+    Returns:
+        Responses API function_call item.
+    """
+    function = tool_call.get("function") or {}
+    arguments = function.get("arguments", "{}")
+    if not isinstance(arguments, str):
+        arguments = json.dumps(arguments, ensure_ascii=False)
+
+    call_id = tool_call.get("id") or f"call_{uuid.uuid4().hex}"
+
+    return {
+        "id": f"fc_{uuid.uuid4().hex}",
+        "type": "function_call",
+        "status": "completed",
+        "call_id": call_id,
+        "name": function.get("name", ""),
+        "arguments": arguments,
+    }
+
+
+def chat_completion_to_response(
+    chat_response: Dict[str, Any],
+    response_id: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    Convert a non-streaming Chat Completions response to Responses API format.
+
+    Args:
+        chat_response: OpenAI chat-completion response.
+        response_id: Optional response ID to use.
+
+    Returns:
+        Responses API response object.
+    """
+    output: List[Dict[str, Any]] = []
+    message = chat_response.get("choices", [{}])[0].get("message", {})
+    text = message.get("content") or ""
+
+    if text:
+        output.append(_message_output_item(text))
+
+    for tool_call in message.get("tool_calls") or []:
+        output.append(_function_call_output_item(tool_call))
+
+    usage = _usage_to_responses_usage(chat_response.get("usage"))
+
+    return {
+        "id": response_id or generate_response_id(),
+        "object": "response",
+        "created_at": chat_response.get("created", int(time.time())),
+        "status": "completed",
+        "background": False,
+        "error": None,
+        "incomplete_details": None,
+        "instructions": None,
+        "max_output_tokens": None,
+        "model": chat_response.get("model"),
+        "output": output,
+        "output_text": text,
+        "parallel_tool_calls": True,
+        "previous_response_id": None,
+        "reasoning": {"effort": None, "summary": None},
+        "store": True,
+        "temperature": None,
+        "text": {"format": {"type": "text"}},
+        "tool_choice": "auto",
+        "tools": [],
+        "top_p": None,
+        "truncation": "disabled",
+        "usage": usage,
+        "user": None,
+        "metadata": {},
+    }
+
+
+def _sse_event(event_name: str, data: Dict[str, Any]) -> str:
+    """
+    Format a Responses API streaming server-sent event.
+
+    Args:
+        event_name: Responses API event name.
+        data: JSON-serializable event payload.
+
+    Returns:
+        SSE text chunk.
+    """
+    return f"event: {event_name}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
+
+
+async def stream_kiro_to_responses(
+    client: httpx.AsyncClient,
+    response: httpx.Response,
+    model: str,
+    model_cache: "ModelInfoCache",
+    auth_manager: "KiroAuthManager",
+    request_messages: Optional[list] = None,
+    request_tools: Optional[list] = None
+) -> AsyncGenerator[str, None]:
+    """
+    Convert a Kiro stream to OpenAI Responses API streaming events.
+
+    Args:
+        client: HTTP client.
+        response: HTTP response with data stream.
+        model: Model name to include in response.
+        model_cache: Model cache for token limits.
+        auth_manager: Authentication manager.
+        request_messages: Original request messages for token fallback.
+        request_tools: Original request tools for token fallback.
+
+    Yields:
+        SSE strings with Responses API event names.
+    """
+    response_id = generate_response_id()
+    created_at = int(time.time())
+    base_response = {
+        "id": response_id,
+        "object": "response",
+        "created_at": created_at,
+        "status": "in_progress",
+        "model": model,
+        "output": [],
+        "output_text": "",
+        "usage": None,
+    }
+
+    yield _sse_event("response.created", {
+        "type": "response.created",
+        "response": base_response,
+    })
+
+    message_item_id = f"msg_{uuid.uuid4().hex}"
+    content_started = False
+    full_text = ""
+    final_usage = None
+    tool_calls: List[Dict[str, Any]] = []
+
+    async for chunk_str in stream_kiro_to_openai(
+        client,
+        response,
+        model,
+        model_cache,
+        auth_manager,
+        request_messages=request_messages,
+        request_tools=request_tools,
+    ):
+        if not chunk_str.startswith("data:"):
+            continue
+
+        data_str = chunk_str[len("data:"):].strip()
+        if not data_str or data_str == "[DONE]":
+            continue
+
+        chunk_data = json.loads(data_str)
+        delta = chunk_data.get("choices", [{}])[0].get("delta", {})
+
+        if "content" in delta and delta["content"]:
+            if not content_started:
+                message_item = _message_output_item("", message_item_id)
+                yield _sse_event("response.output_item.added", {
+                    "type": "response.output_item.added",
+                    "output_index": 0,
+                    "item": message_item,
+                })
+                yield _sse_event("response.content_part.added", {
+                    "type": "response.content_part.added",
+                    "item_id": message_item_id,
+                    "output_index": 0,
+                    "content_index": 0,
+                    "part": {"type": "output_text", "text": "", "annotations": []},
+                })
+                content_started = True
+
+            full_text += delta["content"]
+            yield _sse_event("response.output_text.delta", {
+                "type": "response.output_text.delta",
+                "item_id": message_item_id,
+                "output_index": 0,
+                "content_index": 0,
+                "delta": delta["content"],
+            })
+
+        if "tool_calls" in delta:
+            tool_calls.extend(delta["tool_calls"])
+
+        if "usage" in chunk_data:
+            final_usage = chunk_data["usage"]
+
+    output: List[Dict[str, Any]] = []
+    if content_started:
+        message_item = _message_output_item(full_text, message_item_id)
+        output.append(message_item)
+        yield _sse_event("response.output_text.done", {
+            "type": "response.output_text.done",
+            "item_id": message_item_id,
+            "output_index": 0,
+            "content_index": 0,
+            "text": full_text,
+        })
+        yield _sse_event("response.content_part.done", {
+            "type": "response.content_part.done",
+            "item_id": message_item_id,
+            "output_index": 0,
+            "content_index": 0,
+            "part": message_item["content"][0],
+        })
+        yield _sse_event("response.output_item.done", {
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item": message_item,
+        })
+
+    for tool_call in tool_calls:
+        item = _function_call_output_item(tool_call)
+        arguments = item.get("arguments", "")
+        added_item = {**item, "arguments": ""}
+        output.append(item)
+        yield _sse_event("response.output_item.added", {
+            "type": "response.output_item.added",
+            "output_index": len(output) - 1,
+            "item": added_item,
+        })
+        if arguments:
+            yield _sse_event("response.function_call_arguments.delta", {
+                "type": "response.function_call_arguments.delta",
+                "item_id": item["id"],
+                "output_index": len(output) - 1,
+                "delta": arguments,
+            })
+        yield _sse_event("response.function_call_arguments.done", {
+            "type": "response.function_call_arguments.done",
+            "item_id": item["id"],
+            "output_index": len(output) - 1,
+            "arguments": arguments,
+        })
+        yield _sse_event("response.output_item.done", {
+            "type": "response.output_item.done",
+            "output_index": len(output) - 1,
+            "item": item,
+        })
+
+    completed_response = {
+        **base_response,
+        "status": "completed",
+        "output": output,
+        "output_text": full_text,
+        "usage": _usage_to_responses_usage(final_usage),
+    }
+    yield _sse_event("response.completed", {
+        "type": "response.completed",
+        "response": completed_response,
+    })
+    yield "data: [DONE]\n\n"
+
+
+async def collect_responses_response(
+    client: httpx.AsyncClient,
+    response: httpx.Response,
+    model: str,
+    model_cache: "ModelInfoCache",
+    auth_manager: "KiroAuthManager",
+    request_messages: Optional[list] = None,
+    request_tools: Optional[list] = None
+) -> Dict[str, Any]:
+    """
+    Collect a Kiro stream into a non-streaming Responses API object.
+
+    Args:
+        client: HTTP client.
+        response: HTTP response with data stream.
+        model: Model name.
+        model_cache: Model cache for token limits.
+        auth_manager: Authentication manager.
+        request_messages: Original request messages for token fallback.
+        request_tools: Original request tools for token fallback.
+
+    Returns:
+        Responses API response object.
+    """
+    chat_response = await collect_stream_response(
+        client,
+        response,
+        model,
+        model_cache,
+        auth_manager,
+        request_messages=request_messages,
+        request_tools=request_tools,
+    )
+    return chat_completion_to_response(chat_response)

--- a/tests/unit/test_converters_openai.py
+++ b/tests/unit/test_converters_openai.py
@@ -14,18 +14,153 @@ from unittest.mock import patch
 
 from kiro.converters_openai import (
     build_kiro_payload,
+    convert_responses_request_to_chat,
     convert_openai_messages_to_unified,
     convert_openai_tools_to_unified,
     _extract_images_from_tool_message,
     reasoning_effort_to_budget,
     extract_thinking_config_from_openai,
 )
-from kiro.models_openai import ChatMessage, ChatCompletionRequest, Tool, ToolFunction
+from kiro.models_openai import ChatMessage, ChatCompletionRequest, ResponsesRequest, Tool, ToolFunction
 
 
 # ==================================================================================================
 # Tests for convert_openai_messages_to_unified
 # ==================================================================================================
+
+class TestConvertResponsesRequestToChat:
+    """Tests for converting OpenAI Responses API requests to chat format."""
+
+    def test_converts_string_input_and_instructions(self):
+        """
+        What it does: Converts top-level instructions plus string input.
+        Purpose: Ensure simple Codex Desktop Responses requests reach Kiro as chat messages.
+        """
+        print("Setup: Responses request with instructions and string input...")
+        request = ResponsesRequest(
+            model="claude-sonnet-4-5",
+            instructions="You are a coding assistant.",
+            input="Inspect the repo.",
+        )
+
+        print("Action: Converting to chat request...")
+        chat_request = convert_responses_request_to_chat(request)
+
+        assert chat_request.messages[0].role == "system"
+        assert chat_request.messages[0].content == "You are a coding assistant."
+        assert chat_request.messages[1].role == "user"
+        assert chat_request.messages[1].content == "Inspect the repo."
+
+    def test_converts_response_message_content_blocks(self):
+        """
+        What it does: Converts Responses message content blocks.
+        Purpose: Preserve text from typed input_text blocks.
+        """
+        print("Setup: Responses request with typed message content...")
+        request = ResponsesRequest(
+            model="claude-sonnet-4-5",
+            input=[{
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Hello from blocks"}],
+            }],
+        )
+
+        print("Action: Converting to chat request...")
+        chat_request = convert_responses_request_to_chat(request)
+
+        assert len(chat_request.messages) == 1
+        assert chat_request.messages[0].role == "user"
+        assert chat_request.messages[0].content == "Hello from blocks"
+
+    def test_converts_function_call_and_output_items(self):
+        """
+        What it does: Converts function_call and function_call_output items.
+        Purpose: Ensure Responses tool history maps onto chat tool calls/results.
+        """
+        print("Setup: Responses request with tool history...")
+        request = ResponsesRequest(
+            model="claude-sonnet-4-5",
+            input=[
+                {
+                    "type": "function_call",
+                    "call_id": "call_123",
+                    "name": "read_file",
+                    "arguments": {"path": "README.md"},
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_123",
+                    "output": "file contents",
+                },
+            ],
+        )
+
+        print("Action: Converting to chat request...")
+        chat_request = convert_responses_request_to_chat(request)
+
+        assistant_message = chat_request.messages[0]
+        tool_message = chat_request.messages[1]
+        assert assistant_message.role == "assistant"
+        assert assistant_message.tool_calls[0]["id"] == "call_123"
+        assert assistant_message.tool_calls[0]["function"]["name"] == "read_file"
+        assert '"path": "README.md"' in assistant_message.tool_calls[0]["function"]["arguments"]
+        assert tool_message.role == "tool"
+        assert tool_message.tool_call_id == "call_123"
+        assert tool_message.content == "file contents"
+
+    def test_converts_flat_responses_tools(self):
+        """
+        What it does: Converts Responses API flat function tool definitions.
+        Purpose: Ensure Codex-style tools are available to Kiro.
+        """
+        print("Setup: Responses request with flat tools...")
+        request = ResponsesRequest(
+            model="claude-sonnet-4-5",
+            input="Use a tool.",
+            tools=[{
+                "type": "function",
+                "name": "shell",
+                "description": "Run a command",
+                "parameters": {"type": "object", "properties": {"cmd": {"type": "string"}}},
+            }],
+        )
+
+        print("Action: Converting to chat request...")
+        chat_request = convert_responses_request_to_chat(request)
+
+        assert len(chat_request.tools) == 1
+        assert chat_request.tools[0].name == "shell"
+        assert chat_request.tools[0].input_schema["properties"]["cmd"]["type"] == "string"
+
+    def test_converts_responses_reasoning_effort(self):
+        """
+        What it does: Converts Responses reasoning.effort to chat reasoning_effort.
+        Purpose: Preserve upstream reasoning controls for Responses clients.
+        """
+        print("Setup: Responses request with reasoning effort...")
+        request = ResponsesRequest(
+            model="claude-sonnet-4-5",
+            input="Think briefly.",
+            reasoning={"effort": "low"},
+        )
+
+        print("Action: Converting to chat request...")
+        chat_request = convert_responses_request_to_chat(request)
+
+        assert chat_request.reasoning_effort == "low"
+
+    def test_rejects_empty_responses_input(self):
+        """
+        What it does: Rejects a Responses request without usable input.
+        Purpose: Prevent sending an empty message list to Kiro.
+        """
+        print("Setup: Empty Responses request...")
+        request = ResponsesRequest(model="claude-sonnet-4-5")
+
+        print("Action: Converting to chat request...")
+        with pytest.raises(ValueError, match="must include input"):
+            convert_responses_request_to_chat(request)
 
 class TestConvertOpenAIMessagesToUnified:
     """Tests for convert_openai_messages_to_unified function."""

--- a/tests/unit/test_routes_openai.py
+++ b/tests/unit/test_routes_openai.py
@@ -424,6 +424,123 @@ class TestChatCompletionsAuthentication:
         assert response.status_code == 401
 
 
+class TestResponsesAuthentication:
+    """Tests for authentication on /v1/responses endpoint."""
+
+    def test_responses_requires_authentication(self, test_client):
+        """
+        What it does: Verifies Responses endpoint requires authentication.
+        Purpose: Ensure protected endpoint is secured.
+        """
+        print("Action: POST /v1/responses without auth...")
+        response = test_client.post(
+            "/v1/responses",
+            json={
+                "model": "claude-sonnet-4-5",
+                "input": "Hello",
+            }
+        )
+
+        print(f"Status: {response.status_code}")
+        assert response.status_code == 401
+
+    def test_responses_rejects_invalid_key(self, test_client, invalid_proxy_api_key):
+        """
+        What it does: Verifies Responses endpoint rejects invalid API key.
+        Purpose: Ensure authentication is enforced.
+        """
+        print("Action: POST /v1/responses with invalid key...")
+        response = test_client.post(
+            "/v1/responses",
+            headers={"Authorization": f"Bearer {invalid_proxy_api_key}"},
+            json={
+                "model": "claude-sonnet-4-5",
+                "input": "Hello",
+            }
+        )
+
+        print(f"Status: {response.status_code}")
+        assert response.status_code == 401
+
+
+class TestResponsesValidation:
+    """Tests for request validation on /v1/responses endpoint."""
+
+    def test_validates_missing_model(self, test_client, valid_proxy_api_key):
+        """
+        What it does: Verifies missing model field is rejected.
+        Purpose: Ensure model is required.
+        """
+        print("Action: POST /v1/responses without model...")
+        response = test_client.post(
+            "/v1/responses",
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
+            json={"input": "Hello"}
+        )
+
+        print(f"Status: {response.status_code}")
+        assert response.status_code == 422
+
+    def test_rejects_empty_input_with_actionable_400(self, test_client, valid_proxy_api_key):
+        """
+        What it does: Verifies empty Responses input returns a gateway validation error.
+        Purpose: Avoid forwarding empty requests to Kiro.
+        """
+        print("Action: POST /v1/responses without input...")
+        response = test_client.post(
+            "/v1/responses",
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
+            json={"model": "claude-sonnet-4-5"}
+        )
+
+        print(f"Status: {response.status_code}, Body: {response.json()}")
+        assert response.status_code == 400
+        assert "must include input" in response.json()["detail"]
+
+    def test_accepts_valid_string_input_format(self, test_client, valid_proxy_api_key):
+        """
+        What it does: Verifies valid string input passes Pydantic validation.
+        Purpose: Ensure basic Responses API requests are accepted.
+        """
+        print("Action: POST /v1/responses with string input...")
+        response = test_client.post(
+            "/v1/responses",
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
+            json={
+                "model": "claude-sonnet-4-5",
+                "input": "Hello",
+                "stream": False,
+            }
+        )
+
+        print(f"Status: {response.status_code}")
+        assert response.status_code != 422
+
+    def test_accepts_responses_function_tool_format(self, test_client, valid_proxy_api_key):
+        """
+        What it does: Verifies flat Responses API function tools pass validation.
+        Purpose: Ensure Codex Desktop tool definitions are accepted.
+        """
+        print("Action: POST /v1/responses with flat function tool...")
+        response = test_client.post(
+            "/v1/responses",
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
+            json={
+                "model": "claude-sonnet-4-5",
+                "input": "Use a tool.",
+                "tools": [{
+                    "type": "function",
+                    "name": "shell",
+                    "description": "Run a command",
+                    "parameters": {"type": "object", "properties": {"cmd": {"type": "string"}}},
+                }],
+            }
+        )
+
+        print(f"Status: {response.status_code}")
+        assert response.status_code != 422
+
+
 class TestChatCompletionsValidation:
     """Tests for request validation on /v1/chat/completions endpoint."""
     
@@ -825,6 +942,17 @@ class TestRouterIntegration:
         
         print(f"Found routes: {routes}")
         assert "/v1/chat/completions" in routes
+
+    def test_router_has_responses_endpoint(self):
+        """
+        What it does: Verifies Responses endpoint is registered.
+        Purpose: Ensure Codex Desktop can call the Responses API path.
+        """
+        print("Checking: Router endpoints...")
+        routes = [route.path for route in router.routes]
+
+        print(f"Found routes: {routes}")
+        assert "/v1/responses" in routes
     
     def test_root_endpoint_uses_get_method(self):
         """
@@ -877,6 +1005,19 @@ class TestRouterIntegration:
                 assert "POST" in route.methods
                 return
         pytest.fail("Chat completions endpoint not found")
+
+    def test_responses_endpoint_uses_post_method(self):
+        """
+        What it does: Verifies Responses endpoint uses POST method.
+        Purpose: Ensure correct HTTP method for OpenAI-compatible clients.
+        """
+        print("Checking: HTTP methods...")
+        for route in router.routes:
+            if route.path == "/v1/responses":
+                print(f"Route /v1/responses methods: {route.methods}")
+                assert "POST" in route.methods
+                return
+        pytest.fail("Responses endpoint not found")
 
 
 # =============================================================================

--- a/tests/unit/test_streaming_responses.py
+++ b/tests/unit/test_streaming_responses.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+
+"""
+Unit tests for streaming_responses module.
+
+Tests for:
+- Chat Completions response conversion to Responses API objects
+- Responses API semantic streaming events
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro.streaming_responses import chat_completion_to_response, stream_kiro_to_responses
+
+
+@pytest.fixture
+def mock_model_cache():
+    """Mock for ModelInfoCache."""
+    cache = MagicMock()
+    cache.get_max_input_tokens.return_value = 200000
+    return cache
+
+
+@pytest.fixture
+def mock_auth_manager():
+    """Mock for KiroAuthManager."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_http_client():
+    """Mock for httpx.AsyncClient."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_response():
+    """Mock for httpx.Response."""
+    response = AsyncMock()
+    response.status_code = 200
+    response.aclose = AsyncMock()
+    return response
+
+
+class TestChatCompletionToResponse:
+    """Tests for chat_completion_to_response."""
+
+    def test_converts_text_message_to_response_object(self):
+        """
+        What it does: Converts a normal chat completion into a Responses object.
+        Purpose: Ensure non-streaming /v1/responses returns the expected shape.
+        """
+        print("Setup: Chat completion with text...")
+        chat_response = {
+            "id": "chatcmpl_123",
+            "created": 123,
+            "model": "claude-sonnet-4-5",
+            "choices": [{
+                "message": {"role": "assistant", "content": "Hello there"},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+        }
+
+        print("Action: Converting to Responses object...")
+        response = chat_completion_to_response(chat_response, response_id="resp_test")
+
+        assert response["id"] == "resp_test"
+        assert response["object"] == "response"
+        assert response["status"] == "completed"
+        assert response["output_text"] == "Hello there"
+        assert response["output"][0]["type"] == "message"
+        assert response["output"][0]["content"][0]["type"] == "output_text"
+        assert response["usage"]["input_tokens"] == 3
+        assert response["usage"]["output_tokens"] == 2
+
+    def test_converts_tool_calls_to_function_call_items(self):
+        """
+        What it does: Converts chat tool_calls into Responses function_call output items.
+        Purpose: Ensure Codex can receive tool requests from /v1/responses.
+        """
+        print("Setup: Chat completion with tool call...")
+        chat_response = {
+            "created": 123,
+            "model": "claude-sonnet-4-5",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": '{"path":"README.md"}'},
+                    }],
+                },
+            }],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+        }
+
+        print("Action: Converting to Responses object...")
+        response = chat_completion_to_response(chat_response, response_id="resp_test")
+
+        assert response["output_text"] == ""
+        assert len(response["output"]) == 1
+        assert response["output"][0]["type"] == "function_call"
+        assert response["output"][0]["call_id"] == "call_123"
+        assert response["output"][0]["name"] == "read_file"
+
+
+class TestStreamKiroToResponses:
+    """Tests for Responses API streaming events."""
+
+    @pytest.mark.asyncio
+    async def test_yields_responses_text_delta_events(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+        """
+        What it does: Converts chat stream chunks into Responses API text delta events.
+        Purpose: Ensure streaming clients receive semantic Responses events.
+        """
+        print("Setup: Mock chat stream with text and usage...")
+
+        async def mock_stream_kiro_to_openai(*args, **kwargs):
+            yield 'data: {"choices":[{"delta":{"role":"assistant","content":"Hel"},"finish_reason":null}]}\n\n'
+            yield 'data: {"choices":[{"delta":{"content":"lo"},"finish_reason":null}]}\n\n'
+            yield 'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}\n\n'
+            yield "data: [DONE]\n\n"
+
+        print("Action: Streaming to Responses format...")
+        chunks = []
+        with patch("kiro.streaming_responses.stream_kiro_to_openai", mock_stream_kiro_to_openai):
+            async for chunk in stream_kiro_to_responses(
+                mock_http_client,
+                mock_response,
+                "claude-sonnet-4-5",
+                mock_model_cache,
+                mock_auth_manager,
+            ):
+                chunks.append(chunk)
+
+        assert any("event: response.created" in chunk for chunk in chunks)
+        assert any("event: response.output_text.delta" in chunk and '"delta": "Hel"' in chunk for chunk in chunks)
+        assert any("event: response.output_text.done" in chunk and '"text": "Hello"' in chunk for chunk in chunks)
+        assert any("event: response.completed" in chunk and '"output_text": "Hello"' in chunk for chunk in chunks)
+        assert chunks[-1] == "data: [DONE]\n\n"
+
+    @pytest.mark.asyncio
+    async def test_yields_function_call_items_for_tool_calls(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+        """
+        What it does: Converts chat stream tool calls into Responses output items.
+        Purpose: Ensure streaming /v1/responses exposes function calls.
+        """
+        print("Setup: Mock chat stream with tool call...")
+
+        async def mock_stream_kiro_to_openai(*args, **kwargs):
+            payload = {
+                "choices": [{
+                    "delta": {
+                        "tool_calls": [{
+                            "id": "call_123",
+                            "type": "function",
+                            "function": {"name": "shell", "arguments": '{"cmd":"ls"}'},
+                        }]
+                    },
+                    "finish_reason": None,
+                }]
+            }
+            yield f"data: {json.dumps(payload)}\n\n"
+            yield 'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}\n\n'
+            yield "data: [DONE]\n\n"
+
+        print("Action: Streaming to Responses format...")
+        chunks = []
+        with patch("kiro.streaming_responses.stream_kiro_to_openai", mock_stream_kiro_to_openai):
+            async for chunk in stream_kiro_to_responses(
+                mock_http_client,
+                mock_response,
+                "claude-sonnet-4-5",
+                mock_model_cache,
+                mock_auth_manager,
+            ):
+                chunks.append(chunk)
+
+        tool_item_chunks = [chunk for chunk in chunks if '"type": "function_call"' in chunk]
+        assert len(tool_item_chunks) >= 1
+        assert any('"call_id": "call_123"' in chunk for chunk in tool_item_chunks)
+        assert any('"name": "shell"' in chunk for chunk in tool_item_chunks)
+        assert any("event: response.function_call_arguments.delta" in chunk for chunk in chunks)
+        assert any("event: response.function_call_arguments.done" in chunk for chunk in chunks)


### PR DESCRIPTION
## Summary
- add OpenAI-compatible POST /v1/responses for Codex Desktop
- translate Responses API input, instructions, function calls, function outputs, and flat tools into the existing Kiro chat conversion path
- emit Responses API response objects and streaming SSE events, including text deltas and function-call argument events
- normalize credential paths so configured ~ paths are expanded consistently

## Why
Codex Desktop uses the OpenAI Responses API surface rather than Chat Completions. This lets Kiro Gateway remain transparent while accepting that newer client API shape and reusing the existing Kiro conversion, streaming, auth, and retry behavior.

## Tests
- venv/bin/python -m pytest -v
- Tested from Codex desktop app with this configuration in `~/.codex/config.toml`

```
model = "claude-opus-4-6"
model_provider = "kiro"

[model_providers.kiro]
name = "Kiro Gateway"
base_url = "http://localhost:9999/v1"
env_key = "KIRO_GATEWAY_API_KEY"
wire_api = "responses"
```

<img width="1401" height="923" alt="image" src="https://github.com/user-attachments/assets/5f497c4d-09a4-4618-90c2-a011b99944f0" />
