### PR TITLE
fix(model_resolver): resolve MODEL_ALIASES in get_model_id_for_kiro

### DIFF
--- a/kiro/model_resolver.py
+++ b/kiro/model_resolver.py
@@ -192,20 +192,20 @@ def normalize_model_name(name: str) -> str:
 def get_model_id_for_kiro(model_name: str, hidden_models: Dict[str, str]) -> str:
     """
     Get the model ID to send to Kiro API.
-    
+
     This is a simple helper for converters that don't have access to the full
-    ModelResolver. It normalizes the name and checks hidden models.
-    
+    ModelResolver. It resolves aliases, normalizes the name, and checks hidden models.
+
     For hidden models (like claude-3.7-sonnet), returns the internal Kiro ID.
     For regular models, returns the normalized name.
-    
+
     Args:
         model_name: External model name from client
         hidden_models: Dict mapping display names to internal Kiro IDs
-    
+
     Returns:
         Model ID to send to Kiro API
-    
+
     Examples:
         >>> get_model_id_for_kiro("claude-haiku-4-5-20251001", {})
         'claude-haiku-4.5'
@@ -214,7 +214,14 @@ def get_model_id_for_kiro(model_name: str, hidden_models: Dict[str, str]) -> str
         >>> get_model_id_for_kiro("claude-3-7-sonnet", {"claude-3.7-sonnet": "CLAUDE_3_7_SONNET_20250219_V1_0"})
         'CLAUDE_3_7_SONNET_20250219_V1_0'
     """
-    normalized = normalize_model_name(model_name)
+    from kiro.config import MODEL_ALIASES
+    
+    # Resolve alias first
+    resolved_model = MODEL_ALIASES.get(model_name, model_name)
+    if resolved_model != model_name:
+        logger.debug(f"Alias resolved: '{model_name}' → '{resolved_model}'")
+    
+    normalized = normalize_model_name(resolved_model)
     internal = hidden_models.get(normalized, normalized)
     return to_runtime_model_id(internal)
 

--- a/tests/unit/test_model_resolver.py
+++ b/tests/unit/test_model_resolver.py
@@ -629,6 +629,86 @@ class TestGetModelIdForKiro:
         print(f"Comparing result: Expected 'claude-unknown-model' (pass-through), Got '{result}'")
         assert result == "claude-unknown-model"
 
+    def test_resolves_alias_before_normalization(self):
+        """
+        What it does: Resolves MODEL_ALIASES before normalizing the model name.
+        Goal: Check that aliases are resolved first in the resolution chain.
+        """
+        from unittest.mock import patch
+        
+        aliases = {"kiro-sonnet": "claude-sonnet-4.5"}
+        
+        print("Action: get_model_id_for_kiro('kiro-sonnet', {}) with alias...")
+        with patch("kiro.config.MODEL_ALIASES", aliases):
+            result = get_model_id_for_kiro("kiro-sonnet", {})
+        
+        print(f"Comparing result: Expected 'claude-sonnet-4.5', Got '{result}'")
+        assert result == "claude-sonnet-4.5"
+
+    def test_alias_resolution_then_normalization(self):
+        """
+        What it does: Resolves alias, then normalizes the result.
+        Goal: Check full chain: alias → normalize → hidden lookup.
+        """
+        from unittest.mock import patch
+        
+        # Alias points to unnormalized name, should still work
+        aliases = {"my-haiku": "claude-haiku-4-5"}
+        
+        print("Action: get_model_id_for_kiro('my-haiku', {}) with alias to unnormalized...")
+        with patch("kiro.config.MODEL_ALIASES", aliases):
+            result = get_model_id_for_kiro("my-haiku", {})
+        
+        print(f"Comparing result: Expected 'claude-haiku-4.5' (normalized), Got '{result}'")
+        assert result == "claude-haiku-4.5"
+
+    def test_alias_to_hidden_model(self):
+        """
+        What it does: Alias resolves to a hidden model.
+        Goal: Check chain: alias → normalize → hidden lookup → internal ID.
+        """
+        from unittest.mock import patch
+        
+        aliases = {"my-special": "claude-3.7-sonnet"}
+        hidden = {"claude-3.7-sonnet": "CLAUDE_3_7_SONNET_INTERNAL"}
+        
+        print("Action: get_model_id_for_kiro('my-special', hidden) with alias to hidden...")
+        with patch("kiro.config.MODEL_ALIASES", aliases):
+            result = get_model_id_for_kiro("my-special", hidden)
+        
+        print(f"Comparing result: Expected 'CLAUDE_3_7_SONNET_INTERNAL', Got '{result}'")
+        assert result == "CLAUDE_3_7_SONNET_INTERNAL"
+
+    def test_non_aliased_model_unchanged(self):
+        """
+        What it does: Non-aliased models work normally.
+        Goal: Check that alias resolution doesn't break normal models.
+        """
+        from unittest.mock import patch
+        
+        aliases = {"kiro-sonnet": "claude-sonnet-4.5"}
+        
+        print("Action: get_model_id_for_kiro('claude-opus-4.5', {}) without alias...")
+        with patch("kiro.config.MODEL_ALIASES", aliases):
+            result = get_model_id_for_kiro("claude-opus-4.5", {})
+        
+        print(f"Comparing result: Expected 'claude-opus-4.5', Got '{result}'")
+        assert result == "claude-opus-4.5"
+
+    def test_empty_aliases_dict(self):
+        """
+        What it does: Empty aliases dict doesn't break resolution.
+        Goal: Check graceful handling of empty aliases.
+        """
+        from unittest.mock import patch
+        
+        print("Action: get_model_id_for_kiro('claude-sonnet-4-5', {}) with empty aliases...")
+        with patch("kiro.config.MODEL_ALIASES", {}):
+            result = get_model_id_for_kiro("claude-sonnet-4-5", {})
+        
+        print(f"Comparing result: Expected 'claude-sonnet-4.5' (normalized), Got '{result}'")
+        assert result == "claude-sonnet-4.5"
+
 
 # =============================================================================
 # TestModelResolver - Tests for ModelResolver class


### PR DESCRIPTION
`MODEL_ALIASES` weren't being resolved in `get_model_id_for_kiro()`, which is the path the converters use in legacy mode (`ACCOUNT_SYSTEM=false`). Custom aliases like `kiro-sonnet` got sent to the Kiro API as-is and were rejected with "Invalid model ID" instead of being resolved to e.g. `claude-sonnet-4.5`. Account-system mode resolved them correctly, only the legacy converter path was skipping the lookup.

The use case where this hurts: pointing Cursor IDE's "custom OpenAI base URL" at the gateway. `claude-*` names conflict with Cursor's built-in model names, so the only way to use a Kiro Claude model is via `MODEL_ALIASES`, and that wasn't working.

Fix: alias resolution is now the first step in `get_model_id_for_kiro()`, so the chain is `alias → normalize → hidden lookup → runtime ID`.

Added 5 tests in `TestGetModelIdForKiro` covering aliased / non-aliased / alias-to-hidden / empty-alias-dict cases:

- `test_resolves_alias_before_normalization`
- `test_alias_resolution_then_normalization`
- `test_alias_to_hidden_model`
- `test_non_aliased_model_unchanged`
- `test_empty_aliases_dict`

All 123 tests in `test_model_resolver.py` pass; verified end-to-end against Cursor IDE over a Cloudflare tunnel.
