### PR TITLE
fix(models): accept inline non-standard message roles (#190)

### DIFF
--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -183,11 +183,14 @@ class AnthropicMessage(BaseModel):
     Message in Anthropic format.
 
     Attributes:
-        role: Message role (user or assistant)
+        role: Message role. Normally "user" or "assistant", but accepted as a
+            free-form string because some clients (e.g. Claude Code) send other
+            roles such as "system" inside the messages array. Unknown roles are
+            normalized to "user" downstream by normalize_message_roles().
         content: Message content (string or list of content blocks)
     """
 
-    role: Literal["user", "assistant"]
+    role: str
     content: Union[str, List[ContentBlock]]
 
     model_config = {"extra": "allow"}

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -623,6 +623,81 @@ class TestAnthropicMessagesRequestWithImages:
 
 
 # ==================================================================================================
+# Tests for inline non-standard message roles (Issue #190)
+# ==================================================================================================
+
+class TestAnthropicMessageInlineRoles:
+    """
+    Tests for AnthropicMessage with inline non-standard roles.
+
+    These tests verify the fix for Issue #190 - 422 Validation Error
+    when newer Claude Code clients inline a message with role "system"
+    inside the messages array.
+
+    The role field is intentionally a free-form str: unknown roles such
+    as "system" and "developer" are normalized to "user" downstream by
+    converters_core.normalize_message_roles().
+    """
+
+    def test_message_with_system_role_validates(self):
+        """
+        What it does: Verifies AnthropicMessage accepts role "system".
+        Purpose: This is the PRIMARY test for Issue #190 fix.
+
+        Before the fix, this raised a ValidationError because role was
+        declared as Literal["user", "assistant"].
+        """
+        print("Setup: Creating AnthropicMessage with role 'system'...")
+        message = AnthropicMessage(
+            role="system",
+            content="<system-reminder>context blob</system-reminder>"
+        )
+
+        print(f"Comparing role: Expected 'system', Got '{message.role}'")
+        assert message.role == "system"
+        assert message.content == "<system-reminder>context blob</system-reminder>"
+
+    def test_message_with_developer_role_validates(self):
+        """
+        What it does: Verifies other non-standard roles also validate.
+        Purpose: Ensure the field is leniently typed, not just patched
+        for the single "system" value.
+        """
+        print("Setup: Creating AnthropicMessage with role 'developer'...")
+        message = AnthropicMessage(role="developer", content="some context")
+
+        print(f"Comparing role: Expected 'developer', Got '{message.role}'")
+        assert message.role == "developer"
+
+    def test_standard_roles_still_validate(self):
+        """
+        What it does: Verifies user/assistant roles are unaffected.
+        Purpose: Guard against regressions in the common path.
+        """
+        assert AnthropicMessage(role="user", content="hi").role == "user"
+        assert AnthropicMessage(role="assistant", content="hello").role == "assistant"
+
+    def test_request_with_inline_system_message_validates(self):
+        """
+        What it does: Verifies the exact Issue #190 request validates.
+        Purpose: End-to-end validation for the failing Claude Code payload
+        that carries an inline role "system" message at index 1.
+        """
+        print("Setup: Creating request with inline 'system' role message...")
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4-8",
+            max_tokens=16,
+            messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "system", "content": "<system-reminder>...</system-reminder>"},
+            ],
+        )
+
+        print(f"Comparing roles: Got {[m.role for m in request.messages]}")
+        assert [m.role for m in request.messages] == ["user", "system"]
+
+
+# ==================================================================================================
 # Tests for TextContentBlock
 # ==================================================================================================
 


### PR DESCRIPTION
## Summary

Newer Claude Code clients (`claude-opus-4-8`) inline a message with `role: "system"` inside the `messages` array — typically at index 1, carrying context blobs like `<system-reminder>` and `currentDate`. The gateway rejected these requests with **HTTP 422** before any downstream normalization could run, so the client could not complete a single turn.

```json
{
  "type": "literal_error",
  "loc": ["body", "messages", 1, "role"],
  "msg": "Input should be 'user' or 'assistant'",
  "input": "system"
}
```

Fixes #190.

## Root cause

`AnthropicMessage.role` in `kiro/models_anthropic.py` was declared as `Literal["user", "assistant"]`, so Pydantic rejected `"system"` at the validation layer — *before* the request reached `converters_core.normalize_message_roles()`, which already knows how to fold unknown roles into `"user"`.

## Fix

Widen the `role` field to a free-form `str`. Unknown roles such as `"system"` and `"developer"` continue to be normalized to `"user"` downstream by `normalize_message_roles()`, so the request now flows through correctly instead of being rejected up front. This keeps the gateway lenient on input while the official Anthropic spec (user/assistant only) is still honored on output.

## Tests

Added `TestAnthropicMessageInlineRoles` covering the inline `"system"` role at both the message and full-request level, plus a guard that standard `user`/`assistant` roles are unaffected.

```
425 passed
```
(`tests/unit/test_models_anthropic.py`, `test_converters_anthropic.py`, `test_converters_core.py`)
