### PR TITLE
fix(mcp): add profileArn to MCP web_search request body

### DIFF
--- a/kiro/mcp_tools.py
+++ b/kiro/mcp_tools.py
@@ -133,7 +133,8 @@ async def call_kiro_mcp_api(
         "params": {
             "name": "web_search",
             "arguments": {"query": query}
-        }
+        },
+        "profileArn": auth_manager.profile_arn or ""
     }
     
     # Log MCP request


### PR DESCRIPTION
## Problem

The Kiro MCP API (`runtime.kiro.dev/mcp`) now requires `profileArn` in the request payload. Without it, all `web_search` calls via `call_kiro_mcp_api()` return HTTP 400:

```json
{"message":"profileArn is required for this request.","reason":null}
```

This causes the gateway to return 500 ("Web search failed. Please try again.") to clients whenever they use the Anthropic native `web_search` server tool.

## Root Cause

Normal chat requests already include `profileArn` in the payload (added by `converters_core.py:build_kiro_payload()`), but `call_kiro_mcp_api()` in `mcp_tools.py` constructs its own JSON-RPC request independently and was missing this field.

The MCP endpoint appears to have recently started enforcing `profileArn` as a required field for all request types.

## Fix

Add `auth_manager.profile_arn` to the MCP JSON-RPC request body:

```python
mcp_request = {
    "id": request_id,
    "jsonrpc": "2.0",
    "method": "tools/call",
    "params": {
        "name": "web_search",
        "arguments": {"query": query}
    },
    "profileArn": auth_manager.profile_arn or ""
}
```

## Testing

- Verified that after this fix, web_search requests succeed (previously 100% failure rate with HTTP 400 from MCP API)
- Normal chat requests remain unaffected