### PR TITLE
fix(models): accept non-standard message roles in Anthropic requests

### DIFF
--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -183,11 +183,15 @@ class AnthropicMessage(BaseModel):
     Message in Anthropic format.
 
     Attributes:
-        role: Message role (user or assistant)
+        role: Message role. Officially Anthropic only uses 'user'/'assistant'
+            here, but clients (e.g. Claude Code spawning sub-agents) may inline
+            a 'system' (or other) role into the messages array. We accept any
+            string and let normalize_message_roles() downstream fold unknown
+            roles into 'user', matching the permissive OpenAI-side schema.
         content: Message content (string or list of content blocks)
     """
 
-    role: Literal["user", "assistant"]
+    role: str
     content: Union[str, List[ContentBlock]]
 
     model_config = {"extra": "allow"}

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -1308,6 +1308,30 @@ class TestConvertAnthropicMessages:
         # We verify the images are extracted correctly, which proves the counting works
         print("Images extracted successfully - logging verification complete")
 
+    def test_converts_inlined_system_message(self):
+        """
+        What it does: Verifies a 'system' role message (inlined by Claude Code
+            when spawning sub-agents) is converted to a UnifiedMessage with its
+            role preserved and text extracted.
+        Purpose: Regression for the sub-agent 422 bug. The role is kept as-is
+            here; normalize_message_roles() folds it to 'user' downstream.
+        """
+        print("Setup: Inlined system message...")
+        messages = [
+            AnthropicMessage(role="user", content="task"),
+            AnthropicMessage(role="system", content="You are a sub-agent."),
+        ]
+
+        print("Action: Converting messages...")
+        result = convert_anthropic_messages(messages)
+
+        print(f"Result: {result}")
+        assert len(result) == 2
+        assert result[1].role == "system"
+        assert result[1].content == "You are a sub-agent."
+        assert result[1].tool_calls is None
+        assert result[1].tool_results is None
+
 
 # ==================================================================================================
 # Tests for convert_anthropic_tools

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -525,6 +525,72 @@ class TestAnthropicMessageWithImages:
 
 
 # ==================================================================================================
+# Tests for AnthropicMessage role acceptance (sub-agent "system" role fix)
+# ==================================================================================================
+
+class TestAnthropicMessageRole:
+    """Tests that AnthropicMessage.role accepts roles beyond user/assistant."""
+
+    def test_accepts_user_role(self):
+        """
+        What it does: Verifies AnthropicMessage still accepts 'user' role.
+        Purpose: Guard against regression in the common case.
+        """
+        message = AnthropicMessage(role="user", content="Hello")
+        assert message.role == "user"
+
+    def test_accepts_assistant_role(self):
+        """
+        What it does: Verifies AnthropicMessage still accepts 'assistant' role.
+        Purpose: Guard against regression in the common case.
+        """
+        message = AnthropicMessage(role="assistant", content="Hi")
+        assert message.role == "assistant"
+
+    def test_accepts_system_role_inlined_in_messages(self):
+        """
+        What it does: Verifies AnthropicMessage accepts a 'system' role.
+        Purpose: Claude Code inlines a 'system' message into the messages
+            array when spawning sub-agents. The schema must not reject it
+            with a 422; normalize_message_roles() folds it to 'user' later.
+        """
+        print("Setup: Creating AnthropicMessage with system role...")
+        message = AnthropicMessage(role="system", content="You are a sub-agent.")
+
+        print(f"Comparing role: Expected 'system', Got '{message.role}'")
+        assert message.role == "system"
+        assert message.content == "You are a sub-agent."
+
+    def test_accepts_developer_role(self):
+        """
+        What it does: Verifies AnthropicMessage accepts a 'developer' role.
+        Purpose: Forward compatibility with other non-standard roles that
+            downstream normalization already handles.
+        """
+        message = AnthropicMessage(role="developer", content="ctx")
+        assert message.role == "developer"
+
+    def test_request_with_inlined_system_message_validates(self):
+        """
+        What it does: Verifies a full request with a 'system' message in the
+            messages array validates (the exact shape that triggered the 422).
+        Purpose: End-to-end schema regression for the sub-agent 422 bug.
+        """
+        print("Setup: Building request with an inlined system message...")
+        request = AnthropicMessagesRequest(
+            model="claude-haiku-4.5",
+            max_tokens=1024,
+            messages=[
+                AnthropicMessage(role="user", content="task"),
+                AnthropicMessage(role="system", content="system reminder"),
+            ],
+        )
+
+        print(f"Result: {len(request.messages)} messages")
+        assert request.messages[1].role == "system"
+
+
+# ==================================================================================================
 # Tests for AnthropicMessagesRequest with Image Content
 # ==================================================================================================
 

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -337,25 +337,31 @@ class TestMessagesValidation:
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
     
-    def test_validates_invalid_role(self, test_client, valid_proxy_api_key):
+    def test_accepts_nonstandard_role(self, test_client, valid_proxy_api_key):
         """
