### PR TITLE
fix(models): accept inline 'system' role in Anthropic messages

### DIFF
--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -183,11 +183,16 @@ class AnthropicMessage(BaseModel):
     Message in Anthropic format.
 
     Attributes:
-        role: Message role (user or assistant)
+        role: Message role. Anthropic spec only defines 'user' and 'assistant'
+            for messages (system is a top-level field), but some clients
+            (notably Claude Code on certain model ids) emit inline 'system'
+            messages. We accept it here and rely on
+            ``normalize_message_roles`` in the conversion pipeline to collapse
+            it to 'user' before reaching upstream Kiro.
         content: Message content (string or list of content blocks)
     """
 
-    role: Literal["user", "assistant"]
+    role: Literal["user", "assistant", "system"]
     content: Union[str, List[ContentBlock]]
 
     model_config = {"extra": "allow"}

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -1471,6 +1471,42 @@ class TestAnthropicToKiro:
         assert "userInputMessage" in result["conversationState"]["currentMessage"]
         assert result["profileArn"] == "arn:aws:test"
 
+    def test_inline_system_role_is_normalized_to_user(self):
+        """
+        What it does: Verifies that an inline 'system' role in messages is
+        accepted and normalized to 'user' downstream.
+        Purpose: Some clients (e.g., Claude Code on certain model ids) emit
+        a 'system' message inline rather than using the top-level system
+        field. The schema accepts it; normalize_message_roles collapses it
+        to 'user' so the upstream Kiro payload only contains user/assistant.
+        """
+        print("Setup: Request with inline system message between user turns...")
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4-8",
+            messages=[
+                AnthropicMessage(role="user", content="hello"),
+                AnthropicMessage(role="system", content="<reminder>be concise</reminder>"),
+                AnthropicMessage(role="user", content="ok thanks"),
+            ],
+            max_tokens=1024,
+        )
+
+        print("Action: Converting to Kiro payload...")
+        with patch(
+            "kiro.converters_anthropic.get_model_id_for_kiro",
+            return_value="claude-opus-4.8",
+        ):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
+                result = anthropic_to_kiro(request, "conv-123", "arn:aws:test")
+
+        print(f"Result: {result}")
+        history = result["conversationState"].get("history", [])
+        print(f"History entries: {len(history)}")
+        for entry in history:
+            assert "userInputMessage" in entry or "assistantResponseMessage" in entry, (
+                f"Unexpected history entry shape: {entry}"
+            )
+
     def test_includes_system_prompt(self):
         """
         What it does: Verifies that system prompt is included.

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -525,6 +525,41 @@ class TestAnthropicMessageWithImages:
 
 
 # ==================================================================================================
+# Tests for AnthropicMessage role validation
+# ==================================================================================================
+
+class TestAnthropicMessageRole:
+    """
+    Tests for AnthropicMessage role acceptance.
+
+    Anthropic spec only defines 'user' and 'assistant' for inline messages
+    (system is a top-level field on the request). Some clients (notably
+    Claude Code on certain model ids) emit 'system' inline; we accept it at
+    the schema layer and rely on normalize_message_roles in the conversion
+    pipeline to collapse it to 'user'.
+    """
+
+    def test_accepts_user_role(self):
+        message = AnthropicMessage(role="user", content="hi")
+        assert message.role == "user"
+
+    def test_accepts_assistant_role(self):
+        message = AnthropicMessage(role="assistant", content="hi")
+        assert message.role == "assistant"
+
+    def test_accepts_system_role(self):
+        """Client-compat: inline 'system' role must validate; normalization happens downstream."""
+        message = AnthropicMessage(role="system", content="some reminder text")
+        assert message.role == "system"
+        assert message.content == "some reminder text"
+
+    def test_rejects_unknown_role(self):
+        """Roles outside {user, assistant, system} still fail fast at the boundary."""
+        with pytest.raises(ValidationError):
+            AnthropicMessage(role="developer", content="hi")
+
+
+# ==================================================================================================
 # Tests for AnthropicMessagesRequest with Image Content
 # ==================================================================================================
 


### PR DESCRIPTION
## Summary
- Widens `AnthropicMessage.role` from `Literal["user", "assistant"]` to `Literal["user", "assistant", "system"]` so inline `system` messages reach the existing `normalize_message_roles` pipeline (#64) instead of 422'ing at Pydantic validation.
- Aligns the Anthropic input path with the OpenAI input path, which already accepts and normalizes `system` via the same shared core.
- Adds 4 model-level tests (`TestAnthropicMessageRole`) and 1 end-to-end converter test (`test_inline_system_role_is_normalized_to_user`).

## Why
Claude Code on certain model ids (observed reliably with `claude-opus-4-8`, including the `[1m]` context-window variant) serializes inline `system` messages instead of using the top-level `system` field. The strict `Literal["user", "assistant"]` rejected these at the boundary with HTTP 422 before the existing recovery logic in `converters_core.py:1204` could collapse the role to `user`.

The Anthropic spec defines `system` as a top-level field, not a valid message role - so the strict literal was spec-correct in isolation. But the gateway's role as a transparent proxy is to handle real client behavior, and the conversion pipeline already has full plumbing to do this for the OpenAI input path. This change makes the two input paths symmetric: the same `normalize_message_roles` (added in #64) and `ensure_alternating_roles` already process the unified-format messages downstream regardless of input shape.

Same model/prompt that 422'd before now flows through cleanly. `claude-opus-4-7` traffic and other paths remain unchanged.

## Test plan
- [x] `pytest tests/unit/test_models_anthropic.py::TestAnthropicMessageRole` - 4/4 pass (user/assistant/system accepted, unknown roles like `developer` still fail fast)
- [x] `pytest tests/unit/test_converters_anthropic.py::TestAnthropicToKiro::test_inline_system_role_is_normalized_to_user` - passes; verifies the resulting Kiro payload's history contains only `userInputMessage`/`assistantResponseMessage` entries
- [x] Regression: `pytest tests/unit/test_models_anthropic.py tests/unit/test_converters_anthropic.py tests/unit/test_converters_core.py tests/unit/test_routes_anthropic.py` - 532/532 pass
- [x] Live verification: 19+ `claude-opus-4-8` requests in journal post-change, all 200; mixed with `4-7` traffic, both work

(Replaces #194 - that branch was inadvertently based on a fork's main with unrelated sync commits. This branch is cherry-picked onto a clean `upstream/main`.)