### PR TITLE
fix(mcp): send Kiro client-identity headers on web_search MCP call

### DIFF
--- a/kiro/mcp_tools.py
+++ b/kiro/mcp_tools.py
@@ -41,6 +41,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from loguru import logger
 
 from kiro.tokenizer import count_message_tokens, count_tokens
+from kiro.utils import get_kiro_headers
 
 # Import debug_logger
 try:
@@ -135,7 +136,7 @@ async def call_kiro_mcp_api(
             "arguments": {"query": query}
         }
     }
-    
+
     # Log MCP request
     try:
         mcp_request_json = json.dumps(mcp_request, ensure_ascii=False, indent=2).encode('utf-8')
@@ -146,13 +147,13 @@ async def call_kiro_mcp_api(
     
     try:
         token = await auth_manager.get_access_token()
-        
-        # EXACT headers from architecture
-        headers = {
-            "Authorization": f"Bearer {token}",
-            "x-amzn-codewhisperer-optout": "false",
-            "Content-Type": "application/json"
-        }
+
+        # /mcp requires the same Kiro client-identity headers as the completion
+        # path (else 403); reuse get_kiro_headers and override what differs.
+        headers = get_kiro_headers(auth_manager, token)
+        headers["Content-Type"] = "application/json"  # /mcp is JSON-RPC
+        headers.pop("x-amz-target", None)
+        headers["x-amzn-codewhisperer-optout"] = "false"
         
         mcp_url = f"{auth_manager.q_host}/mcp"
         logger.debug(f"Calling MCP API: {mcp_url}")

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -148,6 +148,51 @@ class TestCallKiroMCPAPI:
         assert results["results"][0]["url"] == "https://python.org"
     
     @pytest.mark.asyncio
+    async def test_mcp_api_sends_kiro_identity_headers(self, mock_auth_manager):
+        """
+        What it does: Verifies the MCP request sends the Kiro client-identity headers.
+        Purpose: Guard against the 403 regression - /mcp rejects a bare Authorization header.
+        """
+        print("Setup: Mocking MCP API response to capture posted headers...")
+        query = "Python tutorials"
+
+        mock_response_data = {
+            "id": "web_search_tooluse_abc123_1234567890_xyz",
+            "jsonrpc": "2.0",
+            "result": {
+                "content": [{
+                    "type": "text",
+                    "text": json.dumps({"results": [], "totalResults": 0, "query": query})
+                }],
+                "isError": False
+            }
+        }
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json = Mock(return_value=mock_response_data)
+
+        mock_post = AsyncMock(return_value=mock_response)
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value.post = mock_post
+
+        print("Action: Calling call_kiro_mcp_api...")
+        with patch("kiro.mcp_tools.httpx.AsyncClient", return_value=mock_client):
+            await call_kiro_mcp_api(query, mock_auth_manager)
+
+        print("Inspecting posted request headers...")
+        assert mock_post.call_count == 1
+        headers = mock_post.call_args.kwargs["headers"]
+
+        print(f"Checking Kiro client-identity headers present...")
+        assert "KiroIDE" in headers["User-Agent"]
+        assert mock_auth_manager.fingerprint in headers["User-Agent"]
+        assert "KiroIDE" in headers["x-amz-user-agent"]
+        assert headers["x-amzn-kiro-agent-mode"] == "vibe"
+        assert "Authorization" in headers
+        assert headers["Authorization"].startswith("Bearer ")
+
+    @pytest.mark.asyncio
     async def test_mcp_api_error_response(self, mock_auth_manager):
         """
         What it does: Verifies handling of MCP API error response.


### PR DESCRIPTION
## Problem

Claude Code's native `web_search` server-side tool, routed through the gateway to `runtime.kiro.dev/mcp`, fails with **403** for IAM Identity Center (AWS SSO OIDC / kiro-cli) accounts, even when MCP is enabled on the profile:

```json
{"message":"User is not authorized to make this call.","reason":null}
```

This 403 is distinct from the `profileArn` **400** issue (#173, addressed by #180/#189/#175). It surfaces only once `profileArn` is present: the request is then authenticated, but the endpoint still declines it.

## Root Cause

`call_kiro_mcp_api()` in `mcp_tools.py` sent only three headers (`Authorization`, `x-amzn-codewhisperer-optout`, `Content-Type`). The completion path (`/generateAssistantResponse`, via `get_kiro_headers` in `utils.py`) sends a full Kiro client-identity set: `User-Agent` with the `KiroIDE-<version>-<fingerprint>` signature, `x-amz-user-agent`, `x-amzn-kiro-agent-mode`, and the `amz-sdk-*` pair.

The `/mcp` endpoint gates authorization on these client-identity signals. A bare `Authorization` header is rejected with 403 even when the account is entitled. Completions work because they send the full identity; MCP did not.

## Fix

Build the MCP headers from the canonical `get_kiro_headers` (single source of truth, shared with the completion path) and override only the three fields that differ for `/mcp`:

- `Content-Type: application/json` — `/mcp` is JSON-RPC, not the `x-amz-json-1.0` completion API
- drop `x-amz-target` — completion-operation-specific, meaningless to `/mcp`
- `x-amzn-codewhisperer-optout: false` — preserves the original MCP value

Reusing `get_kiro_headers` (rather than duplicating the literals) means future `KiroIDE` version bumps flow to the MCP call automatically instead of silently drifting.

## Scope — depends on profileArn contributions

This PR is deliberately surgical: it contains **only** the novel client-identity-headers fix.

A complete `web_search` fix **also requires `profileArn` in the MCP request body** — without it the endpoint returns **400**, before the 403 this PR addresses. That `profileArn` work is **not** included here; it is contributed separately by **#180 / #189 / #175** (and tracked in #173). This change stacks on top of those: once a `profileArn` PR merges, this header fix carries the call the rest of the way past the 403.

Credit to those contributors for the `profileArn` half of the puzzle.

## Testing

- Verified end-to-end: the native `web_search` tool returns live results through the gateway on an enterprise SSO OIDC (kiro-cli) account, where it previously 403'd (with `profileArn` applied locally).
- Added a regression test asserting the MCP request sends the Kiro client-identity headers.
- `tests/unit/test_mcp_tools.py` passes (22 tests).

The header change is additive (sends more identity signal, matching the completion path), so it should not regress auth types that already worked.