### PR TITLE
fix(routes): skip profileArn for Builder ID (AWS_SSO_OIDC) accounts

### DIFF
--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -323,8 +323,13 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
             conversation_id = generate_conversation_id()
             
             # Build payload for Kiro
-            # profileArn is required by runtime.kiro.dev for all auth types
-            profile_arn_for_payload = auth_manager.profile_arn or PROFILE_ARN or ""
+            # profileArn is required by runtime.kiro.dev for non-Builder-ID accounts
+            # Builder ID (AWS_SSO_OIDC) accounts have no profileArn - sending it causes 403
+            # See: https://github.com/jwadow/kiro-gateway/issues/168
+            if auth_manager.auth_type == AuthType.AWS_SSO_OIDC:
+                profile_arn_for_payload = ""
+            else:
+                profile_arn_for_payload = auth_manager.profile_arn or PROFILE_ARN or ""
             
             try:
                 kiro_payload = build_kiro_payload(
@@ -571,8 +576,13 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
     conversation_id = generate_conversation_id()
     
     # Build payload for Kiro
-    # profileArn is required by runtime.kiro.dev for all auth types
-    profile_arn_for_payload = auth_manager.profile_arn or PROFILE_ARN or ""
+    # profileArn is required by runtime.kiro.dev for non-Builder-ID accounts
+    # Builder ID (AWS_SSO_OIDC) accounts have no profileArn - sending it causes 403
+    # See: https://github.com/jwadow/kiro-gateway/issues/168
+    if auth_manager.auth_type == AuthType.AWS_SSO_OIDC:
+        profile_arn_for_payload = ""
+    else:
+        profile_arn_for_payload = auth_manager.profile_arn or PROFILE_ARN or ""
     
     try:
         kiro_payload = build_kiro_payload(


### PR DESCRIPTION
## Problem

Builder ID (free tier) accounts fail with **403** when profileArn is sent to `q.amazonaws.com`, even though the profileArn exists in the local SQLite database (populated by kiro-cli).

Since May 2026, `runtime.kiro.dev` requires profileArn — but Builder ID accounts cannot use it there either. The only viable path for Builder ID is the legacy endpoint **without** profileArn.

This complements #175 (legacy endpoint switch) by fixing the remaining 403 on the legacy endpoint itself.

## Fix

In `routes_openai.py`, skip profileArn for `AWS_SSO_OIDC` auth type in both the `chat_completions` and `stream_completions` code paths:

```python
if auth_manager.auth_type == AuthType.AWS_SSO_OIDC:
    profile_arn_for_payload = ""
else:
    profile_arn_for_payload = auth_manager.profile_arn or PROFILE_ARN or ""
```

## Tested

- `deepseek-3.2` via `q.amazonaws.com` → 200 ✅
- `claude-sonnet-4.5` via `q.amazonaws.com` → 200 ✅
- Without fix → 403 on both models

Fixes #168
Related: #175

---

> 🤖 This PR was generated by [MiMo v2.5 Pro](https://huggingface.co/XiaomiMiMo/MiMo-2.5-Pro) (Xiaomi), an AI reasoning model. The fix, code, testing, and PR description were all produced autonomously by the AI.