### PR TITLE
fix(anthropic): accept inline system role and merge into system prompt

### DIFF
--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -435,7 +435,7 @@ def anthropic_to_kiro(
     This is the main entry point for Anthropic → Kiro conversion.
 
     Key differences from OpenAI:
-    - System prompt is a separate field (not in messages)
+    - System prompt is a separate field; inline system messages are merged into it
     - Content can be string or list of content blocks
     - Tool format uses input_schema instead of parameters
 
@@ -450,15 +450,34 @@ def anthropic_to_kiro(
     Raises:
         ValueError: If there are no messages to send
     """
-    # Convert messages to unified format
-    unified_messages = convert_anthropic_messages(request.messages)
+    # Separate inline system messages from conversation turns
+    inline_system_parts: List[str] = []
+    conversation_messages: List[AnthropicMessage] = []
+    for msg in request.messages:
+        if msg.role == "system":
+            inline_system_parts.append(convert_anthropic_content_to_text(msg.content))
+        else:
+            conversation_messages.append(msg)
+
+    if inline_system_parts:
+        logger.debug(
+            f"Merged {len(inline_system_parts)} inline system message(s) into system prompt"
+        )
+
+    # Convert conversation messages to unified format
+    unified_messages = convert_anthropic_messages(conversation_messages)
 
     # Convert tools to unified format
     unified_tools = convert_anthropic_tools(request.tools)
 
-    # System prompt is already separate in Anthropic format!
-    # It can be a string or list of content blocks (for prompt caching)
+    # System prompt from top-level field, then append inline system messages
     system_prompt = extract_system_prompt(request.system)
+    if inline_system_parts:
+        inline_system_text = "\n\n".join(inline_system_parts)
+        if system_prompt:
+            system_prompt = f"{system_prompt}\n\n{inline_system_text}"
+        else:
+            system_prompt = inline_system_text
 
     # Get model ID for Kiro API (normalizes + resolves hidden models)
     # Pass-through principle: we normalize and send to Kiro, Kiro decides if valid

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -183,11 +183,11 @@ class AnthropicMessage(BaseModel):
     Message in Anthropic format.
 
     Attributes:
-        role: Message role (user or assistant)
+        role: Message role (user, assistant, or inline system)
         content: Message content (string or list of content blocks)
     """
 
-    role: Literal["user", "assistant"]
+    role: Literal["user", "assistant", "system"]
     content: Union[str, List[ContentBlock]]
 
     model_config = {"extra": "allow"}

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -1499,6 +1499,71 @@ class TestAnthropicToKiro:
         print(f"Current content: {current_content}")
         assert "You are a helpful assistant." in current_content
 
+    def test_merges_inline_system_message_into_system_prompt(self):
+        """
+        What it does: Verifies inline system messages are merged into system prompt.
+        Purpose: Ensure system role messages do not appear as conversation turns.
+        """
+        print("Setup: Request with inline system message...")
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-4-5",
+            messages=[
+                AnthropicMessage(role="user", content="Hello!"),
+                AnthropicMessage(role="system", content="Session hook context"),
+            ],
+            max_tokens=1024,
+        )
+
+        print("Action: Converting to Kiro payload...")
+        with patch(
+            "kiro.converters_anthropic.get_model_id_for_kiro",
+            return_value="claude-sonnet-4.5",
+        ):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
+                result = anthropic_to_kiro(request, "conv-123", "arn:aws:test")
+
+        print(f"Result: {result}")
+        current_content = result["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]["content"]
+        history = result["conversationState"].get("history", [])
+
+        assert "Session hook context" in current_content
+        assert history == []
+
+    def test_merges_top_level_and_inline_system_prompts_in_order(self):
+        """
+        What it does: Verifies top-level system precedes inline system messages.
+        Purpose: Preserve Claude Code system prompt ordering.
+        """
+        print("Setup: Request with top-level and inline system prompts...")
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-4-5",
+            messages=[
+                AnthropicMessage(role="user", content="Hello!"),
+                AnthropicMessage(role="system", content="Inline system context"),
+            ],
+            max_tokens=1024,
+            system="Top-level system prompt",
+        )
+
+        print("Action: Converting to Kiro payload...")
+        with patch(
+            "kiro.converters_anthropic.get_model_id_for_kiro",
+            return_value="claude-sonnet-4.5",
+        ):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
+                result = anthropic_to_kiro(request, "conv-123", "arn:aws:test")
+
+        current_content = result["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]["content"]
+        top_level_index = current_content.index("Top-level system prompt")
+        inline_index = current_content.index("Inline system context")
+
+        assert top_level_index < inline_index
+        assert "Hello!" in current_content
+
     def test_includes_tools(self):
         """
         What it does: Verifies that tools are included in payload.

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -340,7 +340,7 @@ class TestMessagesValidation:
     def test_validates_invalid_role(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies invalid message role is rejected.
-        Purpose: Anthropic model strictly validates role (only 'user' or 'assistant').
+        Purpose: Anthropic model validates role (user, assistant, or system only).
         """
         print("Action: POST /v1/messages with invalid role...")
         response = test_client.post(
@@ -354,8 +354,30 @@ class TestMessagesValidation:
         )
         
         print(f"Status: {response.status_code}")
-        # Anthropic model strictly validates role - only 'user' or 'assistant' allowed
         assert response.status_code == 422
+
+    def test_accepts_system_role_in_messages(self, test_client, valid_proxy_api_key):
+        """
+        What it does: Verifies inline system role in messages is accepted.
+        Purpose: Claude Code sends SessionStart hook context as messages[].role=system.
+        """
+        print("Action: POST /v1/messages with system role in messages...")
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-4-5",
+                "max_tokens": 1024,
+                "system": "You are a helpful assistant.",
+                "messages": [
+                    {"role": "user", "content": "Hello"},
+                    {"role": "system", "content": "Session hook context"},
+                ],
+            }
+        )
+
+        print(f"Status: {response.status_code}")
+        assert response.status_code != 422
     
     def test_accepts_valid_request_format(self, test_client, valid_proxy_api_key):
         """


### PR DESCRIPTION
Fixes #190

Follow-up to the approach discussed in https://github.com/jwadow/kiro-gateway/issues/190#issuecomment-4601707637

## Summary

- Widens `AnthropicMessage.role` to accept `"system"` so Claude Code requests no longer fail Pydantic validation with HTTP 422.
- In `anthropic_to_kiro()`, peels off inline `messages[].role == "system"` entries and merges their text into the top-level `system` prompt (top-level `system` first, inline parts after), then converts only `user` / `assistant` messages.

## Why merge into `system` (not only `normalize_message_roles` → `user`)

For the common Claude Code shape:

```json
[
  {"role": "user", "content": "..."},
  {"role": "system", "content": "<SessionStart / hook context>"}
]
```

normalizing inline `system` to `user` can turn hook context into the current user turn and trigger `ensure_alternating_roles()` placeholders. Merging into `system_prompt` matches the OpenAI path (`role: system` → `system_prompt`, not history) and keeps system instructions separate from user turns.

## Trade-off: prompt caching

Merging changes the serialized prefix vs. client-placed `cache_control` breakpoints, so Anthropic-style prompt cache hits may become misses (cost/latency, not a functional error). The gateway already extracts text only and does not forward `cache_control` to Kiro today. The normalize→`user` approach in #195 also reshapes the request and is not cache-neutral.

## Test plan

- [x] `pytest tests/unit/test_routes_anthropic.py::TestMessagesValidation::test_accepts_system_role_in_messages`
- [x] `pytest tests/unit/test_converters_anthropic.py::TestAnthropicToKiro::test_merges_inline_system_message_into_system_prompt`
- [x] `pytest tests/unit/test_converters_anthropic.py::TestAnthropicToKiro::test_merges_top_level_and_inline_system_prompts_in_order`
- [x] `pytest tests/unit/test_routes_anthropic.py tests/unit/test_converters_anthropic.py` — 158 passed

Made with [Cursor](https://cursor.com)