### PR TITLE
fix: truncate long MCP tool names instead of rejecting requests

### DIFF
--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -557,46 +557,45 @@ def process_tools_with_long_descriptions(
     return processed_tools if processed_tools else None, tool_documentation
 
 
+import hashlib
+
+# Global mapping for tool name truncation (short_name -> original_name)
+_tool_name_map: Dict[str, str] = {}
+
+
+def _shorten_tool_name(name: str) -> str:
+    """Shorten a tool name to fit the 64-char Kiro API limit using a hash suffix."""
+    if len(name) <= 64:
+        return name
+    # Keep first 56 chars + underscore + 7-char hash for uniqueness
+    h = hashlib.md5(name.encode()).hexdigest()[:7]
+    return name[:56] + "_" + h
+
+
+def get_original_tool_name(short_name: str) -> str:
+    """Reverse-map a shortened tool name back to the original."""
+    return _tool_name_map.get(short_name, short_name)
+
+
 def validate_tool_names(tools: Optional[List[UnifiedTool]]) -> None:
     """
-    Validates tool names against Kiro API 64-character limit.
+    Truncates tool names that exceed the Kiro API 64-character limit.
     
-    Logs WARNING for each problematic tool and raises ValueError
-    with complete list of violations.
+    Instead of rejecting requests, long names are shortened with a hash suffix
+    and a reverse mapping is stored so responses can restore original names.
     
     Args:
-        tools: List of tools to validate
-    
-    Raises:
-        ValueError: If any tool name exceeds 64 characters
-    
-    Example:
-        >>> validate_tool_names([UnifiedTool(name="short_name", description="test")])
-        # No error
-        >>> validate_tool_names([UnifiedTool(name="a" * 70, description="test")])
-        # Raises ValueError with detailed message
+        tools: List of tools to validate/fix (mutated in place)
     """
     if not tools:
         return
     
-    problematic_tools = []
     for tool in tools:
         if len(tool.name) > 64:
-            problematic_tools.append((tool.name, len(tool.name)))
-    
-    if problematic_tools:
-        # Build detailed error message for client (no logging here - routes will log)
-        tool_list = "\n".join([
-            f"  - '{name}' ({length} characters)"
-            for name, length in problematic_tools
-        ])
-        
-        raise ValueError(
-            f"Tool name(s) exceed Kiro API limit of 64 characters:\n"
-            f"{tool_list}\n\n"
-            f"Solution: Use shorter tool names (max 64 characters).\n"
-            f"Example: 'get_user_data' instead of 'get_authenticated_user_profile_data_with_extended_information_about_it'"
-        )
+            short = _shorten_tool_name(tool.name)
+            _tool_name_map[short] = tool.name
+            logger.info(f"Truncated tool name '{tool.name}' -> '{short}'")
+            tool.name = short
 
 
 def convert_tools_to_kiro_format(tools: Optional[List[UnifiedTool]]) -> List[Dict[str, Any]]:

--- a/kiro/streaming_anthropic.py
+++ b/kiro/streaming_anthropic.py
@@ -347,6 +347,10 @@ async def stream_kiro_to_anthropic(
                 tool_name = tool.get("function", {}).get("name", "") or tool.get("name", "")
                 tool_input = tool.get("function", {}).get("arguments", {}) or tool.get("input", {})
                 
+                # Reverse-map truncated tool names back to originals
+                from kiro.converters_core import get_original_tool_name
+                tool_name = get_original_tool_name(tool_name)
+                
                 # ==============================================================================
                 # WebSearch Support - Path B: MCP Tool Emulation (Streaming Interception)
                 # ==============================================================================

--- a/kiro/streaming_openai.py
+++ b/kiro/streaming_openai.py
@@ -192,6 +192,10 @@ async def stream_kiro_to_openai_internal(
                 if tool:
                     tool_name = (tool.get("function") or {}).get("name", "") or tool.get("name", "")
                 
+                # Reverse-map truncated tool names back to originals
+                from kiro.converters_core import get_original_tool_name
+                tool_name = get_original_tool_name(tool_name)
+                
                 # ==============================================================================
                 # WebSearch Support - Path B: MCP Tool Emulation (Streaming Interception)
                 # ==============================================================================
@@ -335,6 +339,10 @@ async def stream_kiro_to_openai_internal(
                 # Use "or" for protection against explicit None in values
                 tool_name = func.get("name") or ""
                 tool_args = func.get("arguments") or "{}"
+                
+                # Reverse-map truncated tool names back to originals
+                from kiro.converters_core import get_original_tool_name
+                tool_name = get_original_tool_name(tool_name)
                 
                 logger.debug(f"Tool call [{idx}] '{tool_name}': id={tc.get('id')}, args_length={len(tool_args)}")
                 


### PR DESCRIPTION
## Problem

Claude Code's MCP plugin naming convention uses the format `mcp__<server>_<plugin>__<method>` which can easily exceed the Kiro API's 64-character tool name limit. For example:

```
mcp__plugin_chrome-devtools-mcp_chrome-devtools__get_console_message (68 chars)
```

The gateway currently rejects these requests with a 400 error:
```
API Error: 400 Tool name(s) exceed Kiro API limit of 64 characters:
  - 'mcp__plugin_chrome-devtools-mcp_chrome-devtools__get_console_message' (68 characters)
```

This makes it impossible to use many MCP plugins with Claude Code through the gateway.

## Fix

Instead of rejecting requests, automatically truncate long tool names to fit within 64 characters using a deterministic scheme:
- Keep the first 56 characters (preserves readability)
- Append `_` + 7-character MD5 hash (ensures uniqueness)

A bidirectional mapping is maintained so that tool names in responses from the Kiro API are restored to their original values before being sent back to Claude Code. This ensures the client never sees the truncated names.

### Example
```
Original:  mcp__plugin_chrome-devtools-mcp_chrome-devtools__get_console_message (68 chars)
Truncated: mcp__plugin_chrome-devtools-mcp_chrome-devtools__get_con_8d29446 (64 chars)
Response:  restored to original before reaching Claude Code
```

## Files Changed

- **converters_core.py:** Replace `validate_tool_names` (which raised ValueError) with truncation + reverse mapping logic
- **streaming_anthropic.py:** Apply `get_original_tool_name()` to restore names in Anthropic-format responses
- **streaming_openai.py:** Same for OpenAI-compatible response path

## Testing

Installed Chrome DevTools MCP plugin in Claude Code — requests now pass through the gateway successfully instead of being rejected.