### PR TITLE
fix(tokenizer): cache cl100k_base locally and retry on network errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ build/
 debug_logs*/
 debug*.json
 
+# tiktoken BPE cache (downloaded on first use, see kiro/tokenizer.py)
+.tiktoken_cache/
+
 # Project-specific
 _notes/
 requests/

--- a/kiro/tokenizer.py
+++ b/kiro/tokenizer.py
@@ -33,11 +33,29 @@ more than GPT-4 (cl100k_base). This is due to differences in BPE vocabularies.
 """
 
 import json
+import os
 from typing import List, Dict, Any, Optional
 from loguru import logger
 
-# Lazy loading of tiktoken to speed up import
+# Lazy loading of tiktoken to speed up import.
+#
+# Sentinel values for _encoding:
+#   None  -> not yet initialised; try again on next call
+#   False -> tiktoken module itself is unavailable; permanently fall back
+#   <obj> -> usable tiktoken Encoding instance
 _encoding = None
+
+# Pin tiktoken's BPE cache to a repo-local directory so cl100k_base.tiktoken
+# (~1.6 MB) is fetched at most once and reused across restarts. Without this,
+# every fresh container or working copy re-downloads from
+# openaipublic.blob.core.windows.net, which has been observed to drop the
+# connection mid-transfer (IncompleteRead). Respect TIKTOKEN_CACHE_DIR if the
+# operator has already set one explicitly.
+_LOCAL_TIKTOKEN_CACHE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    ".tiktoken_cache",
+)
+os.environ.setdefault("TIKTOKEN_CACHE_DIR", _LOCAL_TIKTOKEN_CACHE_DIR)
 
 # Correction coefficient for Claude models
 # Claude tokenizes text approximately 15% more than GPT-4 (cl100k_base)
@@ -48,30 +66,52 @@ CLAUDE_CORRECTION_FACTOR = 1.15
 def _get_encoding():
     """
     Lazy initialization of tokenizer.
-    
+
     Uses cl100k_base - encoding for GPT-4/ChatGPT,
     which is close enough to Claude tokenization.
-    
+
+    Caching strategy:
+        - A successful encoding is cached for the lifetime of the process.
+        - An ``ImportError`` is cached (``_encoding = False``) because a missing
+          tiktoken package will not appear mid-process.
+        - Any other exception (network error fetching the BPE blob, corrupt
+          cache file, ...) is NOT cached, so the next caller retries. A single
+          transient ``IncompleteRead`` from the Azure CDN must not permanently
+          demote the whole process to the length-based fallback.
+
     Returns:
         tiktoken.Encoding or None if tiktoken is unavailable
     """
     global _encoding
-    if _encoding is None:
-        try:
-            import tiktoken
-            _encoding = tiktoken.get_encoding("cl100k_base")
-            logger.debug("[Tokenizer] Initialized tiktoken with cl100k_base encoding")
-        except ImportError:
-            logger.warning(
-                "[Tokenizer] tiktoken not installed. "
-                "Token counting will use fallback estimation. "
-                "Install with: pip install tiktoken"
-            )
-            _encoding = False  # Marker that import failed
-        except Exception as e:
-            logger.error(f"[Tokenizer] Failed to initialize tiktoken: {e}")
-            _encoding = False
-    return _encoding if _encoding else None
+    if _encoding is not None:
+        return _encoding if _encoding else None
+
+    try:
+        import tiktoken
+    except ImportError:
+        logger.warning(
+            "[Tokenizer] tiktoken not installed. "
+            "Token counting will use fallback estimation. "
+            "Install with: pip install tiktoken"
+        )
+        _encoding = False  # tiktoken truly missing — fall back permanently
+        return None
+
+    try:
+        encoding = tiktoken.get_encoding("cl100k_base")
+    except Exception as e:
+        # Most commonly: network failure pulling cl100k_base.tiktoken from
+        # openaipublic.blob.core.windows.net (IncompleteRead, timeout, TLS
+        # error). Leave _encoding=None so the next call retries instead of
+        # silently degrading to the fallback heuristic forever.
+        logger.error(
+            f"[Tokenizer] Failed to initialize tiktoken (will retry on next call): {e}"
+        )
+        return None
+
+    _encoding = encoding
+    logger.debug("[Tokenizer] Initialized tiktoken with cl100k_base encoding")
+    return _encoding
 
 
 def count_tokens(text: str, apply_claude_correction: bool = True) -> int:

--- a/tests/unit/test_tokenizer.py
+++ b/tests/unit/test_tokenizer.py
@@ -10,8 +10,11 @@ Tests:
 - Request token estimation (estimate_request_tokens)
 - Claude correction coefficient (CLAUDE_CORRECTION_FACTOR)
 - Fallback when tiktoken is unavailable
+- Repo-local tiktoken BPE cache and retry-on-network-error
 """
 
+import os
+import sys
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -979,6 +982,126 @@ class TestGetEncoding:
                     pass
         finally:
             tokenizer_module._encoding = original_encoding
