### PR TITLE
fix: accept system role in AnthropicMessage to support Opus Claude Code

### DIFF
--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -187,7 +187,7 @@ class AnthropicMessage(BaseModel):
         content: Message content (string or list of content blocks)
     """
 
-    role: Literal["user", "assistant"]
+    role: str
     content: Union[str, List[ContentBlock]]
 
     model_config = {"extra": "allow"}


### PR DESCRIPTION
## Problem
Claude Code sends messages with `role: "system"` as part of its 
standard request format. The current Pydantic model restricts role 
to `Literal["user", "assistant"]`, causing a 422 validation error 
on every request.

## Fix
Relaxed the role field from `Literal["user", "assistant"]` to `str` 
to accept all role values including system.

## Tested
- Windows, Claude Code v2.1.167
- Confirmed 422 for Opus error before fix, resolved after