### PR TITLE
feat(thinking): support native adaptive reasoning blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,19 @@
 credentials.json
 state.json
 
+# Local Docker Compose overrides
+docker-compose.yaml
+docker-compose.local.yml
+docker-compose.local.yaml
+compose.local.yml
+compose.local.yaml
+
 # IDE
 .vscode/
 .idea/
 .shard/
+.agents/
+skills-lock.json
 
 # Python
 __pycache__/

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -479,6 +479,26 @@ FAKE_REASONING_INITIAL_BUFFER_SIZE: int = int(os.getenv("FAKE_REASONING_INITIAL_
 
 
 # ==================================================================================================
+# Native Thinking Settings (Kiro/Claude Adaptive Thinking)
+# ==================================================================================================
+
+# Experimental native thinking pass-through for Kiro models that expose Claude adaptive thinking.
+#
+# Modes:
+# - "off": Disabled (default, preserves existing fake reasoning behavior)
+# - "auto": Enable only when the client explicitly requests a reasoning effort
+# - "force": Enable for supported models even when the client does not send an effort
+KIRO_NATIVE_THINKING_MODE: str = os.getenv("KIRO_NATIVE_THINKING_MODE", "off").lower()
+if KIRO_NATIVE_THINKING_MODE not in ("off", "auto", "force"):
+    KIRO_NATIVE_THINKING_MODE = "off"
+
+# Claude Opus 4.8/4.7 default to omitted thinking text unless display is explicitly summarized.
+KIRO_NATIVE_THINKING_DISPLAY: str = os.getenv("KIRO_NATIVE_THINKING_DISPLAY", "summarized").lower()
+if KIRO_NATIVE_THINKING_DISPLAY not in ("summarized", "omitted"):
+    KIRO_NATIVE_THINKING_DISPLAY = "summarized"
+
+
+# ==================================================================================================
 # Payload Size Guard Settings
 # ==================================================================================================
 

--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -39,6 +39,8 @@ from kiro.converters_core import (
     UnifiedMessage,
     UnifiedTool,
     ThinkingConfig,
+    build_native_thinking_config,
+    reasoning_effort_to_budget,
     build_kiro_payload,
     extract_text_content,
     extract_images_from_content,
@@ -376,6 +378,7 @@ def extract_thinking_config_from_anthropic(request: AnthropicMessagesRequest) ->
     
     Handles thinking parameter:
     - {"type": "enabled", "budget_tokens": N} → enabled with budget
+    - {"type": "adaptive", "effort": "max"} → enabled with effort-based budget
     - {"type": "disabled"} → disabled
     - None → enabled with default budget
     
@@ -400,6 +403,11 @@ def extract_thinking_config_from_anthropic(request: AnthropicMessagesRequest) ->
         >>> request.thinking = {"type": "enabled", "budget_tokens": 8000}
         >>> extract_thinking_config_from_anthropic(request)
         ThinkingConfig(enabled=True, budget_tokens=8000)
+
+        >>> # Adaptive effort translated to gateway fake thinking budget
+        >>> request.thinking = {"type": "adaptive", "effort": "max"}
+        >>> extract_thinking_config_from_anthropic(request)
+        ThinkingConfig(enabled=True, budget_tokens=4096)
     """
     if not request.thinking:
         # No thinking specified → use defaults
@@ -422,6 +430,31 @@ def extract_thinking_config_from_anthropic(request: AnthropicMessagesRequest) ->
             logger.debug(f"Extracted thinking config from Anthropic: type='enabled', budget={budget}")
         return ThinkingConfig(enabled=True, budget_tokens=budget)
     
+    if thinking_type == "adaptive":
+        effort = request.thinking.get("effort")
+        if not effort:
+            logger.debug("Extracted adaptive thinking config from Anthropic without effort")
+            return ThinkingConfig(enabled=True, budget_tokens=None)
+
+        if effort == "none":
+            logger.debug("Extracted adaptive thinking config from Anthropic: effort='none'")
+            return ThinkingConfig(enabled=False, budget_tokens=None)
+
+        try:
+            budget = reasoning_effort_to_budget(request.max_tokens, effort)
+        except ValueError:
+            logger.warning(
+                f"Unsupported Anthropic adaptive thinking effort '{effort}'. "
+                "Using default fake thinking budget."
+            )
+            return ThinkingConfig(enabled=True, budget_tokens=None)
+
+        logger.debug(
+            f"Extracted adaptive thinking config from Anthropic: effort='{effort}', "
+            f"max_tokens={request.max_tokens}, budget={budget}"
+        )
+        return ThinkingConfig(enabled=True, budget_tokens=budget)
+
     # Unknown type → use defaults
     return ThinkingConfig(enabled=True, budget_tokens=None)
 
@@ -466,12 +499,24 @@ def anthropic_to_kiro(
 
     # Extract thinking configuration from thinking parameter
     thinking_config = extract_thinking_config_from_anthropic(request)
+    native_effort: Optional[str] = None
+    native_display: Optional[str] = None
+    if isinstance(request.thinking, dict) and request.thinking.get("type") == "adaptive":
+        native_effort = request.thinking.get("effort") or "high"
+        native_display = request.thinking.get("display")
+    native_thinking_config = build_native_thinking_config(model_id, native_effort)
+    if native_display in ("summarized", "omitted"):
+        native_thinking_config.display = native_display
+    if native_thinking_config.enabled:
+        # Native adaptive thinking supersedes fake tag injection for this request.
+        thinking_config = ThinkingConfig(enabled=False, budget_tokens=None)
 
     logger.debug(
         f"Converting Anthropic request: model={request.model} -> {model_id}, "
         f"messages={len(unified_messages)}, tools={len(unified_tools) if unified_tools else 0}, "
         f"system_prompt_length={len(system_prompt)}, "
-        f"thinking_enabled={thinking_config.enabled}, thinking_budget={thinking_config.budget_tokens}"
+        f"thinking_enabled={thinking_config.enabled}, thinking_budget={thinking_config.budget_tokens}, "
+        f"native_thinking_enabled={native_thinking_config.enabled}, native_effort={native_thinking_config.effort}"
     )
 
     # Use core function to build payload
@@ -483,6 +528,7 @@ def anthropic_to_kiro(
         conversation_id=conversation_id,
         profile_arn=profile_arn,
         thinking_config=thinking_config,
+        native_thinking_config=native_thinking_config,
     )
 
     return result.payload

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -41,6 +41,8 @@ from kiro.config import (
     FAKE_REASONING_ENABLED,
     FAKE_REASONING_MAX_TOKENS,
     FAKE_REASONING_BUDGET_CAP,
+    KIRO_NATIVE_THINKING_DISPLAY,
+    KIRO_NATIVE_THINKING_MODE,
     KIRO_MAX_PAYLOAD_BYTES,
     AUTO_TRIM_PAYLOAD,
 )
@@ -78,6 +80,174 @@ class ThinkingConfig:
     """
     enabled: bool = True
     budget_tokens: Optional[int] = None
+
+
+@dataclass
+class NativeThinkingConfig:
+    """
+    Native Kiro/Claude adaptive thinking configuration.
+
+    Attributes:
+        enabled: Whether to add native adaptive thinking fields.
+        effort: Adaptive thinking effort level.
+        display: Whether upstream should return summarized or omitted thinking text.
+    """
+    enabled: bool = False
+    effort: Optional[str] = None
+    display: str = "summarized"
+
+
+REASONING_EFFORT_BUDGET_RATIOS: Dict[str, float] = {
+    "none": 0.0,      # 0% - thinking disabled by API adapters
+    "minimal": 0.10,  # 10% - minimal reasoning
+    "low": 0.20,      # 20% - quick reasoning
+    "medium": 0.50,   # 50% - balanced reasoning
+    "high": 0.80,     # 80% - deep reasoning
+    "xhigh": 0.95,    # 95% - near-maximum reasoning depth
+    "max": 1.0,       # 100% - maximum reasoning depth
+}
+
+
+NATIVE_THINKING_SUPPORTED_MODELS = (
+    "claude-opus-4.8",
+    "claude-opus-4.7",
+    "claude-opus-4.6",
+    "claude-sonnet-4.6",
+)
+
+
+def reasoning_effort_to_budget(max_tokens: int, effort: str) -> int:
+    """
+    Convert a reasoning effort level to a fake thinking token budget.
+
+    Args:
+        max_tokens: Maximum output tokens for the request.
+        effort: Reasoning effort level.
+
+    Returns:
+        Thinking budget in tokens.
+
+    Raises:
+        ValueError: If the effort level is not supported.
+    """
+    try:
+        ratio = REASONING_EFFORT_BUDGET_RATIOS[effort]
+    except KeyError as exc:
+        supported_efforts = ", ".join(sorted(REASONING_EFFORT_BUDGET_RATIOS))
+        raise ValueError(
+            f"Unsupported reasoning effort '{effort}'. Supported values: {supported_efforts}"
+        ) from exc
+
+    return int(max_tokens * ratio)
+
+
+def supports_native_adaptive_thinking(model_id: str) -> bool:
+    """
+    Check whether a Kiro model is known to support native adaptive thinking.
+
+    Args:
+        model_id: Internal Kiro model ID.
+
+    Returns:
+        True when native adaptive thinking should be attempted.
+    """
+    normalized_model = model_id.lower()
+    return any(model in normalized_model for model in NATIVE_THINKING_SUPPORTED_MODELS)
+
+
+def normalize_native_thinking_effort(effort: Optional[str]) -> Optional[str]:
+    """
+    Normalize client effort values to Claude adaptive thinking effort values.
+
+    Args:
+        effort: Client-provided effort level.
+
+    Returns:
+        Native effort level, or None if the value disables or cannot map to native thinking.
+    """
+    if effort is None:
+        return None
+
+    if effort == "none":
+        return None
+
+    if effort == "minimal":
+        return "low"
+
+    if effort in ("low", "medium", "high", "xhigh", "max"):
+        return effort
+
+    logger.warning(f"Unsupported native thinking effort '{effort}'. Native thinking disabled.")
+    return None
+
+
+def build_native_thinking_config(model_id: str, effort: Optional[str]) -> NativeThinkingConfig:
+    """
+    Build native adaptive thinking configuration from model and client effort.
+
+    Args:
+        model_id: Internal Kiro model ID.
+        effort: Client effort level.
+
+    Returns:
+        NativeThinkingConfig for payload construction.
+    """
+    if KIRO_NATIVE_THINKING_MODE == "off":
+        return NativeThinkingConfig(enabled=False)
+
+    if not supports_native_adaptive_thinking(model_id):
+        return NativeThinkingConfig(enabled=False)
+
+    native_effort = normalize_native_thinking_effort(effort)
+    if native_effort is None:
+        if KIRO_NATIVE_THINKING_MODE != "force":
+            return NativeThinkingConfig(enabled=False)
+        native_effort = "high"
+
+    return NativeThinkingConfig(
+        enabled=True,
+        effort=native_effort,
+        display=KIRO_NATIVE_THINKING_DISPLAY,
+    )
+
+
+def apply_native_thinking_fields(
+    payload: Dict[str, Any],
+    native_thinking_config: Optional[NativeThinkingConfig],
+) -> None:
+    """
+    Add native Kiro/Claude adaptive thinking fields to the payload in-place.
+
+    Args:
+        payload: Kiro API payload.
+        native_thinking_config: Native thinking configuration.
+    """
+    if not native_thinking_config or not native_thinking_config.enabled:
+        return
+
+    payload["thinking"] = {
+        "type": "adaptive",
+        "display": native_thinking_config.display,
+    }
+    payload["output_config"] = {
+        "effort": native_thinking_config.effort or "high",
+    }
+    user_input_message = (
+        payload.get("conversationState", {})
+        .get("currentMessage", {})
+        .get("userInputMessage", {})
+    )
+    user_input_message["thinking"] = {
+        "type": "adaptive",
+        "display": native_thinking_config.display,
+    }
+    user_input_message["outputConfig"] = {
+        "effort": native_thinking_config.effort or "high",
+    }
+    logger.info(
+        f"Native adaptive thinking enabled: effort={payload['output_config']['effort']}, "
+        f"display={payload['thinking']['display']}"
+    )
 
 
 @dataclass
@@ -1409,7 +1579,8 @@ def build_kiro_payload(
     tools: Optional[List[UnifiedTool]],
     conversation_id: str,
     profile_arn: str,
-    thinking_config: ThinkingConfig
+    thinking_config: ThinkingConfig,
+    native_thinking_config: Optional[NativeThinkingConfig] = None,
 ) -> KiroPayloadResult:
     """
     Builds complete payload for Kiro API from unified data.
@@ -1425,6 +1596,7 @@ def build_kiro_payload(
         conversation_id: Unique conversation ID
         profile_arn: AWS CodeWhisperer profile ARN
         thinking_config: Thinking configuration from API adapter
+        native_thinking_config: Native adaptive thinking configuration
     
     Returns:
         KiroPayloadResult with payload and tool documentation
@@ -1575,6 +1747,8 @@ def build_kiro_payload(
             }
         }
     }
+
+    apply_native_thinking_fields(payload, native_thinking_config)
     
     # Add history only if not empty
     if history:

--- a/kiro/converters_openai.py
+++ b/kiro/converters_openai.py
@@ -44,6 +44,8 @@ from kiro.converters_core import (
     UnifiedMessage,
     UnifiedTool,
     ThinkingConfig,
+    build_native_thinking_config,
+    reasoning_effort_to_budget,
     build_kiro_payload as core_build_kiro_payload,
 )
 
@@ -297,44 +299,13 @@ def convert_openai_tools_to_unified(tools: Optional[List[Tool]]) -> Optional[Lis
 # Thinking Configuration Extraction
 # ==================================================================================================
 
-def reasoning_effort_to_budget(max_tokens: int, effort: str) -> int:
-    """
-    Convert reasoning_effort to thinking budget (production-grade mapping).
-    
-    Uses percentage-based approach that adapts to different max_tokens limits.
-    This ensures that thinking budget scales proportionally with the output limit.
-    
-    Args:
-        max_tokens: Maximum output tokens for the request
-        effort: Reasoning effort level ("none", "minimal", "low", "medium", "high", "xhigh")
-    
-    Returns:
-        Thinking budget in tokens
-    
-    Examples:
-        >>> reasoning_effort_to_budget(4096, "high")
-        3276  # 80% of 4096
-        >>> reasoning_effort_to_budget(10000, "medium")
-        5000  # 50% of 10000
-    """
-    percent = {
-        "none": 0.0,      # 0% - thinking disabled (handled separately)
-        "minimal": 0.10,  # 10% - minimal reasoning
-        "low": 0.20,      # 20% - quick reasoning
-        "medium": 0.50,   # 50% - balanced reasoning
-        "high": 0.80,     # 80% - deep reasoning
-        "xhigh": 0.95,    # 95% - maximum reasoning depth
-    }
-    return int(max_tokens * percent[effort])
-
-
 def extract_thinking_config_from_openai(request: ChatCompletionRequest) -> ThinkingConfig:
     """
     Extract thinking configuration from OpenAI request.
     
     Handles reasoning_effort parameter:
     - "none" → disabled (no thinking tags injected)
-    - "minimal", "low", "medium", "high", "xhigh" → enabled with percentage-based budget
+    - "minimal", "low", "medium", "high", "xhigh", "max" → enabled with percentage-based budget
     - None (not specified) → enabled with default budget
     
     Args:
@@ -424,12 +395,17 @@ def build_kiro_payload(
     
     # Extract thinking configuration from reasoning_effort
     thinking_config = extract_thinking_config_from_openai(request_data)
+    native_thinking_config = build_native_thinking_config(model_id, request_data.reasoning_effort)
+    if native_thinking_config.enabled:
+        # Native adaptive thinking supersedes fake tag injection for this request.
+        thinking_config = ThinkingConfig(enabled=False, budget_tokens=None)
     
     logger.debug(
         f"Converting OpenAI request: model={request_data.model} -> {model_id}, "
         f"messages={len(unified_messages)}, tools={len(unified_tools) if unified_tools else 0}, "
         f"system_prompt_length={len(system_prompt)}, "
-        f"thinking_enabled={thinking_config.enabled}, thinking_budget={thinking_config.budget_tokens}"
+        f"thinking_enabled={thinking_config.enabled}, thinking_budget={thinking_config.budget_tokens}, "
+        f"native_thinking_enabled={native_thinking_config.enabled}, native_effort={native_thinking_config.effort}"
     )
     
     # Use core function to build payload
@@ -440,7 +416,8 @@ def build_kiro_payload(
         tools=unified_tools,
         conversation_id=conversation_id,
         profile_arn=profile_arn,
-        thinking_config=thinking_config
+        thinking_config=thinking_config,
+        native_thinking_config=native_thinking_config
     )
     
     return result.payload

--- a/kiro/models_openai.py
+++ b/kiro/models_openai.py
@@ -165,8 +165,8 @@ class ChatCompletionRequest(BaseModel):
     frequency_penalty: Optional[float] = None
     
     # Reasoning (OpenAI reasoning models)
-    # Supports all official reasoning_effort levels from OpenAI API
-    reasoning_effort: Optional[Literal["none", "minimal", "low", "medium", "high", "xhigh"]] = None
+    # Accepts gateway-supported effort levels, including "max" for clients that expose it.
+    reasoning_effort: Optional[Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]] = None
     
     # Tools (function calling)
     tools: Optional[List[Tool]] = None

--- a/kiro/parsers.py
+++ b/kiro/parsers.py
@@ -246,6 +246,8 @@ class AwsEventStreamParser:
         ('{"followupPrompt":', 'followup'),
         ('{"usage":', 'usage'),
         ('{"contextUsagePercentage":', 'context_usage'),
+        ('{"text":', 'thinking'),
+        ('{"signature":', 'thinking_signature'),
     ]
     
     def __init__(self):
@@ -254,6 +256,7 @@ class AwsEventStreamParser:
         self.last_content: Optional[str] = None  # For deduplicating repeating content
         self.current_tool_call: Optional[Dict[str, Any]] = None
         self.tool_calls: List[Dict[str, Any]] = []
+        self.native_thinking_started = False
     
     def feed(self, chunk: bytes) -> List[Dict[str, Any]]:
         """
@@ -328,6 +331,18 @@ class AwsEventStreamParser:
             return {"type": "usage", "data": data.get('usage', 0)}
         elif event_type == 'context_usage':
             return {"type": "context_usage", "data": data.get('contextUsagePercentage', 0)}
+        elif event_type == 'thinking':
+            is_first = not self.native_thinking_started
+            self.native_thinking_started = True
+            return {
+                "type": "thinking",
+                "data": data.get('text', ''),
+                "is_first": is_first,
+                "is_native": True,
+            }
+        elif event_type == 'thinking_signature':
+            self.native_thinking_started = False
+            return {"type": "thinking_signature", "data": data.get('signature', '')}
         
         return None
     
@@ -567,3 +582,4 @@ class AwsEventStreamParser:
         self.last_content = None
         self.current_tool_call = None
         self.tool_calls = []
+        self.native_thinking_started = False

--- a/kiro/streaming_core.py
+++ b/kiro/streaming_core.py
@@ -76,6 +76,7 @@ class KiroEvent:
         context_usage_percentage: Context usage percentage (for context_usage events)
         is_first_thinking_chunk: Whether this is the first thinking chunk
         is_last_thinking_chunk: Whether this is the last thinking chunk
+        is_native_thinking: Whether thinking came from Kiro native reasoning events
     """
     type: str
     content: Optional[str] = None
@@ -85,6 +86,7 @@ class KiroEvent:
     context_usage_percentage: Optional[float] = None
     is_first_thinking_chunk: bool = False
     is_last_thinking_chunk: bool = False
+    is_native_thinking: bool = False
 
 
 @dataclass
@@ -280,6 +282,24 @@ async def _process_chunk(
         
         elif event["type"] == "context_usage":
             yield KiroEvent(type="context_usage", context_usage_percentage=event["data"])
+
+        elif event["type"] == "thinking":
+            if event["data"]:
+                yield KiroEvent(
+                    type="thinking",
+                    thinking_content=event["data"],
+                    is_first_thinking_chunk=event.get("is_first", False),
+                    is_native_thinking=event.get("is_native", False),
+                )
+
+        elif event["type"] == "thinking_signature":
+            logger.debug("Received native thinking signature from Kiro stream")
+            yield KiroEvent(
+                type="thinking",
+                thinking_content="",
+                is_last_thinking_chunk=True,
+                is_native_thinking=True,
+            )
 
 
 # ==================================================================================================

--- a/kiro/streaming_openai.py
+++ b/kiro/streaming_openai.py
@@ -155,13 +155,20 @@ async def stream_kiro_to_openai_internal(
                 
                 yield chunk_text
             
-            elif event.type == "thinking" and event.thinking_content:
+            elif event.type == "thinking" and (event.thinking_content or event.is_last_thinking_chunk):
                 # Accumulate thinking content
-                full_thinking_content += event.thinking_content
+                full_thinking_content += event.thinking_content or ""
                 
                 # Send as reasoning_content or content based on mode
                 if FAKE_REASONING_HANDLING == "as_reasoning_content":
                     delta = {"reasoning_content": event.thinking_content}
+                elif event.is_native_thinking and FAKE_REASONING_HANDLING == "pass":
+                    thinking_text = event.thinking_content or ""
+                    if event.is_first_thinking_chunk:
+                        thinking_text = f"<thinking>{thinking_text}"
+                    if event.is_last_thinking_chunk:
+                        thinking_text = f"{thinking_text}</thinking>"
+                    delta = {"content": thinking_text}
                 else:
                     delta = {"content": event.thinking_content}
                 

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -1813,6 +1813,46 @@ class TestExtractThinkingConfigFromAnthropic:
         assert config.enabled is True
         assert config.budget_tokens is None
     
+    def test_thinking_adaptive_max_effort(self):
+        """
+        What it does: Verifies adaptive thinking with effort="max" uses the full output budget.
+        Purpose: Ensure Anthropic clients can request maximum fake thinking depth.
+        """
+        print("Creating request with thinking={'type': 'adaptive', 'effort': 'max'}...")
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4.8",
+            messages=[AnthropicMessage(role="user", content="test")],
+            max_tokens=4096,
+            thinking={"type": "adaptive", "effort": "max"}
+        )
+
+        print("Extracting thinking config...")
+        config = extract_thinking_config_from_anthropic(request)
+
+        print(f"Comparing: enabled={config.enabled}, budget_tokens={config.budget_tokens}")
+        assert config.enabled is True
+        assert config.budget_tokens == 4096
+
+    def test_thinking_adaptive_invalid_effort_uses_default(self):
+        """
+        What it does: Verifies unknown adaptive effort falls back to the default budget.
+        Purpose: Ensure malformed clients do not crash payload conversion.
+        """
+        print("Creating request with thinking={'type': 'adaptive', 'effort': 'ultra'}...")
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4.8",
+            messages=[AnthropicMessage(role="user", content="test")],
+            max_tokens=4096,
+            thinking={"type": "adaptive", "effort": "ultra"}
+        )
+
+        print("Extracting thinking config...")
+        config = extract_thinking_config_from_anthropic(request)
+
+        print(f"Comparing: enabled={config.enabled}, budget_tokens={config.budget_tokens}")
+        assert config.enabled is True
+        assert config.budget_tokens is None
+
     def test_thinking_disabled(self):
         """
         What it does: Verifies ThinkingConfig(enabled=False) when thinking.type="disabled"
@@ -1884,3 +1924,37 @@ class TestAnthropicToKiroIntegration:
         print(f"Checking for <max_thinking_length>6000</max_thinking_length>...")
         assert "<max_thinking_length>6000</max_thinking_length>" in content
         assert "<thinking_mode>enabled</thinking_mode>" in content
+
+    def test_native_adaptive_thinking_fields_supersede_fake_tags(self, monkeypatch):
+        """
+        What it does: Verifies Anthropic adaptive thinking maps to native Kiro fields.
+        Purpose: Ensure native reasoningContentEvent support works for Anthropic API clients.
+        """
+        print("Enabling native thinking auto mode...")
+        monkeypatch.setattr("kiro.converters_core.KIRO_NATIVE_THINKING_MODE", "auto")
+        monkeypatch.setattr("kiro.converters_core.KIRO_NATIVE_THINKING_DISPLAY", "summarized")
+        monkeypatch.setattr("kiro.converters_core.FAKE_REASONING_ENABLED", True)
+
+        print("Creating adaptive thinking request...")
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4.8",
+            messages=[AnthropicMessage(role="user", content="Test message")],
+            max_tokens=1024,
+            thinking={"type": "adaptive", "effort": "max", "display": "summarized"}
+        )
+
+        print("Calling anthropic_to_kiro...")
+        with patch("kiro.converters_anthropic.get_model_id_for_kiro", return_value="claude-opus-4.8"):
+            payload = anthropic_to_kiro(request, "test-conv-native", "arn:aws:test")
+
+        print("Checking native thinking fields...")
+        assert payload["thinking"] == {"type": "adaptive", "display": "summarized"}
+        assert payload["output_config"] == {"effort": "max"}
+        user_input = payload["conversationState"]["currentMessage"]["userInputMessage"]
+        assert user_input["thinking"] == {"type": "adaptive", "display": "summarized"}
+        assert user_input["outputConfig"] == {"effort": "max"}
+
+        print("Checking fake thinking tags were not injected...")
+        content = user_input["content"]
+        assert not content.startswith("<thinking_mode>enabled</thinking_mode>")
+        assert not content.startswith("<max_thinking_length>")

--- a/tests/unit/test_converters_openai.py
+++ b/tests/unit/test_converters_openai.py
@@ -1686,11 +1686,23 @@ class TestReasoningEffortToBudget:
     def test_xhigh_returns_95_percent(self):
         """
         What it does: Verifies reasoning_effort="xhigh" returns 95%
-        Purpose: Ensure maximum reasoning uses 95% budget
+        Purpose: Ensure near-maximum reasoning uses 95% budget
         """
         print("Testing reasoning_effort='xhigh' with max_tokens=4096...")
         result = reasoning_effort_to_budget(4096, "xhigh")
         expected = int(4096 * 0.95)
+
+        print(f"Comparing: expected={expected}, got={result}")
+        assert result == expected
+
+    def test_max_returns_100_percent(self):
+        """
+        What it does: Verifies reasoning_effort="max" returns 100%.
+        Purpose: Ensure maximum reasoning uses the full output budget.
+        """
+        print("Testing reasoning_effort='max' with max_tokens=4096...")
+        result = reasoning_effort_to_budget(4096, "max")
+        expected = 4096
         
         print(f"Comparing: expected={expected}, got={result}")
         assert result == expected
@@ -1797,6 +1809,26 @@ class TestExtractThinkingConfigFromOpenAI:
         assert config.enabled is True
         assert config.budget_tokens == expected_budget
     
+    def test_reasoning_effort_max(self):
+        """
+        What it does: Verifies correct budget calculation for reasoning_effort="max".
+        Purpose: Ensure max effort maps to the full output token budget.
+        """
+        print("Creating request with reasoning_effort='max', max_tokens=4096...")
+        request = ChatCompletionRequest(
+            model="claude-opus-4.8",
+            messages=[ChatMessage(role="user", content="test")],
+            max_tokens=4096,
+            reasoning_effort="max"
+        )
+
+        print("Extracting thinking config...")
+        config = extract_thinking_config_from_openai(request)
+
+        print(f"Comparing: enabled={config.enabled}, budget_tokens={config.budget_tokens}, expected=4096")
+        assert config.enabled is True
+        assert config.budget_tokens == 4096
+
     def test_no_max_tokens_uses_fallback(self):
         """
         What it does: Verifies fallback to 4096 when max_tokens not specified
@@ -1872,3 +1904,39 @@ class TestBuildKiroPayloadIntegration:
         print(f"Checking for <max_thinking_length>{expected_budget}</max_thinking_length>...")
         assert f"<max_thinking_length>{expected_budget}</max_thinking_length>" in content
         assert "<thinking_mode>enabled</thinking_mode>" in content
+    def test_native_thinking_fields_supersede_fake_tags(self, monkeypatch):
+        """
+        What it does: Verifies native thinking mode adds adaptive fields and skips fake tags.
+        Purpose: Ensure Opus 4.8 can use Kiro native reasoningContentEvent streams.
+        """
+        print("Enabling native thinking auto mode...")
+        monkeypatch.setattr("kiro.converters_core.KIRO_NATIVE_THINKING_MODE", "auto")
+        monkeypatch.setattr("kiro.converters_core.KIRO_NATIVE_THINKING_DISPLAY", "summarized")
+        monkeypatch.setattr("kiro.converters_core.FAKE_REASONING_ENABLED", True)
+
+        print("Creating request with reasoning_effort='max'...")
+        request = ChatCompletionRequest(
+            model="claude-opus-4.8",
+            messages=[ChatMessage(role="user", content="Test message")],
+            max_tokens=8000,
+            reasoning_effort="max"
+        )
+
+        print("Calling build_kiro_payload...")
+        payload = build_kiro_payload(
+            request_data=request,
+            conversation_id="test-conv-native",
+            profile_arn="arn:aws:test"
+        )
+
+        print("Checking native thinking fields...")
+        assert payload["thinking"] == {"type": "adaptive", "display": "summarized"}
+        assert payload["output_config"] == {"effort": "max"}
+        user_input = payload["conversationState"]["currentMessage"]["userInputMessage"]
+        assert user_input["thinking"] == {"type": "adaptive", "display": "summarized"}
+        assert user_input["outputConfig"] == {"effort": "max"}
+
+        print("Checking fake thinking tags were not injected...")
+        content = user_input["content"]
+        assert not content.startswith("<thinking_mode>enabled</thinking_mode>")
+        assert not content.startswith("<max_thinking_length>")

--- a/tests/unit/test_models_openai.py
+++ b/tests/unit/test_models_openai.py
@@ -1065,12 +1065,12 @@ class TestReasoningEffort:
     
     def test_reasoning_effort_valid_values(self):
         """
-        What it does: Verifies all 6 reasoning_effort values are accepted
-        Purpose: Ensure Pydantic validates all official OpenAI reasoning_effort levels
+        What it does: Verifies all supported reasoning_effort values are accepted
+        Purpose: Ensure Pydantic validates all gateway-supported reasoning_effort levels
         """
         print("Testing all valid reasoning_effort values...")
         
-        for effort in ["none", "minimal", "low", "medium", "high", "xhigh"]:
+        for effort in ["none", "minimal", "low", "medium", "high", "xhigh", "max"]:
             print(f"  Testing reasoning_effort='{effort}'...")
             request = ChatCompletionRequest(
                 model="claude-sonnet-4.5",

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -496,6 +496,81 @@ class TestAwsEventStreamParserFeed:
         assert events[0]["type"] == "context_usage"
         assert events[0]["data"] == 25.5
     
+    def test_parses_native_thinking_event(self, aws_event_parser):
+        """
+        What it does: Tests parsing of native Kiro reasoningContentEvent text payloads.
+        Goal: Ensure native thinking text is surfaced to streaming adapters.
+        """
+        print("Setup: Chunk with native thinking text...")
+        chunk = b'{"text":"Let me reason about this."}'
+
+        print("Action: Parsing chunk...")
+        events = aws_event_parser.feed(chunk)
+
+        print(f"Result: {events}")
+        assert len(events) == 1
+        assert events[0]["type"] == "thinking"
+        assert events[0]["data"] == "Let me reason about this."
+        assert events[0]["is_first"] is True
+        assert events[0]["is_native"] is True
+
+    def test_native_thinking_subsequent_chunk_is_not_first(self, aws_event_parser):
+        """
+        What it does: Tests first-chunk tracking across native thinking chunks.
+        Goal: Ensure only the first native thinking chunk opens a visible thinking block.
+        """
+        print("Setup: Two native thinking chunks without a signature between them...")
+
+        print("Action: Parsing first thinking chunk...")
+        first_events = aws_event_parser.feed(b'{"text":"First sequence"}')
+
+        print("Action: Parsing second thinking chunk...")
+        second_events = aws_event_parser.feed(b'{"text":"Second sequence"}')
+
+        print(f"First result: {first_events}")
+        print(f"Second result: {second_events}")
+        assert first_events[0]["is_first"] is True
+        assert second_events[0]["is_first"] is False
+
+    def test_parses_native_thinking_signature_event(self, aws_event_parser):
+        """
+        What it does: Tests parsing of native Kiro reasoningContentEvent signature payloads.
+        Goal: Ensure signature frames are recognized separately from visible text.
+        """
+        print("Setup: Chunk with native thinking signature...")
+        chunk = b'{"signature":"opaque-signature"}'
+
+        print("Action: Parsing chunk...")
+        events = aws_event_parser.feed(chunk)
+
+        print(f"Result: {events}")
+        assert len(events) == 1
+        assert events[0]["type"] == "thinking_signature"
+        assert events[0]["data"] == "opaque-signature"
+
+    def test_native_thinking_signature_resets_first_chunk_state(self, aws_event_parser):
+        """
+        What it does: Tests signature handling resets native thinking sequence state.
+        Goal: Ensure the next native thinking sequence opens a fresh visible thinking block.
+        """
+        print("Setup: Native thinking chunk, signature, then another thinking chunk...")
+
+        print("Action: Parsing first thinking sequence...")
+        first_events = aws_event_parser.feed(b'{"text":"First sequence"}')
+
+        print("Action: Parsing signature...")
+        signature_events = aws_event_parser.feed(b'{"signature":"sig1"}')
+
+        print("Action: Parsing second thinking sequence...")
+        second_events = aws_event_parser.feed(b'{"text":"Second sequence"}')
+
+        print(f"First result: {first_events}")
+        print(f"Signature result: {signature_events}")
+        print(f"Second result: {second_events}")
+        assert first_events[0]["is_first"] is True
+        assert signature_events[0]["type"] == "thinking_signature"
+        assert second_events[0]["is_first"] is True
+
     def test_handles_incomplete_json(self, aws_event_parser):
         """
         What it does: Tests handling of incomplete JSON.
@@ -656,6 +731,7 @@ class TestAwsEventStreamParserReset:
         print("Setup: Filling parser with data...")
         aws_event_parser.feed(b'{"content":"test"}')
         aws_event_parser.feed(b'{"name":"func","toolUseId":"call_1"}')
+        aws_event_parser.feed(b'{"text":"native thinking"}')
         
         print("Action: Resetting parser...")
         aws_event_parser.reset()
@@ -665,6 +741,7 @@ class TestAwsEventStreamParserReset:
         assert aws_event_parser.last_content is None
         assert aws_event_parser.current_tool_call is None
         assert aws_event_parser.tool_calls == []
+        assert aws_event_parser.native_thinking_started is False
 
 
 class TestAwsEventStreamParserFinalizeToolCall:

--- a/tests/unit/test_streaming_openai.py
+++ b/tests/unit/test_streaming_openai.py
@@ -458,6 +458,56 @@ class TestStreamingOpenaiThinkingContent:
         assert len(content_chunks) >= 1
         print("✓ Thinking yielded as content")
 
+    @pytest.mark.asyncio
+    async def test_yields_native_thinking_with_visible_tags_in_pass_mode(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        """
+        What it does: Wraps native Kiro thinking chunks in visible tags for pass mode.
+        Goal: Ensure OpenCode-compatible streams visibly separate reasoning from answers.
+        """
+        print("Setup: Mock stream with native thinking content...")
+
+        async def mock_parse_kiro_stream(*args, **kwargs):
+            yield KiroEvent(
+                type="thinking",
+                thinking_content="Let me think",
+                is_first_thinking_chunk=True,
+                is_native_thinking=True,
+            )
+            yield KiroEvent(
+                type="thinking",
+                thinking_content=" through it.",
+                is_native_thinking=True,
+            )
+            yield KiroEvent(
+                type="thinking",
+                thinking_content="",
+                is_last_thinking_chunk=True,
+                is_native_thinking=True,
+            )
+            yield KiroEvent(type="content", content="Here is my answer")
+
+        print("Action: Streaming native thinking to OpenAI content in pass mode...")
+        chunks = []
+
+        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
+            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+                with patch('kiro.streaming_openai.FAKE_REASONING_HANDLING', 'pass'):
+                    async for chunk in stream_kiro_to_openai(
+                        mock_http_client, mock_response, "claude-opus-4.8",
+                        mock_model_cache, mock_auth_manager
+                    ):
+                        chunks.append(chunk)
+
+        joined_chunks = "".join(chunks)
+        print(f"Received {len(chunks)} chunks")
+
+        assert "<thinking>" in joined_chunks
+        assert "Let me think" in joined_chunks
+        assert "</thinking>" in joined_chunks
+        print("✓ Native thinking yielded as visible tagged content")
+
 
 # ==================================================================================================
 # Tests for None protection in tool calls


### PR DESCRIPTION
## Summary

This PR adds opt-in support for Claude/Kiro native adaptive thinking while preserving the existing fake-reasoning behavior by default.

It also extends OpenAI-compatible `reasoning_effort` handling to accept `max`, so clients can request Claude’s maximum native adaptive thinking effort through the gateway.

## What Changed

- Added `reasoning_effort="max"` to the OpenAI-compatible request schema.
- Moved reasoning-effort budget mapping into shared converter logic.
- Added experimental native adaptive thinking config:
  - `KIRO_NATIVE_THINKING_MODE=off|auto|force`
  - `KIRO_NATIVE_THINKING_DISPLAY=summarized|omitted`
- When native mode is enabled for supported models, the gateway sends Kiro/Claude native thinking fields:
  - `thinking: { type: "adaptive", display: "summarized" }`
  - `output_config: { effort: "max" }`
- Native thinking is feature-flagged and defaults to `off`, preserving current behavior.
- Added parser support for Kiro `reasoningContentEvent` frames, including text and signature events.
- Streams native reasoning through existing OpenAI/Anthropic response paths:
  - OpenAI: `reasoning_content` in semantic mode.
  - Visible tagged content in `pass` mode for clients that do not render `reasoning_content`.
  - Anthropic: native-style thinking blocks through the existing thinking response path.
- Added parser state handling so native thinking sequences open/close correctly across signature boundaries.
- Updated `.gitignore` to keep local compose overrides and local agent skill files out of commits.

## Why

Claude Opus 4.8 supports adaptive thinking, but the gateway previously only exposed fake prompt-tag reasoning. That meant clients could request higher effort levels, but the request did not activate Kiro’s native reasoning stream.

This change keeps fake reasoning available, but adds an opt-in native path for models that support adaptive thinking.

## Compatibility

The native thinking mode is intentionally disabled by default:

```bash
KIRO_NATIVE_THINKING_MODE=off
```

To enable it only when clients explicitly request effort:

```bash
KIRO_NATIVE_THINKING_MODE=auto
KIRO_NATIVE_THINKING_DISPLAY=summarized
```

To force native thinking for supported models even without a client effort value:

```bash
KIRO_NATIVE_THINKING_MODE=force
```

Existing fake reasoning env vars continue to work.

## Validation

- `python -m pytest -q`
  - `1702 passed`
- Live Kiro/Gateway probe confirmed `reasoning_effort=max` sends:
  - `thinking.type=adaptive`
  - `thinking.display=summarized`
  - `output_config.effort=max`
- Live low-vs-max probe on the same prompt:
  - `low`: 65 reasoning events, 648 reasoning chars
  - `max`: 97 reasoning events, 1006 reasoning chars
- Local CodeRabbit CLI review was run against the upstream base commit.
  - It found one minor issue around native thinking close events with empty content.
  - The issue was fixed.
  - Follow-up local CodeRabbit review of the fix returned `findings: 0`.
- TruffleHog scan on the final commit range:
  - `verified_secrets: 0`
  - `unverified_secrets: 0`

## Notes

Kiro’s native thinking fields are not publicly documented for the private `generateAssistantResponse` endpoint. They were validated with live upstream probes against the runtime API. For that reason, this PR keeps the native path behind explicit environment flags.