### PR TITLE
fix(models): accept unknown message roles for Claude Code compatibility

### DIFF
--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -187,7 +187,7 @@ class AnthropicMessage(BaseModel):
         content: Message content (string or list of content blocks)
     """
 
-    role: Literal["user", "assistant"]
+    role: str  # Accept any role; converter normalizes unknown roles (e.g., 'system') to 'user'
     content: Union[str, List[ContentBlock]]
 
     model_config = {"extra": "allow"}

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -337,25 +337,28 @@ class TestMessagesValidation:
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
     
-    def test_validates_invalid_role(self, test_client, valid_proxy_api_key):
+    def test_normalizes_unknown_role(self, test_client, valid_proxy_api_key):
         """
-        What it does: Verifies invalid message role is rejected.
-        Purpose: Anthropic model strictly validates role (only 'user' or 'assistant').
+        What it does: Verifies unknown message roles are accepted and normalized to 'user'.
+        Purpose: Claude Code and other clients send 'system' role inside messages array.
+        The gateway normalizes unknown roles (e.g., 'system', 'developer') to 'user'
+        instead of rejecting them with 422, maintaining compatibility.
         """
-        print("Action: POST /v1/messages with invalid role...")
+        print("Action: POST /v1/messages with unknown role 'system'...")
         response = test_client.post(
             "/v1/messages",
             headers={"x-api-key": valid_proxy_api_key},
             json={
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
-                "messages": [{"role": "invalid_role", "content": "Hello"}]
+                "messages": [{"role": "system", "content": "You are helpful."},
+                             {"role": "user", "content": "Hello"}]
             }
         )
-        
+
         print(f"Status: {response.status_code}")
-        # Anthropic model strictly validates role - only 'user' or 'assistant' allowed
-        assert response.status_code == 422
+        assert response.status_code != 422, "Unknown roles should pass validation, not be rejected"
+        assert response.status_code < 500, f"Unexpected server error: {response.status_code}"
     
     def test_accepts_valid_request_format(self, test_client, valid_proxy_api_key):
         """


### PR DESCRIPTION
## Summary
- Relaxed `AnthropicMessage.role` validation from `Literal["user", "assistant"]` to `str` to accept unknown roles (e.g., `system`, `developer`)
- The existing `normalize_message_roles()` converter handles normalization to `user` before forwarding to Kiro API
- Updated test to reflect the new behavior and use realistic `system` role scenario

## Context
Claude Code sends `system` role inside the messages array when proxying through the gateway. Previously this was rejected with 422 at the Pydantic validation layer, before the converter had a chance to normalize it.

## Test plan
- [x] `test_normalizes_unknown_role` passes — unknown roles no longer return 422
- [x] Manual test: proxy Claude Code traffic through gateway, verify `system` role messages go through