+
+
+class TestEncodingCacheAndRetry:
+    """Tests for repo-local BPE cache directory and retry-on-network-error."""
+
+    def test_local_cache_dir_set_on_import(self):
+        """
+        What it does: Verifies tokenizer module pins TIKTOKEN_CACHE_DIR to a
+        repo-local `.tiktoken_cache` directory on import.
+        Purpose: Ensure cl100k_base.tiktoken is cached persistently so the
+        ~1.6 MB blob is fetched at most once per repo. Without this, every
+        fresh working copy re-downloads from openaipublic.blob.core.windows.net
+        and is exposed to IncompleteRead drops.
+        """
+        cache_dir = os.environ.get("TIKTOKEN_CACHE_DIR")
+        assert cache_dir, "TIKTOKEN_CACHE_DIR should be set after importing kiro.tokenizer"
+        assert cache_dir.rstrip(os.sep).endswith(".tiktoken_cache"), (
+            f"Expected cache dir to end in .tiktoken_cache, got: {cache_dir!r}"
+        )
+
+    def test_network_failure_is_not_cached(self):
+        """
+        What it does: Simulates a network error during cl100k_base download
+        and verifies `_encoding` is left as None so the next call retries.
+        Purpose: A single transient CDN failure (IncompleteRead, TLS reset,
+        timeout) must not permanently demote the process to the length-based
+        fallback. This guards against the regression where every later
+        request silently lost tiktoken precision.
+        """
+        import kiro.tokenizer as tokenizer_module
+
+        original_encoding = tokenizer_module._encoding
+        tokenizer_module._encoding = None
+        try:
+            with patch("tiktoken.get_encoding", side_effect=ConnectionError("simulated IncompleteRead")):
+                result = _get_encoding()
+
+            assert result is None, "Network failure should yield None to caller"
+            assert tokenizer_module._encoding is None, (
+                "Network failure must not be cached — next call must retry"
+            )
+        finally:
+            tokenizer_module._encoding = original_encoding
+
+    def test_retry_after_network_failure_succeeds(self):
+        """
+        What it does: First call fails with a network error; second call
+        succeeds and the result is cached.
+        Purpose: Validate the full recovery path users hit after the CDN
+        becomes reachable again, including that the successful encoding is
+        memoised so subsequent calls don't refetch.
+        """
+        import kiro.tokenizer as tokenizer_module
+
+        original_encoding = tokenizer_module._encoding
+        tokenizer_module._encoding = None
+
+        fake_encoding = MagicMock(name="cl100k_base_encoding")
+        fake_encoding.encode.return_value = [1, 2, 3]
+
+        calls = {"count": 0}
+
+        def flaky_get_encoding(name):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise ConnectionError("simulated IncompleteRead")
+            return fake_encoding
+
+        try:
+            with patch("tiktoken.get_encoding", side_effect=flaky_get_encoding):
+                first = _get_encoding()
+                assert first is None, "First (failing) call should return None"
+                assert tokenizer_module._encoding is None, "First failure must not be cached"
+
+                second = _get_encoding()
+                assert second is fake_encoding, "Second call should recover and return encoding"
+                assert tokenizer_module._encoding is fake_encoding, "Recovered encoding must be cached"
+
+                third = _get_encoding()
+                assert third is fake_encoding, "Cached encoding should be reused"
+                assert calls["count"] == 2, (
+                    "tiktoken.get_encoding should be invoked exactly twice "
+                    "(one failure + one success), not on every call"
+                )
+        finally:
+            tokenizer_module._encoding = original_encoding
+
+    def test_import_error_is_cached_permanently(self):
+        """
+        What it does: When tiktoken itself is missing, `_encoding` is set to
+        False so subsequent calls return None without re-attempting the import.
+        Purpose: ImportError is a permanent condition (the package will not
+        appear mid-process) and is the one case where caching the disabled
+        state is correct — in contrast to transient network failures.
+        """
+        import kiro.tokenizer as tokenizer_module
+
+        original_encoding = tokenizer_module._encoding
+        original_tiktoken = sys.modules.get("tiktoken")
+        tokenizer_module._encoding = None
+        try:
+            # Putting None into sys.modules makes `import tiktoken` raise ImportError.
+            with patch.dict(sys.modules, {"tiktoken": None}):
+                first = _get_encoding()
+                assert first is None, "Missing tiktoken should yield None"
+                assert tokenizer_module._encoding is False, (
+                    "ImportError must be cached (sentinel False) to skip retry"
+                )
+
+                # Second call must short-circuit on the cached sentinel,
+                # not attempt the import again.
+                with patch("builtins.__import__", side_effect=AssertionError(
+                    "import tiktoken must not be retried after a cached ImportError"
+                )):
+                    second = _get_encoding()
+                assert second is None
+        finally:
+            tokenizer_module._encoding = original_encoding
+            if original_tiktoken is not None:
+                sys.modules["tiktoken"] = original_tiktoken
 
 
 class TestTokenizerIntegration:


### PR DESCRIPTION
`_get_encoding` used to mark tiktoken unusable on ANY exception, including a transient `IncompleteRead` while pulling cl100k_base.tiktoken from the Azure blob CDN. A single dropped connection on first use permanently demoted the whole process to the length-based fallback heuristic, silently losing tokenization precision for every later request until restart.

Two changes:

1. Pin `TIKTOKEN_CACHE_DIR` (via `setdefault`, so operator overrides win) to a repo-local `.tiktoken_cache/` directory. The ~1.6 MB BPE blob is fetched at most once per working copy and reused across restarts, eliminating the per-process re-download that exposed us to CDN flakiness in the first place. `.tiktoken_cache/` added to .gitignore.

2. Separate `ImportError` (tiktoken truly missing → cache the disabled state permanently) from runtime errors (network/IO failure during BPE download → do NOT cache, return None this call, retry on next call). One transient blip no longer kills tokenization for the lifetime of the process.

Tests (tests/unit/test_tokenizer.py::TestEncodingCacheAndRetry):
- TIKTOKEN_CACHE_DIR is set to repo-local `.tiktoken_cache` on module import.
- Network failure does not poison the `_encoding` sentinel.
- After a failure, the next call retries and a recovered encoding is cached.
- `ImportError` is still cached so we don't re-import a missing package on every call (regression guard for the previous behavior).