### PR TITLE
docs: add Windows kiro-cli env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,10 @@ PROXY_API_KEY="my-super-secret-password-123"
 
 # Path to kiro-cli SQLite database (for AWS IAM Identity Center users)
 # The gateway will auto-detect AWS SSO OIDC and use the correct endpoint
+# Linux/macOS:
 # KIRO_CLI_DB_FILE="~/.local/share/kiro-cli/data.sqlite3"
+# Windows:
+# KIRO_CLI_DB_FILE="%LOCALAPPDATA%/kiro-cli/data.sqlite3"
 
 # Disable SQLite write-back (read-only mode)
 # When enabled, gateway will only read from kiro-cli database without modifying it.


### PR DESCRIPTION
Adds the default Windows kiro-cli SQLite database path to .env.example.

This helps Windows users copy .env.example to .env and configure KIRO_CLI_DB_FILE correctly without accidentally using the Linux/macOS path. It can resolve cases where the gateway keeps reading stale credentials or an old Kiro account after logging in with kiro-cli on Windows.