### PR TITLE
fix(anthropic): allow and extract system messages inside messages list

### DIFF
--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -450,8 +450,23 @@ def anthropic_to_kiro(
     Raises:
         ValueError: If there are no messages to send
     """
+    # Extract system messages from request messages
+    system_parts = []
+    non_system_messages = []
+    for msg in request.messages:
+        role = getattr(msg, "role", None)
+        content = getattr(msg, "content", None)
+        if isinstance(msg, dict):
+            role = msg.get("role")
+            content = msg.get("content")
+        
+        if role == "system":
+            system_parts.append(convert_anthropic_content_to_text(content))
+        else:
+            non_system_messages.append(msg)
+
     # Convert messages to unified format
-    unified_messages = convert_anthropic_messages(request.messages)
+    unified_messages = convert_anthropic_messages(non_system_messages)
 
     # Convert tools to unified format
     unified_tools = convert_anthropic_tools(request.tools)
@@ -459,6 +474,14 @@ def anthropic_to_kiro(
     # System prompt is already separate in Anthropic format!
     # It can be a string or list of content blocks (for prompt caching)
     system_prompt = extract_system_prompt(request.system)
+
+    # Merge system messages from messages list into the system prompt
+    if system_parts:
+        system_from_messages = "\n".join(system_parts)
+        if system_prompt:
+            system_prompt = f"{system_prompt}\n{system_from_messages}"
+        else:
+            system_prompt = system_from_messages
 
     # Get model ID for Kiro API (normalizes + resolves hidden models)
     # Pass-through principle: we normalize and send to Kiro, Kiro decides if valid

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -183,11 +183,11 @@ class AnthropicMessage(BaseModel):
     Message in Anthropic format.
 
     Attributes:
-        role: Message role (user or assistant)
+        role: Message role (user, assistant, or system)
         content: Message content (string or list of content blocks)
     """
 
-    role: Literal["user", "assistant"]
+    role: Literal["user", "assistant", "system"]
     content: Union[str, List[ContentBlock]]
 
     model_config = {"extra": "allow"}

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -1499,6 +1499,44 @@ class TestAnthropicToKiro:
         print(f"Current content: {current_content}")
         assert "You are a helpful assistant." in current_content
 
+    def test_extracts_system_messages_from_messages_list(self):
+        """
+        What it does: Verifies that system messages within the messages list are extracted and merged.
+        Purpose: Ensure compatibility when client passes system messages inside the messages array.
+        """
+        print("Setup: Request with system message in messages array...")
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-4-5",
+            messages=[
+                AnthropicMessage(role="system", content="System instruction from list."),
+                AnthropicMessage(role="user", content="Hello!")
+            ],
+            max_tokens=1024,
+            system="Top level system instruction.",
+        )
+
+        print("Action: Converting to Kiro payload...")
+        with patch(
+            "kiro.converters_anthropic.get_model_id_for_kiro",
+            return_value="claude-sonnet-4.5",
+        ):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
+                result = anthropic_to_kiro(request, "conv-123", "arn:aws:test")
+
+        print(f"Result: {result}")
+        
+        current_content = result["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]["content"]
+        
+        print(f"Current content: {current_content}")
+        assert "Top level system instruction." in current_content
+        assert "System instruction from list." in current_content
+        
+        # Verify history is empty (the only remaining message is the user one, which is the currentMessage)
+        history = result["conversationState"].get("history", [])
+        assert len(history) == 0
+
     def test_includes_tools(self):
         """
         What it does: Verifies that tools are included in payload.


### PR DESCRIPTION
Some clients/wrappers send system prompts inside the messages array under the system role when targeting /v1/messages. This PR updates the Anthropic schema to accept role: "system", extracts them from the message history list, and merges them directly into the system prompt parameter (matching the existing behavior of the OpenAI converter).


Fixes #219