### PR TITLE
fix: aliases not resolved when building Kiro API payload

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,3 +23,4 @@ These contributors have made significant, sustained contributions to the project
 - [@BoosterY](https://github.com/BoosterY) — SQLite write-back field preservation (#131), regional configuration auto-detection (#132, #133)
 - [@leikaiwei](https://github.com/leikaiwei) — Anthropic token counting fix (#135)
 - [@ramaiyaKushal](https://github.com/ramaiyaKushal) — Missing import fix (#138)
+- [@brandflugan](https://github.com/brandflugan) — fix aliases not resolved when building Kiro API payload (#198)

--- a/kiro/converters_openai.py
+++ b/kiro/converters_openai.py
@@ -35,6 +35,7 @@ from loguru import logger
 
 from kiro.config import HIDDEN_MODELS
 from kiro.model_resolver import get_model_id_for_kiro
+from kiro.config import MODEL_ALIASES
 from kiro.models_openai import ChatMessage, ChatCompletionRequest, Tool
 
 # Import from core - reuse shared logic
@@ -420,7 +421,7 @@ def build_kiro_payload(
     
     # Get model ID for Kiro API (normalizes + resolves hidden models)
     # Pass-through principle: we normalize and send to Kiro, Kiro decides if valid
-    model_id = get_model_id_for_kiro(request_data.model, HIDDEN_MODELS)
+    model_id = get_model_id_for_kiro(request_data.model, HIDDEN_MODELS, MODEL_ALIASES)
     
     # Extract thinking configuration from reasoning_effort
     thinking_config = extract_thinking_config_from_openai(request_data)

--- a/kiro/model_resolver.py
+++ b/kiro/model_resolver.py
@@ -189,7 +189,7 @@ def normalize_model_name(name: str) -> str:
     return name
 
 
-def get_model_id_for_kiro(model_name: str, hidden_models: Dict[str, str]) -> str:
+def get_model_id_for_kiro(model_name: str, hidden_models: Dict[str, str], aliases: Optional[Dict[str, str]] = None) -> str:
     """
     Get the model ID to send to Kiro API.
     
@@ -214,6 +214,9 @@ def get_model_id_for_kiro(model_name: str, hidden_models: Dict[str, str]) -> str
         >>> get_model_id_for_kiro("claude-3-7-sonnet", {"claude-3.7-sonnet": "CLAUDE_3_7_SONNET_20250219_V1_0"})
         'CLAUDE_3_7_SONNET_20250219_V1_0'
     """
+    # Resolve alias first (before normalization)
+    if aliases and model_name in aliases:
+        model_name = aliases[model_name]
     normalized = normalize_model_name(model_name)
     internal = hidden_models.get(normalized, normalized)
     return to_runtime_model_id(internal)

--- a/tests/unit/test_model_resolver.py
+++ b/tests/unit/test_model_resolver.py
@@ -629,6 +629,43 @@ class TestGetModelIdForKiro:
         print(f"Comparing result: Expected 'claude-unknown-model' (pass-through), Got '{result}'")
         assert result == "claude-unknown-model"
 
+    def test_alias_resolves_before_normalization(self):
+        """
+        What it does: Alias is resolved before normalization.
+        Goal: Check that aliases map to target model ID for Kiro API.
+        """
+        aliases = {"claude-opus-4.6-kiro": "claude-opus-4.6"}
+
+        print("Action: get_model_id_for_kiro('claude-opus-4.6-kiro', {}, aliases)...")
+        result = get_model_id_for_kiro("claude-opus-4.6-kiro", {}, aliases)
+
+        print(f"Comparing result: Expected 'claude-opus-4.6', Got '{result}'")
+        assert result == "claude-opus-4.6"
+
+    def test_alias_resolves_then_hidden_model_applied(self):
+        """
+        What it does: Alias resolves first, then hidden model lookup applies.
+        Goal: Check alias → normalize → hidden lookup chain.
+        """
+        aliases = {"my-legacy": "claude-3.7-sonnet"}
+        hidden = {"claude-3.7-sonnet": "CLAUDE_3_7_SONNET_20250219_V1_0"}
+
+        print("Action: get_model_id_for_kiro('my-legacy', hidden, aliases)...")
+        result = get_model_id_for_kiro("my-legacy", hidden, aliases)
+
+        print(f"Comparing result: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0', Got '{result}'")
+        assert result == "CLAUDE_3_7_SONNET_20250219_V1_0"
+
+    def test_no_aliases_behaves_as_before(self):
+        """
+        What it does: Without aliases parameter, behavior is unchanged.
+        Goal: Backward compatibility when aliases not provided.
+        """
+        print("Action: get_model_id_for_kiro('claude-sonnet-4-5', {})...")
+        result = get_model_id_for_kiro("claude-sonnet-4-5", {})
+
+        print(f"Comparing result: Expected 'claude-sonnet-4.5', Got '{result}'")
+        assert result == "claude-sonnet-4.5"
 
 # =============================================================================
 # TestModelResolver - Tests for ModelResolver class


### PR DESCRIPTION
## Fix: Aliases not resolved when building Kiro API payload

### Problem

MODEL_ALIASES were applied during model listing and account routing (ModelResolver.resolve()), but `get_model_id_for_kiro()` — used by `build_kiro_payload()` to determine the actual model ID sent to the Kiro API — did not resolve aliases. This caused aliased model names (e.g. `auto-kiro`) to be sent verbatim to the API, resulting in 400 errors: "Invalid model ID or insufficient subscription level."

### Fix

Added an optional `aliases` parameter to `get_model_id_for_kiro()` that resolves aliases before normalization. Updated `converters_openai.py` to pass `MODEL_ALIASES` to the function.

### Changes

- `kiro/model_resolver.py` — `get_model_id_for_kiro()` now accepts `aliases` dict and resolves before normalizing
- `kiro/converters_openai.py` — passes `MODEL_ALIASES` to `get_model_id_for_kiro()`
- `tests/unit/test_model_resolver.py` — added 3 tests covering alias resolution in payload building

### Tested

- `claude-opus-4.6-kiro` alias correctly resolves to `claude-opus-4.6` in API requests
- Backward compatible — existing behavior unchanged when no aliases provided