### PR TITLE
fix(docker): isolate gateway token lifecycle from host kiro-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
-# Create non-root user for security
-RUN groupadd -r kiro && useradd -r -g kiro kiro
+# Create non-root user for security (UID 1000 to match typical host user for volume permissions)
+RUN groupadd -g 1000 kiro && useradd -u 1000 -g 1000 kiro
 
 # Set working directory and give ownership to kiro user
 WORKDIR /app
@@ -30,6 +30,9 @@ RUN rm -f credentials.json state.json
 # Create directory for debug logs with proper permissions
 RUN mkdir -p debug_logs && chown -R kiro:kiro debug_logs
 
+# Create writable directory for the gateway's own copy of the kiro-cli database
+RUN mkdir -p /home/kiro/.local/share/kiro-cli && chown -R kiro:kiro /home/kiro
+
 # Switch to non-root user
 USER kiro
 
@@ -40,6 +43,9 @@ EXPOSE 8000
 # Using httpx (our main HTTP library) instead of requests
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import httpx; httpx.get('http://localhost:8000/health', timeout=5)"
+
+# Entrypoint copies seed database then runs CMD
+ENTRYPOINT ["./entrypoint.sh"]
 
 # Run the application
 CMD ["python", "main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,9 +47,8 @@ services:
       # Uncomment and adjust path as needed:
       # - ~/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro
       
-      # Mount kiro-cli database (if using KIRO_CLI_DB_FILE)
-      # Uncomment and adjust path as needed:
-      # - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Linux/macOS
+      # Mount kiro-cli database as read-only seed (copied into container at startup by entrypoint.sh)
+      - ~/.local/share/kiro-cli:/mnt/kiro-cli-seed:ro
       
       # Mount debug logs directory (optional, for debugging)
       - ./debug_logs:/app/debug_logs

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Copy the mounted (read-only) kiro-cli database to a local writable path
+# so the gateway has its own independent token lifecycle.
+
+SRC="/mnt/kiro-cli-seed/data.sqlite3"
+DEST_DIR="/home/kiro/.local/share/kiro-cli"
+DEST="$DEST_DIR/data.sqlite3"
+
+if [ -f "$SRC" ]; then
+    mkdir -p "$DEST_DIR"
+    cp "$SRC" "$DEST"
+    echo "Copied seed database to $DEST"
+fi
+
+exec "$@"


### PR DESCRIPTION
The upstream SQLite mount causes a token refresh race condition when kiro-cli is active on the host — both processes invalidate each other's tokens, resulting in infinite 403 loops and eventual 504s.

Fix by seeding the database at container startup instead of sharing it:
- Add entrypoint.sh that copies the DB from a read-only mount
- Mount host kiro-cli dir at /mnt/kiro-cli-seed:ro (no write needed)
- Set container user UID to 1000 to match host file ownership
- Create writable /home/kiro dir for the gateway's own DB copy

The gateway now manages its own independent token refresh cycle.