-        What it does: Verifies invalid message role is rejected.
-        Purpose: Anthropic model strictly validates role (only 'user' or 'assistant').
+        What it does: Verifies a non-standard message role is NOT rejected.
+        Purpose: Claude Code inlines a 'system' role into the messages array
+            when spawning sub-agents. The gateway must accept any role string
+            (not 422) and fold unknown roles to 'user' downstream via
+            normalize_message_roles(). Regression for the sub-agent 422 bug.
         """
-        print("Action: POST /v1/messages with invalid role...")
+        print("Action: POST /v1/messages with a non-standard role...")
         response = test_client.post(
             "/v1/messages",
             headers={"x-api-key": valid_proxy_api_key},
             json={
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
-                "messages": [{"role": "invalid_role", "content": "Hello"}]
+                "messages": [
+                    {"role": "user", "content": "Hello"},
+                    {"role": "system", "content": "You are a sub-agent."},
+                ]
             }
         )
-        
+
         print(f"Status: {response.status_code}")
-        # Anthropic model strictly validates role - only 'user' or 'assistant' allowed
-        assert response.status_code == 422
+        # Schema must accept the request; it must not fail validation with 422
+        assert response.status_code != 422
     
     def test_accepts_valid_request_format(self, test_client, valid_proxy_api_key):
         """


### PR DESCRIPTION
## Problem

Some clients inline a `system` (or other non-standard) role into the `messages` array of an Anthropic `/v1/messages` request, instead of only using the top-level `system` field. A common case is tooling that spawns sub-agents and reuses the messages array to carry a system reminder.

The gateway rejected every such request with a `422` **before** it reached the converter, because the Pydantic schema pinned the role to a strict literal:

```python
class AnthropicMessage(BaseModel):
    role: Literal["user", "assistant"]
```

Observed error:

```
Validation error (422): [{'type': 'literal_error',
  'loc': ['body', 'messages', 1, 'role'],
  'msg': "Input should be 'user' or 'assistant'",
  'input': 'system', ...}]
```

This is surprising because the gateway already knows how to handle these roles further down the pipeline — the request just never got there.

## Fix

Relax `AnthropicMessage.role` from `Literal["user", "assistant"]` to a plain `str`, matching the already-permissive OpenAI-side schema (`role: str`).

No converter changes are needed. The downstream pipeline in `converters_core.py` already normalizes non-standard roles:

- `normalize_message_roles()` folds any unknown role (e.g. `system`, `developer`) into `user`.
- `ensure_alternating_roles()` then inserts synthetic assistant turns so the Kiro API's alternating user/assistant requirement is preserved.

So the only thing standing in the way was the input schema rejecting the request too early.

## Tests

- Added `TestAnthropicMessageRole` in `test_models_anthropic.py` covering `user`, `assistant`, `system`, `developer`, and a full request with an inlined `system` message.
- Added `test_converts_inlined_system_message` in `test_converters_anthropic.py` verifying the `system` message is converted to a `UnifiedMessage` with role/text preserved (normalization to `user` happens later in the pipeline).
- Updated the route-level test (`test_validates_invalid_role` → `test_accepts_nonstandard_role`) to assert that a non-standard role is **not** rejected with `422`.

Full suite passes: **1697 passed**.