### PR TITLE
Strip leaked native tool-call markup from assistant content

### DIFF
--- a/kiro/streaming_openai.py
+++ b/kiro/streaming_openai.py
@@ -69,6 +69,34 @@ except ImportError:
 __all__ = ['FirstTokenTimeoutError', 'stream_kiro_to_openai', 'stream_with_first_token_retry', 'collect_stream_response']
 
 
+# Native tool-call serialization markers that some models (notably deepseek)
+# leak into the assistant text content. Structured tool_calls are parsed
+# separately, so anything from the first marker onward is duplicate garbage
+# and must be stripped from `content`.
+_TOOL_MARKUP_MARKERS = (
+    "<｜DSML｜",            # <｜DSML｜...   (deepseek DSML function_calls)
+    "<｜tool▁calls▁begin｜>",  # <｜tool▁calls▁begin｜>
+    "<｜tool▁call▁begin｜>",   # <｜tool▁call▁begin｜>
+)
+
+
+def strip_tool_markup(text: Optional[str]) -> Optional[str]:
+    """Remove leaked native tool-call markup from assistant content.
+
+    deepseek (and similar) emit their tool-call serialization as raw text in
+    `content` even though the gateway also extracts structured tool_calls.
+    Cut from the earliest known marker to the end of the string.
+    """
+    if not text:
+        return text
+    cut = min((p for p in (text.find(m) for m in _TOOL_MARKUP_MARKERS) if p != -1), default=-1)
+    if cut == -1:
+        return text
+    cleaned = text[:cut].rstrip()
+    logger.debug(f"Stripped leaked tool-call markup from content ({len(text) - len(cleaned)} chars removed)")
+    return cleaned
+
+
 async def stream_kiro_to_openai_internal(
     client: httpx.AsyncClient,
     response: httpx.Response,
@@ -647,6 +675,10 @@ async def collect_stream_response(
         except (json.JSONDecodeError, IndexError):
             continue
     
+    # Strip any leaked native tool-call markup (e.g. deepseek's <｜DSML｜...) from
+    # content; structured tool_calls are already accumulated separately above.
+    full_content = strip_tool_markup(full_content)
+
     # Form final response
     message = {"role": "assistant", "content": full_content}
     if full_reasoning_content:


### PR DESCRIPTION
Some upstream models (notably deepseek) emit their native tool-call serialization (e.g. `<｜DSML｜function_calls...`) as raw text in the assistant `content`, even though the gateway already extracts the structured `tool_calls` separately. The duplicated markup then leaks into the OpenAI-format response `content`.

Reproduced deterministically against deepseek-3.2: whenever the model emits a tool call, `content` contains the DSML markup regardless of whether `tools` were declared in the request (structured `tool_calls` are parsed correctly in both cases).

Fix: add `strip_tool_markup()` and apply it to the accumulated content in `collect_stream_response()` before building the message, cutting from the first known marker to end-of-string. `tool_calls` are untouched.

Note: covers the non-streaming path; the streaming path needs cross-chunk buffering to strip markers split across deltas (follow-up).