### PR TITLE
fix(converters): strip Claude Code 2.1.x billing attribution from sys…

### DIFF
--- a/kiro/config.py
+++ b/kiro/config.py
@@ -343,6 +343,19 @@ TRUNCATION_RECOVERY: bool = os.getenv("TRUNCATION_RECOVERY", "true").lower() in 
 LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO").upper()
 
 # ==================================================================================================
+# Billing Attribution Strip
+# ==================================================================================================
+
+# Claude Code 2.1.x prepends a per-request system text block of the form
+# ``x-anthropic-billing-header: cc_version=...; cc_entrypoint=...; cch=<5hex>;``
+# where ``cch`` is a fresh random hex token. The Kiro gateway concatenates all
+# system text blocks before forwarding, so this random prefix would invalidate
+# any upstream prompt cache keyed on the prompt prefix. When enabled (default),
+# the gateway strips the leading attribution line / block before forwarding.
+# Disable only for A/B comparison or to debug attribution behavior.
+STRIP_BILLING_HEADER: bool = os.getenv("STRIP_BILLING_HEADER", "true").lower() in ("true", "1", "yes")
+
+# ==================================================================================================
 # First Token Timeout Settings (Streaming Retry)
 # ==================================================================================================
 

--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -24,11 +24,12 @@ This module is an adapter layer that converts Anthropic-specific formats
 to the unified format used by converters_core.py.
 """
 
+import re
 from typing import Any, Dict, List, Optional
 
 from loguru import logger
 
-from kiro.config import HIDDEN_MODELS
+from kiro.config import HIDDEN_MODELS, STRIP_BILLING_HEADER
 from kiro.model_resolver import get_model_id_for_kiro
 from kiro.models_anthropic import (
     AnthropicMessagesRequest,
@@ -75,6 +76,32 @@ def convert_anthropic_content_to_text(content: Any) -> str:
     return str(content) if content else ""
 
 
+_BILLING_HEADER_LINE_PATTERN = re.compile(
+    r"^x-anthropic-billing-header:[^\n]*\n?", re.IGNORECASE
+)
+
+
+def _strip_billing_attribution(text: str) -> str:
+    """
+    Remove Claude Code's per-request billing attribution string.
+
+    Claude Code (2.1.x) prepends a line like
+    ``x-anthropic-billing-header: cc_version=...; cc_entrypoint=...; cch=<5hex>;``
+    to the system prompt content. The ``cch`` segment is a fresh random hex per
+    request, which defeats any prompt cache keyed on the prompt prefix on
+    upstreams that do not understand the attribution header.
+
+    The line carries no semantic content for the model and is safe to remove
+    before forwarding to Kiro.
+    """
+    if not text or not STRIP_BILLING_HEADER:
+        return text
+    stripped = _BILLING_HEADER_LINE_PATTERN.sub("", text, count=1)
+    if stripped != text:
+        return stripped.lstrip("\n")
+    return text
+
+
 def extract_system_prompt(system: Any) -> str:
     """
     Extracts system prompt text from Anthropic system field.
@@ -86,6 +113,12 @@ def extract_system_prompt(system: Any) -> str:
     The second format is used for prompt caching with cache_control.
     We extract only the text, ignoring cache_control (not supported by Kiro).
 
+    Claude Code injects a per-request billing attribution block as the first
+    system text block (``x-anthropic-billing-header: ...; cch=<5hex>;``). The
+    random ``cch`` segment changes on every request and would invalidate any
+    upstream prompt cache keyed on the prompt prefix, so we drop attribution
+    blocks (and any attribution prefix on string-form prompts) here.
+
     Args:
         system: System prompt in string or list format
 
@@ -96,18 +129,25 @@ def extract_system_prompt(system: Any) -> str:
         return ""
 
     if isinstance(system, str):
-        return system
+        return _strip_billing_attribution(system)
 
     if isinstance(system, list):
         text_parts = []
         for block in system:
+            text: Optional[str] = None
             if isinstance(block, dict):
-                # Handle {"type": "text", "text": "...", "cache_control": {...}}
                 if block.get("type") == "text":
-                    text_parts.append(block.get("text", ""))
+                    text = block.get("text", "")
             elif hasattr(block, "type") and block.type == "text":
-                # Handle Pydantic model
-                text_parts.append(getattr(block, "text", ""))
+                text = getattr(block, "text", "")
+            if text is None:
+                continue
+            # Drop pure-attribution blocks; strip leading attribution line
+            # from mixed blocks (defensive).
+            stripped = _strip_billing_attribution(text)
+            if not stripped.strip():
+                continue
+            text_parts.append(stripped)
         return "\n".join(text_parts)
 
     return str(system)


### PR DESCRIPTION
## Problem

Claude Code 2.1.x prepends a per-request system text block of the form:

x-anthropic-billing-header: cc_version=2.1.153.d02; cc_entrypoint=sdk-cli; cch=<5hex>;

The `cch` token is a fresh random hex on every request. Because `extract_system_prompt()` concatenates all system text blocks into a single string before forwarding to Kiro, this random prefix poisons the prompt seen by upstream and invalidates any prefix-keyed prompt cache. (The attribution header is meant to be an HTTP header but ships in the request body for `claude -p` / SDK mode.)

## Solution

Add `_strip_billing_attribution()` and call it from `extract_system_prompt()` for both string and list system formats. Pure-attribution blocks are dropped; mixed blocks have the leading attribution line removed. Behavior is gated by `STRIP_BILLING_HEADER` (default `true`) so it can be disabled for A/B comparison.

## Empirical validation (local)

Replay benchmark using real captured Claude Code body (212KB, 3 system blocks), N=30 interleaved, randomized cch per request:

| Metric | Baseline (no strip) | Patched (strip) | Δ |
| --- | --- | --- | --- |
| TTFB mean | 4813ms | 4238ms | **-574ms (-11.9%)** |
| TTFB median | 4506ms | 3952ms | -554ms (-12.3%) |
| TTFB p95 | 6263ms | 4958ms | -1305ms (-20.8%) |

Byte-level check via `DEBUG_MODE=all`: incoming body contains `cch=<hex>` and `x-anthropic-billing-header`; outgoing Kiro payload has zero matches for either string.

## Alternative

`CLAUDE_CODE_ATTRIBUTION_HEADER=0` set in the client environment achieves the same effect on the Claude Code side. The gateway-level fix is complementary and protects users / clients that don't (or can't) set the env var.

## Files

- `kiro/config.py`: add `STRIP_BILLING_HEADER` env (default true)
- `kiro/converters_anthropic.py`: add `_strip_billing_attribution()`, apply in `extract_system_prompt()`