### PR TITLE
fix: support Anthropic server-side tools and runtime.kiro.dev MCP

### DIFF
--- a/kiro/mcp_tools.py
+++ b/kiro/mcp_tools.py
@@ -147,12 +147,19 @@ async def call_kiro_mcp_api(
     try:
         token = await auth_manager.get_access_token()
         
-        # EXACT headers from architecture
+        # EXACT headers from architecture + profileArn (required by runtime.kiro.dev)
         headers = {
             "Authorization": f"Bearer {token}",
             "x-amzn-codewhisperer-optout": "false",
             "Content-Type": "application/json"
         }
+        
+        # Add profileArn if available (required by runtime.kiro.dev)
+        from kiro.config import PROFILE_ARN
+        profile_arn = auth_manager.profile_arn or PROFILE_ARN or ""
+        if profile_arn:
+            headers["x-amzn-codewhisperer-profile-arn"] = profile_arn
+            mcp_request["profileArn"] = profile_arn
         
         mcp_url = f"{auth_manager.q_host}/mcp"
         logger.debug(f"Calling MCP API: {mcp_url}")

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -221,7 +221,7 @@ class AnthropicTool(BaseModel):
     type: Optional[str] = None
     
     # Common fields
-    name: str
+    name: Optional[str] = None
     description: Optional[str] = None
     input_schema: Optional[Dict[str, Any]] = None  # Now optional for server-side tools
     
@@ -235,11 +235,16 @@ class AnthropicTool(BaseModel):
     
     @model_validator(mode="after")
     def validate_tool_consistency(self):
-        """Validate that user-defined tools have input_schema."""
+        """Validate that user-defined tools have input_schema and name."""
         is_server_side = self.type is not None
         
         if not is_server_side:
-            # User-defined tool: input_schema is required
+            # User-defined tool: name and input_schema are required
+            if not self.name:
+                raise ValueError(
+                    "name is required for user-defined tools "
+                    "(those without a 'type' field)"
+                )
             if self.input_schema is None:
                 raise ValueError(
                     "input_schema is required for user-defined tools "


### PR DESCRIPTION
## Problem

Two bugs prevent Claude Code's native `web_search_20250305` server-side tool from working through the gateway:

### Bug 1: Pydantic 422 on server-side tools

The `AnthropicTool` model in `models_anthropic.py` has `name: str` as a required field. However, Anthropic's native server-side tools (like `web_search_20250305`) only send a `type` field — no `name`. This causes Pydantic to reject the request with a 422 validation error before it ever reaches the route handler.

**Reproduction:** Send a request with `"tools": [{"type": "web_search_20250305"}]` (this is what Claude Code sends when web search is enabled).

### Bug 2: Missing profileArn for runtime.kiro.dev/mcp

The `call_kiro_mcp_api` function in `mcp_tools.py` doesn't include the `profileArn` that `runtime.kiro.dev/mcp` requires, causing a 400 error when the MCP endpoint is called.

## Fix

1. **models_anthropic.py:** Make `name` optional (`Optional[str] = None`) and add a `@model_validator` that enforces `name` is present only for user-defined tools (those without a `type` field). Server-side tools pass through without validation errors.

2. **mcp_tools.py:** Add `profileArn` to both the `x-amzn-codewhisperer-profile-arn` header and the MCP request body, sourced from `auth_manager.profile_arn` or the `PROFILE_ARN` config.

## Testing

After this fix, Claude Code's web search works end-to-end through the gateway (both Path A native server-side tools and Path B MCP emulation).