### PR TITLE
fix: harden request validation and profileArn handling for Kiro API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,20 @@ __pycache__/
 dist/
 build/
 
+# Python virtual environment (local only - never push to GitHub)
+# This project keeps its venv in the repo root (bin/, lib/, include/, pyvenv.cfg)
+.venv/
+venv/
+env/
+ENV/
+pyvenv.cfg
+/bin/
+/lib/
+/lib64
+/include/
+/share/
+/pyvenv.cfg
+
 # Debug logs (generated when DEBUG_MODE is enabled)
 debug_logs*/
 debug*.json
@@ -31,3 +45,6 @@ requests/
 .pytest_cache/
 .coverage
 htmlcov/
+
+# Kiro spec/workflow files (local only)
+.kiro/

--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -24,7 +24,7 @@ This module is an adapter layer that converts Anthropic-specific formats
 to the unified format used by converters_core.py.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from loguru import logger
 
@@ -255,6 +255,51 @@ def extract_tool_uses_from_anthropic_content(content: Any) -> List[Dict[str, Any
     return tool_calls
 
 
+def extract_inline_system_messages(
+    messages: List[AnthropicMessage],
+) -> Tuple[List[str], List[AnthropicMessage]]:
+    """
+    Separates inline system messages from the conversation messages.
+
+    Some clients (e.g. Claude Code) place ``{"role": "system", ...}`` entries
+    inside the ``messages`` array instead of using the top-level ``system``
+    field. This function extracts the text of those inline system messages
+    (preserving their relative order) and returns the remaining user/assistant
+    messages with their order preserved.
+
+    The extracted inline system messages are excluded from the returned
+    conversation messages so they are never sent to the Kiro API as
+    conversation history.
+
+    Args:
+        messages: List of Anthropic messages (may contain inline system roles)
+
+    Returns:
+        Tuple of:
+        - List of inline system prompt texts, in original order
+        - List of non-system messages (user/assistant), in original order
+    """
+    inline_system_texts: List[str] = []
+    conversation_messages: List[AnthropicMessage] = []
+
+    for msg in messages:
+        if msg.role == "system":
+            # Extract text from string or list-of-content-blocks content
+            system_text = convert_anthropic_content_to_text(msg.content)
+            if system_text:
+                inline_system_texts.append(system_text)
+        else:
+            conversation_messages.append(msg)
+
+    if inline_system_texts:
+        logger.debug(
+            f"Folded {len(inline_system_texts)} inline system message(s) "
+            f"from messages array into system prompt"
+        )
+
+    return inline_system_texts, conversation_messages
+
+
 def convert_anthropic_messages(
     messages: List[AnthropicMessage],
 ) -> List[UnifiedMessage]:
@@ -449,16 +494,34 @@ def anthropic_to_kiro(
 
     Raises:
         ValueError: If there are no messages to send
+        MissingProfileArnError: If no profileArn could be resolved (raised by
+            the core payload builder before contacting the Kiro API).
     """
-    # Convert messages to unified format
-    unified_messages = convert_anthropic_messages(request.messages)
+    # Separate inline system messages (role="system" inside the messages array)
+    # from the actual conversation. Some clients (e.g. Claude Code) inline the
+    # system prompt this way instead of using the top-level system field.
+    inline_system_texts, conversation_messages = extract_inline_system_messages(
+        request.messages
+    )
+
+    # Convert messages to unified format (inline system messages excluded)
+    unified_messages = convert_anthropic_messages(conversation_messages)
 
     # Convert tools to unified format
     unified_tools = convert_anthropic_tools(request.tools)
 
     # System prompt is already separate in Anthropic format!
     # It can be a string or list of content blocks (for prompt caching)
-    system_prompt = extract_system_prompt(request.system)
+    top_level_system = extract_system_prompt(request.system)
+
+    # Combine top-level system content with any inline system messages,
+    # preserving order: top-level system first, then inline system messages
+    # in their original order.
+    system_parts: List[str] = []
+    if top_level_system:
+        system_parts.append(top_level_system)
+    system_parts.extend(inline_system_texts)
+    system_prompt = "\n".join(system_parts)
 
     # Get model ID for Kiro API (normalizes + resolves hidden models)
     # Pass-through principle: we normalize and send to Kiro, Kiro decides if valid

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -436,19 +436,48 @@ def inject_thinking_tags(content: str, thinking_config: ThinkingConfig) -> str:
 # JSON Schema Sanitization
 # ==================================================================================================
 
+# JSON Schema meta/annotation keywords that Kiro API rejects in tool inputSchema.
+#
+# Kiro's tool schema validation is stricter than standard JSON Schema and fails
+# the whole request with a vague "Improperly formed request"
+# (reason: REQUEST_BODY_INVALID) when any of these are present. They are pure
+# metadata/annotations that carry no structural meaning for argument validation,
+# so stripping them is safe and preserves the user's intent.
+#
+# Notably, Claude Code sends "$schema" on EVERY tool definition
+# (e.g. "https://json-schema.org/draft/2020-12/schema"), which was the root
+# cause of the REQUEST_BODY_INVALID rejections.
+#
+# NOTE: Structural "$"-keywords like "$ref"/"$defs" are intentionally NOT included
+# here — removing those would corrupt the schema. Only annotation keywords are listed.
+DISALLOWED_SCHEMA_KEYS: frozenset = frozenset({
+    "$schema",
+    "$id",
+    "$anchor",
+    "$comment",
+})
+
+
 def sanitize_json_schema(schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """
     Sanitizes JSON Schema from fields that Kiro API doesn't accept.
-    
-    Kiro API returns 400 "Improperly formed request" error if:
-    - required is an empty array []
-    - additionalProperties is present in schema
-    
-    This function recursively processes the schema and removes problematic fields.
-    
+
+    Kiro API returns a vague 400 "Improperly formed request"
+    (reason: REQUEST_BODY_INVALID) error if a tool's inputSchema contains
+    fields it does not support. Known offenders:
+    - ``required`` as an empty array ``[]``
+    - ``additionalProperties`` anywhere in the schema
+    - JSON Schema meta/annotation keywords (see ``DISALLOWED_SCHEMA_KEYS``),
+      most notably ``$schema`` which Claude Code sends on every tool
+      (e.g. ``"$schema": "https://json-schema.org/draft/2020-12/schema"``)
+
+    This function recursively processes the schema and removes problematic
+    fields, so the same handling applies to nested objects, ``properties``,
+    and list-valued combinators (``anyOf``/``oneOf``/``allOf``).
+
     Args:
         schema: JSON Schema to sanitize
-    
+
     Returns:
         Sanitized copy of schema
     """
@@ -464,6 +493,11 @@ def sanitize_json_schema(schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         
         # Skip additionalProperties - Kiro API doesn't support it
         if key == "additionalProperties":
+            continue
+
+        # Skip JSON Schema meta/annotation keywords that Kiro API rejects
+        # (e.g. "$schema" sent by Claude Code on every tool definition).
+        if key in DISALLOWED_SCHEMA_KEYS:
             continue
         
         # Recursively process nested objects
@@ -483,6 +517,62 @@ def sanitize_json_schema(schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         else:
             result[key] = value
     
+    return result
+
+
+def ensure_object_schema(schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Guarantee a tool root input schema is a valid JSON Schema object.
+
+    Bedrock (the engine behind Kiro's runtime) requires every tool's
+    ``inputSchema.json.type`` to be exactly ``"object"`` and to carry a
+    ``properties`` map. Real clients sometimes send tool schemas that violate
+    this, which surfaces as:
+
+        "toolConfig.tools.N.toolSpec.inputSchema.json.type must be one of [object]"
+
+    Common violations this normalizes:
+    - Missing ``type`` (e.g. a bare ``{}`` or only ``{"properties": {...}}``)
+    - A non-object ``type`` (e.g. ``"string"``) at the schema root, which makes
+      no sense for a tool's argument container
+    - Missing ``properties`` for an object schema (Bedrock expects the key)
+
+    This is applied ONLY to the root of a tool input schema (in
+    ``convert_tools_to_kiro_format``), never recursively, so nested property
+    schemas keep their own legitimate non-object types.
+
+    Args:
+        schema: A sanitized tool input schema (may be empty or partial).
+
+    Returns:
+        A schema dict whose root is ``type: "object"`` with a ``properties`` map.
+
+    Examples:
+        >>> ensure_object_schema({})
+        {'type': 'object', 'properties': {}}
+        >>> ensure_object_schema({"properties": {"x": {"type": "string"}}})
+        {'properties': {'x': {'type': 'string'}}, 'type': 'object'}
+        >>> ensure_object_schema({"type": "string"})
+        {'type': 'object', 'properties': {}}
+    """
+    if not schema or not isinstance(schema, dict):
+        return {"type": "object", "properties": {}}
+
+    result = dict(schema)
+
+    # Force the root type to "object" if missing or not already "object".
+    if result.get("type") != "object":
+        if "type" in result:
+            logger.debug(
+                f"Tool input schema root type was {result.get('type')!r}; "
+                f"normalizing to 'object' for Bedrock compatibility"
+            )
+        result["type"] = "object"
+
+    # Bedrock expects object schemas to declare a properties map.
+    if not isinstance(result.get("properties"), dict):
+        result["properties"] = {}
+
     return result
 
 
@@ -616,7 +706,15 @@ def convert_tools_to_kiro_format(tools: Optional[List[UnifiedTool]]) -> List[Dic
     for tool in tools:
         # Sanitize parameters from fields that Kiro API doesn't accept
         sanitized_params = sanitize_json_schema(tool.input_schema)
-        
+
+        # Guarantee a valid top-level schema for Bedrock/Kiro.
+        # Bedrock requires every tool's inputSchema.json.type to be "object"
+        # (error: "toolConfig.tools.N.toolSpec.inputSchema.json.type must be
+        # one of [object]"). Some clients send tools with a missing or
+        # non-object top-level type (e.g. a bare/empty schema for a no-argument
+        # tool), so we normalize the root here.
+        sanitized_params = ensure_object_schema(sanitized_params)
+
         # Kiro API requires non-empty description
         description = tool.description
         if not description or not description.strip():

--- a/kiro/debug_logger.py
+++ b/kiro/debug_logger.py
@@ -36,7 +36,7 @@ import io
 import json
 import shutil
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 from loguru import logger
 
 from kiro.config import DEBUG_MODE, DEBUG_DIR
@@ -184,6 +184,39 @@ class DebugLogger:
         else:
             # "errors" mode - buffer
             self._kiro_request_body_buffer = body
+
+    def log_kiro_request_payload(self, payload: Any) -> None:
+        """
+        Serialize and log the outgoing Kiro request payload for debugging.
+
+        Serialization (json.dumps + encode) is performed ONLY when debug logging
+        is enabled (DEBUG_MODE is "errors" or "all"). When logging is disabled
+        (the default "off" mode), this returns immediately WITHOUT serializing,
+        avoiding wasted CPU and memory on the request hot path for potentially
+        large payloads (Kiro payloads can reach hundreds of KB).
+
+        This is the preferred entry point for route handlers: it lets callers
+        pass the raw payload object and pay the serialization cost only when a
+        debug mode is active, instead of always serializing and discarding.
+
+        Args:
+            payload: JSON-serializable Kiro request payload (typically a dict).
+
+        Returns:
+            None
+        """
+        # Fast path: skip all serialization work when logging is disabled.
+        if not self._is_enabled():
+            return
+
+        try:
+            body = json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
+        except (TypeError, ValueError) as e:
+            # Non-serializable payload: log and skip rather than breaking the request.
+            logger.warning(f"[DebugLogger] Failed to serialize Kiro request payload: {e}")
+            return
+
+        self.log_kiro_request_body(body)
 
     def log_raw_chunk(self, chunk: bytes):
         """

--- a/kiro/exceptions.py
+++ b/kiro/exceptions.py
@@ -32,6 +32,88 @@ from fastapi.responses import JSONResponse
 from loguru import logger
 
 
+class MissingProfileArnError(ValueError):
+    """
+    Raised when no profileArn can be resolved for a Kiro API request.
+
+    The Kiro runtime (`runtime.kiro.dev`) rejects `generateAssistantResponse`
+    requests without a `profileArn` with an opaque HTTP 400
+    ("profileArn is required for this request."). The Gateway detects this
+    condition before contacting the Kiro API and surfaces this actionable
+    error instead.
+
+    This subclasses ``ValueError`` so that the existing ``except ValueError``
+    handlers in both the OpenAI and Anthropic routes (streaming and
+    non-streaming paths) translate it into an HTTP 400 response in the
+    correct per-API error format.
+
+    The error message intentionally references the ``PROFILE_ARN``
+    configuration key and never includes any credential, token, or
+    access-key value.
+    """
+
+    #: Default user-facing message. Contains the literal ``PROFILE_ARN`` key
+    #: and a statement that the value is required. Contains no secrets.
+    DEFAULT_MESSAGE: str = (
+        "profileArn is required but could not be resolved. Set the PROFILE_ARN "
+        "configuration value (for example, in your .env file) to your AWS "
+        "CodeWhisperer profile ARN, or use credentials that provide one."
+    )
+
+    def __init__(self, message: str = "") -> None:
+        """
+        Initialize the error.
+
+        Args:
+            message: Optional override for the user-facing message. When empty,
+                ``DEFAULT_MESSAGE`` is used.
+        """
+        super().__init__(message or self.DEFAULT_MESSAGE)
+
+
+class MalformedProfileArnError(ValueError):
+    """
+    Raised when a profileArn is present but is not a valid CodeWhisperer ARN.
+
+    The most common cause is leaving the documentation placeholder
+    ``arn:aws:codewhisperer:us-east-1:...`` in the configuration (the ``...``
+    is never replaced with a real AWS account ID and profile). The Kiro runtime
+    accepts that *some* profileArn is present but then rejects the malformed
+    value during body validation with an opaque
+    ``HTTP 400 "Improperly formed request." (reason: REQUEST_BODY_INVALID)``.
+
+    Detecting this in the Gateway lets us return an actionable error instead of
+    the cryptic upstream one (AGENTS.md §9 "User Experience First").
+
+    Subclasses ``ValueError`` so existing route handlers translate it to HTTP
+    400 in the correct per-API error format. The message references the
+    ``PROFILE_ARN`` key and never includes credential values.
+    """
+
+    def __init__(self, profile_arn: str = "") -> None:
+        """
+        Initialize the error.
+
+        Args:
+            profile_arn: The offending profileArn value. Only the
+                non-sensitive ARN string is echoed (an ARN is an identifier,
+                not a secret); it helps the user spot the placeholder.
+        """
+        detail = (
+            f"PROFILE_ARN is set to an invalid value ('{profile_arn}'). "
+            if profile_arn
+            else "PROFILE_ARN is set to an invalid value. "
+        )
+        message = (
+            f"{detail}It must be a real AWS CodeWhisperer profile ARN of the form "
+            "'arn:aws:codewhisperer:<region>:<aws-account-id>:profile/<profile-id>'. "
+            "The default '...' placeholder must be replaced with your actual AWS "
+            "account ID and profile ID. You can find this ARN in your Kiro IDE "
+            "request traffic, in the Amazon Q Developer console, or via kiro-cli."
+        )
+        super().__init__(message)
+
+
 def sanitize_validation_errors(errors: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Converts validation errors to JSON-serializable format.

--- a/kiro/http_client.py
+++ b/kiro/http_client.py
@@ -41,7 +41,12 @@ from loguru import logger
 from kiro.config import MAX_RETRIES, BASE_RETRY_DELAY, FIRST_TOKEN_MAX_RETRIES, STREAMING_READ_TIMEOUT
 from kiro.auth import KiroAuthManager
 from kiro.utils import get_kiro_headers
-from kiro.network_errors import classify_network_error, get_short_error_message, NetworkErrorInfo
+from kiro.network_errors import (
+    classify_network_error,
+    get_short_error_message,
+    build_http_error_detail,
+    NetworkErrorInfo,
+)
 
 
 class KiroHttpClient:
@@ -312,21 +317,12 @@ class KiroHttpClient:
         
         # All attempts exhausted - provide detailed, user-friendly error message
         if last_error_info:
-            # Use classified error information
-            error_message = last_error_info.user_message
-            
-            # Add troubleshooting steps
-            if last_error_info.troubleshooting_steps:
-                error_message += "\n\nTroubleshooting:\n"
-                for i, step in enumerate(last_error_info.troubleshooting_steps, 1):
-                    error_message += f"{i}. {step}\n"
-            
-            # Add technical details for debugging
-            error_message += f"\nTechnical details: {last_error_info.technical_details}"
-            
+            # Use classified error information. The detail is built via the shared
+            # formatter so connection-level failures here and mid-stream body drops
+            # (classified in the streaming collectors) produce identical messages.
             raise HTTPException(
                 status_code=last_error_info.suggested_http_code,
-                detail=error_message.strip()
+                detail=build_http_error_detail(last_error_info)
             )
         else:
             # Fallback if no error was captured (shouldn't happen)

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -182,12 +182,21 @@ class AnthropicMessage(BaseModel):
     """
     Message in Anthropic format.
 
+    Per the Anthropic specification the system prompt is carried in the
+    top-level ``system`` field, and ``messages`` roles are ``user`` or
+    ``assistant``. However, some clients (e.g. Claude Code) inline a
+    ``{"role": "system", ...}`` entry inside ``messages``. To avoid rejecting
+    those requests with an HTTP 422 before any conversion runs, this model
+    also accepts the ``system`` role. Inline system messages are folded into
+    the system prompt by the Anthropic converter and excluded from the
+    conversation history sent to the Kiro API.
+
     Attributes:
-        role: Message role (user or assistant)
+        role: Message role (user, assistant, or inline system)
         content: Message content (string or list of content blocks)
     """
 
-    role: Literal["user", "assistant"]
+    role: Literal["user", "assistant", "system"]
     content: Union[str, List[ContentBlock]]
 
     model_config = {"extra": "allow"}

--- a/kiro/network_errors.py
+++ b/kiro/network_errors.py
@@ -434,3 +434,39 @@ def get_short_error_message(error_info: NetworkErrorInfo) -> str:
         >>> logger.warning(get_short_error_message(error_info))
     """
     return error_info.user_message
+
+
+def build_http_error_detail(error_info: NetworkErrorInfo) -> str:
+    """
+    Builds a detailed, user-friendly error string for an HTTPException detail.
+
+    Combines the user-facing message, numbered troubleshooting steps, and the
+    technical details into a single multi-line string. This is the standard
+    representation used when raising an HTTPException for a classified network
+    error, so that connectivity failures surface the same actionable guidance
+    everywhere in the gateway (HTTP client retries and mid-stream body drops).
+
+    Args:
+        error_info: The classified network error information.
+
+    Returns:
+        A formatted, stripped multi-line error message suitable for use as an
+        HTTPException `detail`.
+
+    Example:
+        >>> error_info = classify_network_error(exception)
+        >>> raise HTTPException(
+        ...     status_code=error_info.suggested_http_code,
+        ...     detail=build_http_error_detail(error_info),
+        ... )
+    """
+    detail = error_info.user_message
+
+    if error_info.troubleshooting_steps:
+        detail += "\n\nTroubleshooting:\n"
+        for i, step in enumerate(error_info.troubleshooting_steps, 1):
+            detail += f"{i}. {step}\n"
+
+    detail += f"\nTechnical details: {error_info.technical_details}"
+
+    return detail.strip()

--- a/kiro/profile_resolver.py
+++ b/kiro/profile_resolver.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+
+# Kiro Gateway
+# https://github.com/jwadow/kiro-gateway
+# Copyright (C) 2025 Jwadow
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Profile ARN resolution for Kiro API requests.
+
+The Kiro runtime (``runtime.kiro.dev``) requires a ``profileArn`` on every
+``generateAssistantResponse`` request. When it is missing, the upstream API
+rejects the request with an opaque HTTP 400 ("profileArn is required for this
+request.") that is not actionable for the user.
+
+This module centralizes the single rule used by BOTH API surfaces (OpenAI and
+Anthropic) and BOTH request modes (streaming and non-streaming) for resolving
+the effective profile ARN, so behaviour is identical everywhere. Routes call
+:func:`resolve_profile_arn` and, when it yields an empty result, return the
+``Missing_Profile_Error`` instead of contacting the Kiro API.
+"""
+
+from typing import Any
+import re
+
+from loguru import logger
+
+from kiro.config import PROFILE_ARN
+
+
+# Strict-enough shape for a CodeWhisperer profile ARN:
+#   arn:aws:codewhisperer:<region>:<aws-account-id>:profile/<profile-id>
+# - region: lowercase letters, digits, hyphens (e.g. us-east-1)
+# - account id: one or more digits (real AWS account IDs are 12 digits, but we
+#   only require "all digits, non-empty" to avoid rejecting legitimate-but-
+#   unusual setups while still catching the "..." placeholder, whose account-id
+#   segment is non-numeric)
+# - profile id: non-empty token of allowed identifier characters
+#
+# This intentionally rejects the documentation placeholder
+# "arn:aws:codewhisperer:us-east-1:..." whose account-id segment is "..".
+_PROFILE_ARN_PATTERN = re.compile(
+    r"^arn:aws:codewhisperer:[a-z0-9-]+:\d+:profile/[A-Za-z0-9._-]+$"
+)
+
+
+def is_valid_profile_arn(profile_arn: str) -> bool:
+    """
+    Check whether a string is a structurally valid CodeWhisperer profile ARN.
+
+    This does NOT verify the ARN exists or is authorized — it only catches
+    obviously malformed values (most importantly the ``...`` placeholder) so
+    the Gateway can surface an actionable error instead of the opaque upstream
+    ``REQUEST_BODY_INVALID``.
+
+    Args:
+        profile_arn: The candidate ARN string.
+
+    Returns:
+        True if the value matches the expected ARN shape, False otherwise.
+
+    Examples:
+        >>> is_valid_profile_arn("arn:aws:codewhisperer:us-east-1:123456789012:profile/ABCDEF123456")
+        True
+        >>> is_valid_profile_arn("arn:aws:codewhisperer:us-east-1:...")
+        False
+        >>> is_valid_profile_arn("")
+        False
+    """
+    if not profile_arn or not isinstance(profile_arn, str):
+        return False
+    return bool(_PROFILE_ARN_PATTERN.match(profile_arn.strip()))
+
+
+def resolve_profile_arn(auth_manager: Any) -> str:
+    """
+    Resolve the effective profileArn from the auth manager and configuration.
+
+    Resolution rule (single source of truth for both APIs and both modes):
+
+    1. If the auth manager provides a non-empty ``profile_arn``, use it.
+    2. Otherwise, if the ``PROFILE_ARN`` configuration value is non-empty,
+       use it.
+    3. Otherwise, return an empty string, signalling that no profileArn could
+       be resolved.
+
+    The returned value is stripped of surrounding whitespace so that a value
+    consisting only of spaces is treated as missing.
+
+    Args:
+        auth_manager: The account's auth manager. Expected to expose a
+            ``profile_arn`` attribute (may be ``None`` or empty).
+
+    Returns:
+        The resolved profile ARN, or an empty string when none is available.
+
+    Examples:
+        >>> class _Auth:
+        ...     profile_arn = "arn:aws:codewhisperer:us-east-1:123:profile/abc"
+        >>> resolve_profile_arn(_Auth())
+        'arn:aws:codewhisperer:us-east-1:123:profile/abc'
+    """
+    auth_profile_arn = getattr(auth_manager, "profile_arn", None) or ""
+    if isinstance(auth_profile_arn, str):
+        auth_profile_arn = auth_profile_arn.strip()
+
+    if auth_profile_arn:
+        return auth_profile_arn
+
+    config_profile_arn = (PROFILE_ARN or "").strip()
+    if config_profile_arn:
+        return config_profile_arn
+
+    logger.debug(
+        "Profile resolver found no profileArn (auth manager empty and "
+        "PROFILE_ARN unset)"
+    )
+    return ""

--- a/kiro/routes_anthropic.py
+++ b/kiro/routes_anthropic.py
@@ -34,7 +34,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import APIKeyHeader
 from loguru import logger
 
-from kiro.config import PROXY_API_KEY, PROFILE_ARN
+from kiro.config import PROXY_API_KEY
 from kiro.models_anthropic import (
     AnthropicMessagesRequest,
     AnthropicCountTokensRequest,
@@ -45,6 +45,8 @@ from kiro.models_anthropic import (
 from kiro.auth import KiroAuthManager, AuthType
 from kiro.cache import ModelInfoCache
 from kiro.converters_anthropic import anthropic_to_kiro
+from kiro.profile_resolver import resolve_profile_arn, is_valid_profile_arn
+from kiro.exceptions import MissingProfileArnError, MalformedProfileArnError
 from kiro.streaming_anthropic import (
     stream_kiro_to_anthropic,
     collect_anthropic_response,
@@ -376,10 +378,17 @@ async def messages(
             conversation_id = generate_conversation_id()
             
             # Build payload for Kiro
-            # profileArn is required by runtime.kiro.dev for all auth types
-            profile_arn_for_payload = auth_manager.profile_arn or PROFILE_ARN or ""
+            # profileArn is required by runtime.kiro.dev for all auth types.
+            # Resolve via the shared Profile_Resolver and reject early with an
+            # actionable error if none is available, so we never send a request
+            # to the Kiro API without a profileArn.
+            profile_arn_for_payload = resolve_profile_arn(auth_manager)
             
             try:
+                if not profile_arn_for_payload:
+                    raise MissingProfileArnError()
+                if not is_valid_profile_arn(profile_arn_for_payload):
+                    raise MalformedProfileArnError(profile_arn_for_payload)
                 kiro_payload = anthropic_to_kiro(
                     request_data,
                     conversation_id,
@@ -684,10 +693,17 @@ async def messages(
     conversation_id = generate_conversation_id()
     
     # Build payload for Kiro
-    # profileArn is required by runtime.kiro.dev for all auth types
-    profile_arn_for_payload = auth_manager.profile_arn or PROFILE_ARN or ""
+    # profileArn is required by runtime.kiro.dev for all auth types.
+    # Resolve via the shared Profile_Resolver and reject early with an
+    # actionable error if none is available, so we never send a request to the
+    # Kiro API without a profileArn.
+    profile_arn_for_payload = resolve_profile_arn(auth_manager)
     
     try:
+        if not profile_arn_for_payload:
+            raise MissingProfileArnError()
+        if not is_valid_profile_arn(profile_arn_for_payload):
+            raise MalformedProfileArnError(profile_arn_for_payload)
         kiro_payload = anthropic_to_kiro(
             request_data,
             conversation_id,

--- a/kiro/routes_anthropic.py
+++ b/kiro/routes_anthropic.py
@@ -407,13 +407,9 @@ async def messages(
                     }
                 )
             
-            # Log Kiro payload
-            try:
-                kiro_request_body = json.dumps(kiro_payload, ensure_ascii=False, indent=2).encode('utf-8')
-                if debug_logger:
-                    debug_logger.log_kiro_request_body(kiro_request_body)
-            except Exception as e:
-                logger.warning(f"Failed to log Kiro request: {e}")
+            # Log Kiro payload (serialization is skipped entirely when DEBUG_MODE=off)
+            if debug_logger:
+                debug_logger.log_kiro_request_payload(kiro_payload)
             
             # Create HTTP client
             url = f"{auth_manager.api_host}/generateAssistantResponse"
@@ -722,13 +718,9 @@ async def messages(
             }
         )
     
-    # Log Kiro payload
-    try:
-        kiro_request_body = json.dumps(kiro_payload, ensure_ascii=False, indent=2).encode('utf-8')
-        if debug_logger:
-            debug_logger.log_kiro_request_body(kiro_request_body)
-    except Exception as e:
-        logger.warning(f"Failed to log Kiro request: {e}")
+    # Log Kiro payload (serialization is skipped entirely when DEBUG_MODE=off)
+    if debug_logger:
+        debug_logger.log_kiro_request_payload(kiro_payload)
     
     # Create HTTP client with retry logic
     # For streaming: use per-request client to avoid CLOSE_WAIT leak on VPN disconnect (issue #54)

--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -357,13 +357,9 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
             
-            # Log Kiro payload
-            try:
-                kiro_request_body = json.dumps(kiro_payload, ensure_ascii=False, indent=2).encode('utf-8')
-                if debug_logger:
-                    debug_logger.log_kiro_request_body(kiro_request_body)
-            except Exception as e:
-                logger.warning(f"Failed to log Kiro request: {e}")
+            # Log Kiro payload (serialization is skipped entirely when DEBUG_MODE=off)
+            if debug_logger:
+                debug_logger.log_kiro_request_payload(kiro_payload)
             
             # Create HTTP client
             url = f"{auth_manager.api_host}/generateAssistantResponse"
@@ -626,13 +622,9 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     
-    # Log Kiro payload
-    try:
-        kiro_request_body = json.dumps(kiro_payload, ensure_ascii=False, indent=2).encode('utf-8')
-        if debug_logger:
-            debug_logger.log_kiro_request_body(kiro_request_body)
-    except Exception as e:
-        logger.warning(f"Failed to log Kiro request: {e}")
+    # Log Kiro payload (serialization is skipped entirely when DEBUG_MODE=off)
+    if debug_logger:
+        debug_logger.log_kiro_request_payload(kiro_payload)
     
     # Create HTTP client with retry logic
     # For streaming: use per-request client to avoid CLOSE_WAIT leak on VPN disconnect (issue #54)

--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -37,7 +37,6 @@ from loguru import logger
 from kiro.config import (
     PROXY_API_KEY,
     APP_VERSION,
-    PROFILE_ARN,
 )
 from kiro.models_openai import (
     OpenAIModel,
@@ -48,6 +47,8 @@ from kiro.auth import KiroAuthManager, AuthType
 from kiro.cache import ModelInfoCache
 from kiro.model_resolver import ModelResolver
 from kiro.converters_openai import build_kiro_payload
+from kiro.profile_resolver import resolve_profile_arn, is_valid_profile_arn
+from kiro.exceptions import MissingProfileArnError, MalformedProfileArnError
 from kiro.streaming_openai import stream_kiro_to_openai, collect_stream_response, stream_with_first_token_retry
 from kiro.http_client import KiroHttpClient
 from kiro.utils import generate_conversation_id
@@ -323,14 +324,35 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
             conversation_id = generate_conversation_id()
             
             # Build payload for Kiro
-            # profileArn is required by runtime.kiro.dev for all auth types
-            profile_arn_for_payload = auth_manager.profile_arn or PROFILE_ARN or ""
+            # profileArn is required by runtime.kiro.dev for all auth types.
+            # Resolve via the shared Profile_Resolver and reject early with an
+            # actionable error if none is available, so we never send a request
+            # to the Kiro API without a profileArn.
+            profile_arn_for_payload = resolve_profile_arn(auth_manager)
             
             try:
+                if not profile_arn_for_payload:
+                    raise MissingProfileArnError()
+                if not is_valid_profile_arn(profile_arn_for_payload):
+                    raise MalformedProfileArnError(profile_arn_for_payload)
                 kiro_payload = build_kiro_payload(
                     request_data,
                     conversation_id,
                     profile_arn_for_payload
+                )
+            except (MissingProfileArnError, MalformedProfileArnError) as e:
+                logger.warning(f"HTTP 400 - POST /v1/chat/completions - {e}")
+                if debug_logger:
+                    debug_logger.flush_on_error(400, str(e))
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "error": {
+                            "message": str(e),
+                            "type": "invalid_request_error",
+                            "code": 400,
+                        }
+                    }
                 )
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
@@ -571,14 +593,35 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
     conversation_id = generate_conversation_id()
     
     # Build payload for Kiro
-    # profileArn is required by runtime.kiro.dev for all auth types
-    profile_arn_for_payload = auth_manager.profile_arn or PROFILE_ARN or ""
+    # profileArn is required by runtime.kiro.dev for all auth types.
+    # Resolve via the shared Profile_Resolver and reject early with an
+    # actionable error if none is available, so we never send a request to the
+    # Kiro API without a profileArn.
+    profile_arn_for_payload = resolve_profile_arn(auth_manager)
     
     try:
+        if not profile_arn_for_payload:
+            raise MissingProfileArnError()
+        if not is_valid_profile_arn(profile_arn_for_payload):
+            raise MalformedProfileArnError(profile_arn_for_payload)
         kiro_payload = build_kiro_payload(
             request_data,
             conversation_id,
             profile_arn_for_payload
+        )
+    except (MissingProfileArnError, MalformedProfileArnError) as e:
+        logger.warning(f"HTTP 400 - POST /v1/chat/completions - {e}")
+        if debug_logger:
+            debug_logger.flush_on_error(400, str(e))
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": {
+                    "message": str(e),
+                    "type": "invalid_request_error",
+                    "code": 400,
+                }
+            }
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/kiro/streaming_anthropic.py
+++ b/kiro/streaming_anthropic.py
@@ -37,6 +37,7 @@ import uuid
 from typing import TYPE_CHECKING, AsyncGenerator, Dict, List, Optional, Any
 
 import httpx
+from fastapi import HTTPException
 from loguru import logger
 
 from kiro.streaming_core import (
@@ -47,6 +48,7 @@ from kiro.streaming_core import (
     calculate_tokens_from_context_usage,
     stream_with_first_token_retry,
 )
+from kiro.network_errors import classify_network_error, build_http_error_detail
 from kiro.tokenizer import count_tokens, estimate_request_tokens
 from kiro.parsers import parse_bracket_tool_calls, deduplicate_tool_calls
 from kiro.config import FIRST_TOKEN_TIMEOUT, FIRST_TOKEN_MAX_RETRIES, FAKE_REASONING_HANDLING
@@ -758,7 +760,25 @@ async def collect_anthropic_response(
         input_tokens = request_token_stats["total_tokens"]
     
     # Collect stream result
-    result = await collect_stream_to_result(response)
+    try:
+        result = await collect_stream_to_result(response)
+    except httpx.RequestError as e:
+        # Upstream closed the connection mid-response (e.g. RemoteProtocolError:
+        # "incomplete chunked read"). This is raised while reading the response
+        # body, AFTER request_with_retry already returned HTTP 200, so the HTTP
+        # client's retry/classification never sees it. Classify it here and raise
+        # a proper 502/504 instead of letting it surface as a generic 500. The
+        # route's HTTPException handlers treat 502/504 as a recoverable network
+        # error (account-system mode fails over to the next account).
+        error_info = classify_network_error(e)
+        logger.error(
+            f"Upstream connection error during non-streaming collection (Anthropic): "
+            f"{error_info.technical_details}"
+        )
+        raise HTTPException(
+            status_code=error_info.suggested_http_code,
+            detail=build_http_error_detail(error_info),
+        )
     upstream_cache_usage = _extract_cache_usage_fields(result.usage)
     
     # Build content blocks

--- a/kiro/streaming_openai.py
+++ b/kiro/streaming_openai.py
@@ -53,6 +53,7 @@ from kiro.streaming_core import (
     calculate_tokens_from_context_usage,
     stream_with_first_token_retry as stream_with_first_token_retry_core,
 )
+from kiro.network_errors import classify_network_error, build_http_error_detail
 
 if TYPE_CHECKING:
     from kiro.auth import KiroAuthManager
@@ -607,45 +608,63 @@ async def collect_stream_response(
     finish_reason = "stop"  # Default fallback
     completion_id = generate_completion_id()
     
-    async for chunk_str in stream_kiro_to_openai(
-        client,
-        response,
-        model,
-        model_cache,
-        auth_manager,
-        request_messages=request_messages,
-        request_tools=request_tools
-    ):
-        if not chunk_str.startswith("data:"):
-            continue
-        
-        data_str = chunk_str[len("data:"):].strip()
-        if not data_str or data_str == "[DONE]":
-            continue
-        
-        try:
-            chunk_data = json.loads(data_str)
+    try:
+        async for chunk_str in stream_kiro_to_openai(
+            client,
+            response,
+            model,
+            model_cache,
+            auth_manager,
+            request_messages=request_messages,
+            request_tools=request_tools
+        ):
+            if not chunk_str.startswith("data:"):
+                continue
             
-            # Extract data from chunk
-            delta = chunk_data.get("choices", [{}])[0].get("delta", {})
-            if "content" in delta:
-                full_content += delta["content"]
-            if "reasoning_content" in delta:
-                full_reasoning_content += delta["reasoning_content"]
-            if "tool_calls" in delta:
-                tool_calls.extend(delta["tool_calls"])
+            data_str = chunk_str[len("data:"):].strip()
+            if not data_str or data_str == "[DONE]":
+                continue
             
-            # Extract finish_reason from chunk (streaming already calculated it correctly)
-            finish_reason_from_chunk = chunk_data.get("choices", [{}])[0].get("finish_reason")
-            if finish_reason_from_chunk:
-                finish_reason = finish_reason_from_chunk
-            
-            # Save usage from last chunk
-            if "usage" in chunk_data:
-                final_usage = chunk_data["usage"]
+            try:
+                chunk_data = json.loads(data_str)
                 
-        except (json.JSONDecodeError, IndexError):
-            continue
+                # Extract data from chunk
+                delta = chunk_data.get("choices", [{}])[0].get("delta", {})
+                if "content" in delta:
+                    full_content += delta["content"]
+                if "reasoning_content" in delta:
+                    full_reasoning_content += delta["reasoning_content"]
+                if "tool_calls" in delta:
+                    tool_calls.extend(delta["tool_calls"])
+                
+                # Extract finish_reason from chunk (streaming already calculated it correctly)
+                finish_reason_from_chunk = chunk_data.get("choices", [{}])[0].get("finish_reason")
+                if finish_reason_from_chunk:
+                    finish_reason = finish_reason_from_chunk
+                
+                # Save usage from last chunk
+                if "usage" in chunk_data:
+                    final_usage = chunk_data["usage"]
+                    
+            except (json.JSONDecodeError, IndexError):
+                continue
+    except httpx.RequestError as e:
+        # Upstream closed the connection mid-response (e.g. RemoteProtocolError:
+        # "incomplete chunked read"). This is raised while reading the response
+        # body, AFTER request_with_retry already returned HTTP 200, so the HTTP
+        # client's retry/classification never sees it. Classify it here and raise
+        # a proper 502/504 instead of letting it surface as a generic 500. The
+        # route's HTTPException handlers treat 502/504 as a recoverable network
+        # error (account-system mode fails over to the next account).
+        error_info = classify_network_error(e)
+        logger.error(
+            f"Upstream connection error during non-streaming collection (OpenAI): "
+            f"{error_info.technical_details}"
+        )
+        raise HTTPException(
+            status_code=error_info.suggested_http_code,
+            detail=build_http_error_detail(error_info),
+        )
     
     # Form final response
     message = {"role": "assistant", "content": full_content}

--- a/tests/integration/test_full_flow.py
+++ b/tests/integration/test_full_flow.py
@@ -328,7 +328,8 @@ class TestStreamingFlagHandling:
         mock_response.aclose = AsyncMock()
         
         # Mock request_with_retry to return our mock response
-        with patch('kiro.routes_openai.KiroHttpClient') as MockHttpClient:
+        with patch('kiro.routes_openai.resolve_profile_arn', return_value="arn:aws:codewhisperer:us-east-1:123456789012:profile/TEST"), \
+             patch('kiro.routes_openai.KiroHttpClient') as MockHttpClient:
             mock_client_instance = AsyncMock()
             mock_client_instance.request_with_retry = AsyncMock(return_value=mock_response)
             mock_client_instance.client = AsyncMock()

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -25,6 +25,7 @@ from kiro.converters_anthropic import (
     convert_anthropic_tools,
     anthropic_to_kiro,
     extract_thinking_config_from_anthropic,
+    extract_inline_system_messages,
 )
 from kiro.converters_core import UnifiedMessage, UnifiedTool
 from kiro.models_anthropic import (
@@ -1884,3 +1885,272 @@ class TestAnthropicToKiroIntegration:
         print(f"Checking for <max_thinking_length>6000</max_thinking_length>...")
         assert "<max_thinking_length>6000</max_thinking_length>" in content
         assert "<thinking_mode>enabled</thinking_mode>" in content
+
+
+class TestExtractInlineSystemMessages:
+    """
+    Tests for extract_inline_system_messages.
+
+    Verifies that inline system messages are folded out of the conversation
+    (Requirements 4.2, 4.4, 5.1, 5.2, 5.3).
+    """
+
+    def test_no_inline_system_returns_messages_unchanged(self):
+        """
+        What it does: With no system role, returns empty texts and all messages.
+        Purpose: Ensure no-op behaviour for normal conversations.
+        """
+        print("Setup: user + assistant messages only...")
+        messages = [
+            AnthropicMessage(role="user", content="Hello"),
+            AnthropicMessage(role="assistant", content="Hi"),
+        ]
+
+        print("Action: extracting inline system messages...")
+        texts, conversation = extract_inline_system_messages(messages)
+
+        print(f"Result: texts={texts}, conversation_len={len(conversation)}")
+        assert texts == []
+        assert len(conversation) == 2
+
+    def test_single_inline_system_extracted(self):
+        """
+        What it does: Extracts a single inline system message text.
+        Purpose: Requirement 4.2 - fold inline system content out.
+        """
+        print("Setup: inline system + user...")
+        messages = [
+            AnthropicMessage(role="system", content="Be concise"),
+            AnthropicMessage(role="user", content="Hello"),
+        ]
+
+        print("Action: extracting inline system messages...")
+        texts, conversation = extract_inline_system_messages(messages)
+
+        print(f"Result: texts={texts}, conversation roles={[m.role for m in conversation]}")
+        assert texts == ["Be concise"]
+        assert [m.role for m in conversation] == ["user"]
+
+    def test_multiple_inline_system_preserve_order(self):
+        """
+        What it does: Preserves order of multiple inline system messages.
+        Purpose: Requirement 5.1 - relative order preserved.
+        """
+        print("Setup: system A, user, system B...")
+        messages = [
+            AnthropicMessage(role="system", content="First"),
+            AnthropicMessage(role="user", content="Hello"),
+            AnthropicMessage(role="system", content="Second"),
+        ]
+
+        print("Action: extracting inline system messages...")
+        texts, conversation = extract_inline_system_messages(messages)
+
+        print(f"Result: texts={texts}")
+        assert texts == ["First", "Second"]
+        assert [m.role for m in conversation] == ["user"]
+
+    def test_inline_system_with_content_blocks(self):
+        """
+        What it does: Extracts text from list-of-blocks system content.
+        Purpose: Requirement 5.3 - extract text from content blocks.
+        """
+        print("Setup: inline system with content blocks...")
+        messages = [
+            AnthropicMessage(
+                role="system",
+                content=[
+                    {"type": "text", "text": "Part 1 "},
+                    {"type": "text", "text": "Part 2"},
+                ],
+            ),
+            AnthropicMessage(role="user", content="Hello"),
+        ]
+
+        print("Action: extracting inline system messages...")
+        texts, conversation = extract_inline_system_messages(messages)
+
+        print(f"Result: texts={texts}")
+        assert texts == ["Part 1 Part 2"]
+
+    def test_conversation_order_preserved(self):
+        """
+        What it does: User/assistant ordering is preserved after extraction.
+        Purpose: Requirement 5.2 - non-system order preserved.
+        """
+        print("Setup: user, system, assistant, user...")
+        messages = [
+            AnthropicMessage(role="user", content="U1"),
+            AnthropicMessage(role="system", content="S"),
+            AnthropicMessage(role="assistant", content="A1"),
+            AnthropicMessage(role="user", content="U2"),
+        ]
+
+        print("Action: extracting inline system messages...")
+        texts, conversation = extract_inline_system_messages(messages)
+
+        print(f"Result: conversation roles={[m.role for m in conversation]}")
+        assert [m.role for m in conversation] == ["user", "assistant", "user"]
+        assert [m.content for m in conversation] == ["U1", "A1", "U2"]
+
+
+class TestAnthropicToKiroInlineSystem:
+    """
+    Integration tests for inline system folding in anthropic_to_kiro.
+
+    Requirements 4.2, 4.3, 4.4, 4.5, 4.6, 5.1, 5.2.
+    """
+
+    def _build(self, request):
+        """Helper to call anthropic_to_kiro with reasoning disabled."""
+        with patch("kiro.converters_anthropic.get_model_id_for_kiro", return_value="claude-sonnet-4.5"):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
+                with patch("kiro.config.TRUNCATION_RECOVERY", False):
+                    return anthropic_to_kiro(request, "conv-123", "arn:aws:test")
+
+    def test_inline_system_folded_into_prompt(self):
+        """
+        What it does: Inline system content appears in the user message content.
+        Purpose: Requirement 4.2 - fold into system prompt.
+        """
+        print("Setup: inline system + user...")
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-4-5",
+            max_tokens=1024,
+            messages=[
+                {"role": "system", "content": "You are a pirate"},
+                {"role": "user", "content": "Hello"},
+            ],
+        )
+
+        print("Action: converting to Kiro payload...")
+        payload = self._build(request)
+
+        content = payload["conversationState"]["currentMessage"]["userInputMessage"]["content"]
+        print(f"Content: {content!r}")
+        assert "You are a pirate" in content
+        assert "Hello" in content
+
+    def test_top_level_and_inline_system_combined(self):
+        """
+        What it does: Combines top-level system and inline system content.
+        Purpose: Requirement 4.3 and 5.1 - both folded, top-level first.
+        """
+        print("Setup: top-level system + inline system + user...")
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-4-5",
+            max_tokens=1024,
+            system="TOP_LEVEL_SYSTEM",
+            messages=[
+                {"role": "system", "content": "INLINE_SYSTEM"},
+                {"role": "user", "content": "Hello"},
+            ],
+        )
+
+        print("Action: converting to Kiro payload...")
+        payload = self._build(request)
+
+        content = payload["conversationState"]["currentMessage"]["userInputMessage"]["content"]
+        print(f"Content: {content!r}")
+        assert "TOP_LEVEL_SYSTEM" in content
+        assert "INLINE_SYSTEM" in content
+        # Top-level system comes before inline system
+        assert content.index("TOP_LEVEL_SYSTEM") < content.index("INLINE_SYSTEM")
+
+    def test_inline_system_excluded_from_history(self):
+        """
+        What it does: Inline system messages are not in conversation history.
+        Purpose: Requirement 4.4 - exclude inline system from history.
+        """
+        print("Setup: system, user, assistant, user...")
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-4-5",
+            max_tokens=1024,
+            messages=[
+                {"role": "system", "content": "SYSTEM_MARKER"},
+                {"role": "user", "content": "First user"},
+                {"role": "assistant", "content": "First assistant"},
+                {"role": "user", "content": "Second user"},
+            ],
+        )
+
+        print("Action: converting to Kiro payload...")
+        payload = self._build(request)
+
+        history = payload["conversationState"].get("history", [])
+        history_json = str(history)
+        print(f"History entries: {len(history)}")
+        # System content is folded into the first user message in history, but
+        # there must be no standalone system entry. Verify the conversation
+        # has exactly the user/assistant turns expected (2 history + current).
+        assert len(history) == 2
+
+    def test_only_inline_system_and_user_produces_valid_payload(self):
+        """
+        What it does: messages with only inline system + user yields a payload.
+        Purpose: Requirement 4.5 - user message preserved.
+        """
+        print("Setup: inline system + user only...")
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-4-5",
+            max_tokens=1024,
+            messages=[
+                {"role": "system", "content": "SYS"},
+                {"role": "user", "content": "The actual question"},
+            ],
+        )
+
+        print("Action: converting to Kiro payload...")
+        payload = self._build(request)
+
+        content = payload["conversationState"]["currentMessage"]["userInputMessage"]["content"]
+        print(f"Content: {content!r}")
+        assert "The actual question" in content
+
+    def test_only_inline_system_no_user_raises(self):
+        """
+        What it does: messages with only inline system raises ValueError.
+        Purpose: Requirement 4.6 - reject when no user/assistant remains.
+        """
+        print("Setup: only inline system messages...")
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-4-5",
+            max_tokens=1024,
+            messages=[
+                {"role": "system", "content": "SYS only"},
+            ],
+        )
+
+        print("Action: expecting ValueError (No messages to send)...")
+        with pytest.raises(ValueError):
+            self._build(request)
+
+    def test_multiple_inline_system_order_in_prompt(self):
+        """
+        What it does: Multiple inline system messages keep order in the prompt.
+        Purpose: Requirement 5.1 - order preserved end-to-end.
+        """
+        print("Setup: system FIRST, user, system SECOND...")
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-4-5",
+            max_tokens=1024,
+            messages=[
+                {"role": "system", "content": "FIRST_SYS"},
+                {"role": "user", "content": "Hello"},
+                {"role": "system", "content": "SECOND_SYS"},
+            ],
+        )
+
+        print("Action: converting to Kiro payload...")
+        payload = self._build(request)
+
+        # System prompt is prepended to the current user message (history empty
+        # of user turns means it lands on current). Search wherever it lands.
+        user_input = payload["conversationState"]["currentMessage"]["userInputMessage"]
+        content = user_input["content"]
+        history_text = str(payload["conversationState"].get("history", []))
+        combined = content + history_text
+        print(f"Combined text: {combined!r}")
+        assert "FIRST_SYS" in combined
+        assert "SECOND_SYS" in combined
+        assert combined.index("FIRST_SYS") < combined.index("SECOND_SYS")

--- a/tests/unit/test_converters_core.py
+++ b/tests/unit/test_converters_core.py
@@ -33,6 +33,7 @@ from kiro.converters_core import (
     extract_tool_uses_from_message,
     sanitize_json_schema,
     convert_tools_to_kiro_format,
+    ensure_object_schema,
     convert_tool_results_to_kiro_format,
     tool_calls_to_text,
     tool_results_to_text,
@@ -2776,10 +2777,121 @@ class TestSanitizeJsonSchema:
         assert result["required"] == ["question", "options"]  # Non-empty required is preserved
         assert result["properties"]["question"]["type"] == "string"
 
+    def test_strips_dollar_schema_key(self):
+        """
+        What it does: Verifies the $schema meta key is removed.
+        Purpose: Root-cause fix for Kiro REQUEST_BODY_INVALID - Claude Code
+                 sends $schema on every tool definition.
+        """
+        print("Setup: schema with $schema meta key (Claude Code style)...")
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {"command": {"type": "string"}},
+            "required": ["command"],
+        }
 
-# ==================================================================================================
-# Tests for extract_tool_results_from_content
-# ==================================================================================================
+        print("Action: Sanitizing schema...")
+        result = sanitize_json_schema(schema)
+
+        print(f"Result: {result}")
+        assert "$schema" not in result
+        assert result["type"] == "object"
+        assert result["required"] == ["command"]
+        assert result["properties"]["command"]["type"] == "string"
+
+    def test_strips_other_meta_keys(self):
+        """
+        What it does: Verifies $id, $anchor and $comment are removed.
+        Purpose: Cover the full set of disallowed annotation keywords.
+        """
+        print("Setup: schema with $id/$anchor/$comment...")
+        schema = {
+            "$id": "https://example.com/s.json",
+            "$anchor": "root",
+            "$comment": "internal note",
+            "type": "object",
+            "properties": {"x": {"type": "number"}},
+        }
+
+        print("Action: Sanitizing schema...")
+        result = sanitize_json_schema(schema)
+
+        print(f"Result: {result}")
+        assert "$id" not in result
+        assert "$anchor" not in result
+        assert "$comment" not in result
+        assert result["properties"]["x"]["type"] == "number"
+
+    def test_strips_nested_dollar_schema(self):
+        """
+        What it does: Verifies $schema is stripped in nested property schemas.
+        Purpose: Ensure recursive sanitization covers nested objects.
+        """
+        print("Setup: nested schema with $schema in a property...")
+        schema = {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "type": "object",
+                    "properties": {"flag": {"type": "boolean"}},
+                }
+            },
+        }
+
+        print("Action: Sanitizing schema...")
+        result = sanitize_json_schema(schema)
+
+        print(f"Result: {result}")
+        assert "$schema" not in result["properties"]["config"]
+        assert result["properties"]["config"]["properties"]["flag"]["type"] == "boolean"
+
+    def test_strips_dollar_schema_inside_combinators(self):
+        """
+        What it does: Verifies $schema removed inside anyOf/oneOf lists.
+        Purpose: Ensure list-valued combinators are sanitized recursively.
+        """
+        print("Setup: schema with $schema inside anyOf entries...")
+        schema = {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "anyOf": [
+                        {"$schema": "http://json-schema.org/draft-07/schema#", "type": "string"},
+                        {"type": "integer"},
+                    ]
+                }
+            },
+        }
+
+        print("Action: Sanitizing schema...")
+        result = sanitize_json_schema(schema)
+
+        print(f"Result: {result}")
+        any_of = result["properties"]["value"]["anyOf"]
+        assert all("$schema" not in entry for entry in any_of)
+        assert any_of[0]["type"] == "string"
+        assert any_of[1]["type"] == "integer"
+
+    def test_preserves_structural_ref_and_defs(self):
+        """
+        What it does: Verifies $ref and $defs are NOT stripped.
+        Purpose: Structural keywords must be preserved to keep the schema valid.
+        """
+        print("Setup: schema using $ref and $defs...")
+        schema = {
+            "type": "object",
+            "properties": {"item": {"$ref": "#/$defs/Item"}},
+            "$defs": {"Item": {"type": "string"}},
+        }
+
+        print("Action: Sanitizing schema...")
+        result = sanitize_json_schema(schema)
+
+        print(f"Result: {result}")
+        assert result["properties"]["item"]["$ref"] == "#/$defs/Item"
+        assert result["$defs"]["Item"]["type"] == "string"
 
 class TestExtractToolResults:
     """Tests for extract_tool_results_from_content function."""
@@ -6455,3 +6567,127 @@ class TestBuildKiroPayloadWithThinkingConfig:
         print(f"Checking for <max_thinking_length>7000</max_thinking_length> in content...")
         assert "<max_thinking_length>7000</max_thinking_length>" in content
         assert "<thinking_mode>enabled</thinking_mode>" in content
+
+
+# ==================================================================================================
+# Tests for ensure_object_schema (Bedrock root-type requirement)
+# ==================================================================================================
+
+class TestEnsureObjectSchema:
+    """
+    Tests for ensure_object_schema.
+
+    Bedrock requires every tool's inputSchema.json.type to be "object"
+    (error: "toolConfig.tools.N.toolSpec.inputSchema.json.type must be one of
+    [object]"). This normalizes the root of a tool input schema.
+    """
+
+    def test_empty_schema_becomes_object(self):
+        """
+        What it does: An empty {} schema gains type=object and properties.
+        Purpose: No-argument tools often send {} which Bedrock rejects.
+        """
+        print("Action: normalizing {}...")
+        result = ensure_object_schema({})
+        print(f"Result: {result}")
+        assert result["type"] == "object"
+        assert result["properties"] == {}
+
+    def test_none_becomes_object(self):
+        """
+        What it does: None becomes a valid object schema.
+        Purpose: Defensive against missing input_schema.
+        """
+        print("Action: normalizing None...")
+        result = ensure_object_schema(None)
+        print(f"Result: {result}")
+        assert result == {"type": "object", "properties": {}}
+
+    def test_missing_type_added(self):
+        """
+        What it does: A schema with properties but no type gets type=object.
+        Purpose: Bedrock requires explicit root type.
+        """
+        print("Action: normalizing schema without type...")
+        result = ensure_object_schema({"properties": {"x": {"type": "string"}}})
+        print(f"Result: {result}")
+        assert result["type"] == "object"
+        assert result["properties"]["x"]["type"] == "string"
+
+    def test_non_object_root_type_forced_to_object(self):
+        """
+        What it does: A root type of "string" is forced to "object".
+        Purpose: Root container must be an object for tool args.
+        """
+        print("Action: normalizing schema with type=string...")
+        result = ensure_object_schema({"type": "string"})
+        print(f"Result: {result}")
+        assert result["type"] == "object"
+        assert result["properties"] == {}
+
+    def test_valid_object_schema_preserved(self):
+        """
+        What it does: A valid object schema is left intact.
+        Purpose: No-op for already-correct schemas.
+        """
+        print("Action: normalizing a valid object schema...")
+        schema = {
+            "type": "object",
+            "properties": {"cmd": {"type": "string"}},
+            "required": ["cmd"],
+        }
+        result = ensure_object_schema(schema)
+        print(f"Result: {result}")
+        assert result["type"] == "object"
+        assert result["properties"]["cmd"]["type"] == "string"
+        assert result["required"] == ["cmd"]
+
+    def test_object_without_properties_gets_properties(self):
+        """
+        What it does: An object schema lacking properties gets an empty map.
+        Purpose: Bedrock expects object schemas to declare properties.
+        """
+        print("Action: normalizing object schema without properties...")
+        result = ensure_object_schema({"type": "object"})
+        print(f"Result: {result}")
+        assert result["properties"] == {}
+
+    def test_does_not_mutate_input(self):
+        """
+        What it does: The input dict is not mutated in place.
+        Purpose: Avoid side effects on caller-owned schemas.
+        """
+        print("Action: ensuring input is not mutated...")
+        original = {"type": "string"}
+        ensure_object_schema(original)
+        print(f"Original after call: {original}")
+        assert original == {"type": "string"}
+
+
+class TestConvertToolsEnsuresObjectType:
+    """End-to-end: convert_tools_to_kiro_format guarantees object root type."""
+
+    def test_no_arg_tool_gets_object_schema(self):
+        """
+        What it does: A tool with empty input_schema yields type=object.
+        Purpose: Root-cause fix for Bedrock 'must be one of [object]' error.
+        """
+        print("Action: converting a no-arg tool...")
+        tools = [UnifiedTool(name="CronList", description="list", input_schema={})]
+        result = convert_tools_to_kiro_format(tools)
+        json_schema = result[0]["toolSpecification"]["inputSchema"]["json"]
+        print(f"Schema: {json_schema}")
+        assert json_schema["type"] == "object"
+        assert json_schema["properties"] == {}
+
+    def test_tool_with_bad_root_type_normalized(self):
+        """
+        What it does: A tool whose schema root type is not object is fixed.
+        Purpose: Ensure every emitted tool passes Bedrock validation.
+        """
+        print("Action: converting a tool with type=array root...")
+        tools = [UnifiedTool(name="Weird", description="d", input_schema={"type": "array"})]
+        result = convert_tools_to_kiro_format(tools)
+        json_schema = result[0]["toolSpecification"]["inputSchema"]["json"]
+        print(f"Schema: {json_schema}")
+        assert json_schema["type"] == "object"

--- a/tests/unit/test_debug_logger.py
+++ b/tests/unit/test_debug_logger.py
@@ -688,3 +688,137 @@ class TestDebugLoggerAppLogsCapture:
             print(f"Проверяем, что app_logs.txt НЕ создан...")
             app_logs_file = debug_dir / "app_logs.txt"
             assert not app_logs_file.exists()
+
+
+class TestLogKiroRequestPayload:
+    """
+    Tests for log_kiro_request_payload().
+
+    This method is a performance optimization: it must skip json.dumps
+    serialization entirely when debug logging is disabled (the default),
+    while preserving identical output when a debug mode is active.
+    """
+
+    @staticmethod
+    def _make_logger(debug_dir):
+        """Build a fresh-initialized DebugLogger bound to the given debug_dir."""
+        from kiro.debug_logger import DebugLogger
+        instance = DebugLogger.__new__(DebugLogger)
+        instance._initialized = False
+        instance.__init__()
+        instance.debug_dir = debug_dir
+        return instance
+
+    def test_off_mode_skips_serialization_entirely(self, tmp_path):
+        """
+        What it does: Verifies that in 'off' mode json.dumps is NEVER called.
+        Goal: This is the core optimization - no CPU wasted serializing a
+              payload that will only be discarded when logging is disabled.
+        """
+        debug_dir = tmp_path / "debug_logs"
+        with patch('kiro.debug_logger.DEBUG_MODE', 'off'):
+            instance = self._make_logger(debug_dir)
+            with patch('kiro.debug_logger.json.dumps') as mock_dumps:
+                instance.log_kiro_request_payload({"conversationState": {"big": "x" * 1000}})
+                mock_dumps.assert_not_called()
+            # Nothing buffered and no file created
+            assert instance._kiro_request_body_buffer is None
+            assert not debug_dir.exists()
+
+    def test_errors_mode_serializes_and_buffers(self, tmp_path):
+        """
+        What it does: Verifies that in 'errors' mode the payload is serialized
+                      and buffered in memory (but not yet written to disk).
+        Goal: Ensure the buffered-until-error contract still holds.
+        """
+        debug_dir = tmp_path / "debug_logs"
+        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+            instance = self._make_logger(debug_dir)
+            instance.log_kiro_request_payload({"model": "claude-sonnet-4.5", "value": 42})
+
+            assert instance._kiro_request_body_buffer is not None
+            parsed = json.loads(instance._kiro_request_body_buffer)
+            assert parsed["model"] == "claude-sonnet-4.5"
+            assert parsed["value"] == 42
+            # Buffered only - no file until flush_on_error
+            assert not (debug_dir / "kiro_request_body.json").exists()
+
+    def test_errors_mode_flush_writes_payload_to_file(self, tmp_path):
+        """
+        What it does: Verifies the buffered payload is written on flush_on_error.
+        Goal: Confirm end-to-end behavior in the intended troubleshooting mode.
+        """
+        debug_dir = tmp_path / "debug_logs"
+        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+            instance = self._make_logger(debug_dir)
+            instance.log_kiro_request_payload({"conversationState": {"id": "abc"}})
+            instance.flush_on_error(400, "Improperly formed request")
+
+            written = debug_dir / "kiro_request_body.json"
+            assert written.exists()
+            assert json.loads(written.read_text())["conversationState"]["id"] == "abc"
+
+    def test_all_mode_writes_payload_immediately(self, tmp_path):
+        """
+        What it does: Verifies that in 'all' mode the payload is written to disk
+                      immediately, pretty-printed.
+        Goal: Ensure the developer 'all' mode still captures every request.
+        """
+        debug_dir = tmp_path / "debug_logs"
+        debug_dir.mkdir()
+        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+            instance = self._make_logger(debug_dir)
+            instance.log_kiro_request_payload({"foo": "bar", "nested": {"a": 1}})
+
+            written = debug_dir / "kiro_request_body.json"
+            assert written.exists()
+            content = written.read_text()
+            assert json.loads(content)["foo"] == "bar"
+            # Pretty-printed (indent=2) -> contains newlines and indentation
+            assert "\n" in content
+            assert "  " in content
+
+    def test_non_serializable_payload_does_not_raise(self, tmp_path):
+        """
+        What it does: Verifies a non-JSON-serializable payload is handled
+                      gracefully (warning logged, nothing buffered/written).
+        Goal: A logging failure must never break the actual API request.
+        """
+        debug_dir = tmp_path / "debug_logs"
+        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+            instance = self._make_logger(debug_dir)
+            # object() cannot be serialized by json.dumps
+            instance.log_kiro_request_payload({"bad": object()})
+
+            assert instance._kiro_request_body_buffer is None
+            assert not (debug_dir / "kiro_request_body.json").exists()
+
+    def test_off_mode_ignores_non_serializable_payload_without_touching_json(self, tmp_path):
+        """
+        What it does: Verifies that in 'off' mode a non-serializable payload is
+                      not even inspected (json.dumps is never reached).
+        Goal: Guarantee the fast path returns before any serialization attempt,
+              so even a problematic payload costs nothing when logging is off.
+        """
+        debug_dir = tmp_path / "debug_logs"
+        with patch('kiro.debug_logger.DEBUG_MODE', 'off'):
+            instance = self._make_logger(debug_dir)
+            with patch('kiro.debug_logger.json.dumps') as mock_dumps:
+                # Should not raise and should not call json.dumps
+                instance.log_kiro_request_payload({"bad": object()})
+                mock_dumps.assert_not_called()
+
+    def test_output_matches_legacy_inline_serialization(self, tmp_path):
+        """
+        What it does: Verifies the buffered bytes are byte-for-byte identical to
+                      the previous inline json.dumps(...).encode('utf-8') call.
+        Goal: Prove this optimization changed performance, not output.
+        """
+        debug_dir = tmp_path / "debug_logs"
+        payload = {"conversationState": {"history": [1, 2, 3]}, "profileArn": "arn:test"}
+        expected = json.dumps(payload, ensure_ascii=False, indent=2).encode('utf-8')
+
+        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+            instance = self._make_logger(debug_dir)
+            instance.log_kiro_request_payload(payload)
+            assert instance._kiro_request_body_buffer == expected

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -289,3 +289,130 @@ class TestValidationExceptionHandlerEdgeCases:
             
             body = json.loads(response.body.decode())
             assert "Привет мир" in body["body"]
+
+
+class TestMissingProfileArnError:
+    """Tests for the MissingProfileArnError exception."""
+
+    def test_is_subclass_of_value_error(self):
+        """
+        What it does: Verifies MissingProfileArnError subclasses ValueError.
+        Purpose: Ensure existing `except ValueError` handlers in routes catch it
+                 and translate it to HTTP 400.
+        """
+        print("Setup: importing MissingProfileArnError...")
+        from kiro.exceptions import MissingProfileArnError
+
+        print("Checking: subclass of ValueError...")
+        assert issubclass(MissingProfileArnError, ValueError)
+
+    def test_default_message_mentions_profile_arn_key(self):
+        """
+        What it does: Verifies default message includes the literal PROFILE_ARN key.
+        Purpose: Requirement 2.3 - actionable error referencing the config key.
+        """
+        print("Setup: creating error with default message...")
+        from kiro.exceptions import MissingProfileArnError
+
+        err = MissingProfileArnError()
+        message = str(err)
+
+        print(f"Message: {message}")
+        assert "PROFILE_ARN" in message
+        assert "required" in message.lower()
+
+    def test_default_message_excludes_secrets(self):
+        """
+        What it does: Verifies the default message contains no credential values.
+        Purpose: Requirement 2.4 - exclude tokens/keys from the error.
+        """
+        print("Setup: creating error with default message...")
+        from kiro.exceptions import MissingProfileArnError
+
+        message = str(MissingProfileArnError()).lower()
+
+        print("Checking: no secret-like tokens leak into the message...")
+        for forbidden in ("token", "secret", "access-key", "accesskey", "password", "bearer"):
+            assert forbidden not in message
+
+    def test_custom_message_is_used(self):
+        """
+        What it does: Verifies a custom message overrides the default.
+        Purpose: Allow callers to provide context-specific messages.
+        """
+        print("Setup: creating error with custom message...")
+        from kiro.exceptions import MissingProfileArnError
+
+        err = MissingProfileArnError("custom PROFILE_ARN message")
+
+        print(f"Message: {err}")
+        assert str(err) == "custom PROFILE_ARN message"
+
+    def test_can_be_caught_as_value_error(self):
+        """
+        What it does: Verifies the error is caught by `except ValueError`.
+        Purpose: Confirm route handler compatibility at runtime.
+        """
+        print("Setup: raising MissingProfileArnError...")
+        from kiro.exceptions import MissingProfileArnError
+
+        caught = False
+        try:
+            raise MissingProfileArnError()
+        except ValueError:
+            caught = True
+
+        print(f"Caught as ValueError: {caught}")
+        assert caught is True
+
+
+class TestMalformedProfileArnError:
+    """Tests for the MalformedProfileArnError exception."""
+
+    def test_is_subclass_of_value_error(self):
+        """
+        What it does: Verifies MalformedProfileArnError subclasses ValueError.
+        Purpose: Ensure route `except ValueError` handlers catch it.
+        """
+        from kiro.exceptions import MalformedProfileArnError
+        assert issubclass(MalformedProfileArnError, ValueError)
+
+    def test_message_mentions_profile_arn_and_placeholder(self):
+        """
+        What it does: Message references PROFILE_ARN and the placeholder guidance.
+        Purpose: Actionable error for the malformed/placeholder case.
+        """
+        from kiro.exceptions import MalformedProfileArnError
+        msg = str(MalformedProfileArnError("arn:aws:codewhisperer:us-east-1:..."))
+        print(f"Message: {msg}")
+        assert "PROFILE_ARN" in msg
+        assert "..." in msg  # guidance about the placeholder
+        assert "profile/" in msg  # shows the expected format
+
+    def test_message_echoes_offending_value(self):
+        """
+        What it does: Includes the offending ARN string to help the user.
+        Purpose: An ARN is an identifier (not a secret), so echoing aids fixing.
+        """
+        from kiro.exceptions import MalformedProfileArnError
+        msg = str(MalformedProfileArnError("arn:aws:codewhisperer:us-east-1:..."))
+        assert "arn:aws:codewhisperer:us-east-1:..." in msg
+
+    def test_message_excludes_secrets(self):
+        """
+        What it does: Message contains no credential-like tokens.
+        Purpose: Never leak secrets in errors.
+        """
+        from kiro.exceptions import MalformedProfileArnError
+        msg = str(MalformedProfileArnError("arn:aws:codewhisperer:us-east-1:...")).lower()
+        for forbidden in ("token", "secret", "access-key", "bearer", "password"):
+            assert forbidden not in msg
+
+    def test_works_without_value(self):
+        """
+        What it does: Builds a sensible message when no value is provided.
+        Purpose: Defensive default.
+        """
+        from kiro.exceptions import MalformedProfileArnError
+        msg = str(MalformedProfileArnError())
+        assert "PROFILE_ARN" in msg

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -1757,3 +1757,81 @@ class TestThinkingParameter:
         print(f"Comparing thinking: got={request.thinking}")
         assert request.thinking is not None
         assert request.thinking["type"] == "disabled"
+
+
+class TestAnthropicMessageInlineSystemRole:
+    """
+    Tests for inline "system" role acceptance in AnthropicMessage.
+
+    Some clients (e.g. Claude Code) place {"role": "system", ...} inside the
+    messages array. The model must accept this without a validation error
+    (Requirement 4.1).
+    """
+
+    def test_accepts_system_role_with_string_content(self):
+        """
+        What it does: Accepts a message with role="system" and string content.
+        Purpose: Requirement 4.1 - no 422 for inline system role.
+        """
+        print("Setup: building a system-role message with string content...")
+        msg = AnthropicMessage(role="system", content="You are helpful")
+
+        print(f"Result: role={msg.role}, content={msg.content!r}")
+        assert msg.role == "system"
+        assert msg.content == "You are helpful"
+
+    def test_accepts_system_role_with_content_blocks(self):
+        """
+        What it does: Accepts role="system" with a list of content blocks.
+        Purpose: Requirement 5.3 - list content must be allowed.
+        """
+        print("Setup: building system-role message with content blocks...")
+        msg = AnthropicMessage(
+            role="system",
+            content=[{"type": "text", "text": "Block A"}],
+        )
+
+        print(f"Result: role={msg.role}, content={msg.content!r}")
+        assert msg.role == "system"
+        assert isinstance(msg.content, list)
+
+    def test_still_accepts_user_and_assistant_roles(self):
+        """
+        What it does: Verifies user/assistant roles still validate.
+        Purpose: Ensure we did not break existing role handling.
+        """
+        print("Setup: building user and assistant messages...")
+        user = AnthropicMessage(role="user", content="hi")
+        assistant = AnthropicMessage(role="assistant", content="hello")
+
+        print(f"Result: {user.role}, {assistant.role}")
+        assert user.role == "user"
+        assert assistant.role == "assistant"
+
+    def test_rejects_unknown_role(self):
+        """
+        What it does: Verifies an unrelated role still fails validation.
+        Purpose: Ensure the Literal was widened only to include "system".
+        """
+        print("Setup: attempting an unknown role 'developer'...")
+        with pytest.raises(ValidationError):
+            AnthropicMessage(role="developer", content="hi")
+
+    def test_request_accepts_inline_system_message(self):
+        """
+        What it does: A full request with an inline system message validates.
+        Purpose: Requirement 4.1 at the request level (no 422).
+        """
+        print("Setup: building a request with an inline system message...")
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-4-5",
+            max_tokens=1024,
+            messages=[
+                {"role": "system", "content": "Be concise"},
+                {"role": "user", "content": "Hello"},
+            ],
+        )
+
+        print(f"Result: {len(request.messages)} messages")
+        assert request.messages[0].role == "system"
+        assert request.messages[1].role == "user"

--- a/tests/unit/test_network_errors.py
+++ b/tests/unit/test_network_errors.py
@@ -15,7 +15,8 @@ from kiro.network_errors import (
     NetworkErrorInfo,
     classify_network_error,
     format_error_for_user,
-    get_short_error_message
+    get_short_error_message,
+    build_http_error_detail,
 )
 
 
@@ -669,3 +670,70 @@ class TestNetworkErrorInfoDataclass:
         assert error_info.technical_details == "Technical details"
         assert error_info.is_retryable is True
         assert error_info.suggested_http_code == 502
+
+
+class TestBuildHttpErrorDetail:
+    """Tests for build_http_error_detail() - the shared HTTPException detail formatter."""
+
+    def _make_info(self, steps):
+        return NetworkErrorInfo(
+            category=ErrorCategory.CONNECTION_RESET,
+            user_message="Connection reset - the server closed the connection unexpectedly.",
+            troubleshooting_steps=steps,
+            technical_details="RemoteProtocolError: peer closed connection (incomplete chunked read)",
+            is_retryable=True,
+            suggested_http_code=502,
+        )
+
+    def test_includes_user_message_steps_and_technical_details(self):
+        """
+        What it does: Verifies the detail string contains the user message,
+                      numbered troubleshooting steps, and technical details.
+        Goal: Ensure the classified error is fully actionable for the client.
+        """
+        info = self._make_info(["Try again in a few moments", "Check network stability"])
+        detail = build_http_error_detail(info)
+
+        assert "Connection reset" in detail
+        assert "Troubleshooting:" in detail
+        assert "1. Try again in a few moments" in detail
+        assert "2. Check network stability" in detail
+        assert "Technical details:" in detail
+        assert "incomplete chunked read" in detail
+
+    def test_omits_troubleshooting_section_when_no_steps(self):
+        """
+        What it does: Verifies the 'Troubleshooting:' header is not present when
+                      there are no steps.
+        Goal: Avoid an empty, confusing section.
+        """
+        info = self._make_info([])
+        detail = build_http_error_detail(info)
+
+        assert "Troubleshooting:" not in detail
+        assert "Technical details:" in detail
+
+    def test_result_is_stripped(self):
+        """
+        What it does: Verifies the returned string has no leading/trailing whitespace.
+        Goal: Keep client-facing error messages clean.
+        """
+        info = self._make_info(["Step one"])
+        detail = build_http_error_detail(info)
+
+        assert detail == detail.strip()
+
+    def test_matches_classified_remote_protocol_error(self):
+        """
+        What it does: End-to-end - classify a RemoteProtocolError and build the detail.
+        Goal: Confirm the mid-stream drop maps to a 502 connectivity detail.
+        """
+        err = httpx.RemoteProtocolError(
+            "peer closed connection without sending complete message body (incomplete chunked read)"
+        )
+        info = classify_network_error(err)
+        detail = build_http_error_detail(info)
+
+        assert info.suggested_http_code == 502
+        assert info.is_retryable is True
+        assert "Network request failed" in detail or "connection" in detail.lower()

--- a/tests/unit/test_profile_resolver.py
+++ b/tests/unit/test_profile_resolver.py
@@ -1,0 +1,242 @@
+# -*- coding: utf-8 -*-
+
+"""
+Unit tests for profile_resolver module.
+
+Tests the shared Profile_Resolver rule used by both API surfaces (OpenAI and
+Anthropic) and both request modes (streaming and non-streaming) to determine
+the effective profileArn:
+
+- Auth manager profileArn takes precedence when non-empty
+- PROFILE_ARN config is used as a fallback
+- Empty result is returned (and signals missing profileArn) when neither is set
+- Whitespace-only values are treated as missing
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from kiro.profile_resolver import resolve_profile_arn, is_valid_profile_arn
+
+
+class _Auth:
+    """Minimal stand-in for an auth manager exposing profile_arn."""
+
+    def __init__(self, profile_arn):
+        self.profile_arn = profile_arn
+
+
+class TestResolveProfileArnSuccess:
+    """Tests for successful profileArn resolution."""
+
+    def test_returns_auth_manager_arn_when_present(self):
+        """
+        What it does: Returns the auth manager profileArn when it is non-empty.
+        Purpose: Requirement 3.1 - auth manager value takes precedence.
+        """
+        print("Setup: auth manager with a profile ARN...")
+        auth = _Auth("arn:aws:codewhisperer:us-east-1:111:profile/auth")
+
+        print("Action: resolving profile ARN...")
+        with patch("kiro.profile_resolver.PROFILE_ARN", "arn:config:fallback"):
+            result = resolve_profile_arn(auth)
+
+        print(f"Result: {result}")
+        assert result == "arn:aws:codewhisperer:us-east-1:111:profile/auth"
+
+    def test_falls_back_to_config_when_auth_empty(self):
+        """
+        What it does: Uses PROFILE_ARN when auth manager profileArn is empty.
+        Purpose: Requirement 3.2 - config fallback.
+        """
+        print("Setup: empty auth manager ARN, config ARN set...")
+        auth = _Auth("")
+
+        print("Action: resolving profile ARN...")
+        with patch("kiro.profile_resolver.PROFILE_ARN", "arn:config:fallback"):
+            result = resolve_profile_arn(auth)
+
+        print(f"Result: {result}")
+        assert result == "arn:config:fallback"
+
+    def test_falls_back_to_config_when_auth_none(self):
+        """
+        What it does: Uses PROFILE_ARN when auth manager profileArn is None.
+        Purpose: Ensure None auth value is handled like empty.
+        """
+        print("Setup: None auth manager ARN, config ARN set...")
+        auth = _Auth(None)
+
+        print("Action: resolving profile ARN...")
+        with patch("kiro.profile_resolver.PROFILE_ARN", "arn:config:fallback"):
+            result = resolve_profile_arn(auth)
+
+        print(f"Result: {result}")
+        assert result == "arn:config:fallback"
+
+
+class TestResolveProfileArnMissing:
+    """Tests for the empty/missing result path."""
+
+    def test_returns_empty_when_both_missing(self):
+        """
+        What it does: Returns empty string when neither source provides a value.
+        Purpose: Requirement 3.3 - empty result signals missing profileArn.
+        """
+        print("Setup: empty auth ARN, empty config...")
+        auth = _Auth("")
+
+        print("Action: resolving profile ARN...")
+        with patch("kiro.profile_resolver.PROFILE_ARN", ""):
+            result = resolve_profile_arn(auth)
+
+        print(f"Result: {result!r}")
+        assert result == ""
+
+    def test_returns_empty_when_auth_missing_attr(self):
+        """
+        What it does: Handles an auth manager without a profile_arn attribute.
+        Purpose: Defensive - getattr default must not raise.
+        """
+        print("Setup: auth manager missing profile_arn attribute...")
+        auth = MagicMock(spec=[])  # no attributes
+
+        print("Action: resolving profile ARN...")
+        with patch("kiro.profile_resolver.PROFILE_ARN", ""):
+            result = resolve_profile_arn(auth)
+
+        print(f"Result: {result!r}")
+        assert result == ""
+
+
+class TestResolveProfileArnEdgeCases:
+    """Paranoid edge-case checks."""
+
+    def test_whitespace_only_auth_arn_treated_as_missing(self):
+        """
+        What it does: A whitespace-only auth ARN falls back to config.
+        Purpose: Ensure whitespace is not mistaken for a real ARN.
+        """
+        print("Setup: whitespace auth ARN, config ARN set...")
+        auth = _Auth("   ")
+
+        print("Action: resolving profile ARN...")
+        with patch("kiro.profile_resolver.PROFILE_ARN", "arn:config:fallback"):
+            result = resolve_profile_arn(auth)
+
+        print(f"Result: {result!r}")
+        assert result == "arn:config:fallback"
+
+    def test_whitespace_only_everywhere_returns_empty(self):
+        """
+        What it does: Whitespace in both sources yields an empty result.
+        Purpose: Requirement 3.3 - whitespace-only must signal missing.
+        """
+        print("Setup: whitespace auth ARN and whitespace config...")
+        auth = _Auth("  ")
+
+        print("Action: resolving profile ARN...")
+        with patch("kiro.profile_resolver.PROFILE_ARN", "   "):
+            result = resolve_profile_arn(auth)
+
+        print(f"Result: {result!r}")
+        assert result == ""
+
+    def test_auth_arn_is_stripped(self):
+        """
+        What it does: Surrounding whitespace on the auth ARN is stripped.
+        Purpose: Ensure a clean value is passed downstream.
+        """
+        print("Setup: auth ARN with surrounding whitespace...")
+        auth = _Auth("  arn:aws:profile/x  ")
+
+        print("Action: resolving profile ARN...")
+        with patch("kiro.profile_resolver.PROFILE_ARN", ""):
+            result = resolve_profile_arn(auth)
+
+        print(f"Result: {result!r}")
+        assert result == "arn:aws:profile/x"
+
+
+class TestIsValidProfileArn:
+    """
+    Tests for is_valid_profile_arn.
+
+    The validator must reject the documentation placeholder
+    (arn:aws:codewhisperer:us-east-1:...) and other malformed values while
+    accepting real CodeWhisperer profile ARNs.
+    """
+
+    def test_accepts_valid_arn(self):
+        """
+        What it does: Accepts a well-formed CodeWhisperer profile ARN.
+        Purpose: Ensure real ARNs pass validation.
+        """
+        print("Setup: valid ARN...")
+        arn = "arn:aws:codewhisperer:us-east-1:123456789012:profile/EHGA3GRVQMUK"
+
+        print("Action: validating...")
+        assert is_valid_profile_arn(arn) is True
+
+    def test_accepts_other_regions(self):
+        """
+        What it does: Accepts ARNs from non us-east-1 regions.
+        Purpose: Region segment must be flexible.
+        """
+        print("Setup: eu-central-1 ARN...")
+        arn = "arn:aws:codewhisperer:eu-central-1:123456789012:profile/ABC123"
+
+        print("Action: validating...")
+        assert is_valid_profile_arn(arn) is True
+
+    def test_rejects_dots_placeholder(self):
+        """
+        What it does: Rejects the literal '...' placeholder.
+        Purpose: Root-cause guard for the REQUEST_BODY_INVALID confusion.
+        """
+        print("Setup: placeholder ARN...")
+        arn = "arn:aws:codewhisperer:us-east-1:..."
+
+        print("Action: validating...")
+        assert is_valid_profile_arn(arn) is False
+
+    def test_rejects_empty(self):
+        """
+        What it does: Rejects empty string.
+        Purpose: Empty is missing, not malformed - but still not valid.
+        """
+        print("Action: validating empty...")
+        assert is_valid_profile_arn("") is False
+
+    def test_rejects_non_arn(self):
+        """
+        What it does: Rejects an unrelated string.
+        Purpose: Guard against garbage values.
+        """
+        print("Action: validating 'auto'...")
+        assert is_valid_profile_arn("auto") is False
+
+    def test_rejects_short_account_id(self):
+        """
+        What it does: Rejects an account id that is non-numeric (placeholder-like).
+        Purpose: The account-id segment must be digits, catching '...'.
+        """
+        print("Action: validating non-numeric account id...")
+        assert is_valid_profile_arn("arn:aws:codewhisperer:us-east-1:ab12:profile/x") is False
+
+    def test_rejects_missing_profile_segment(self):
+        """
+        What it does: Rejects an ARN without the profile/<id> segment.
+        Purpose: The profile path is required.
+        """
+        print("Action: validating ARN missing profile segment...")
+        assert is_valid_profile_arn("arn:aws:codewhisperer:us-east-1:123456789012:") is False
+
+    def test_strips_surrounding_whitespace(self):
+        """
+        What it does: Accepts a valid ARN with surrounding whitespace.
+        Purpose: Be lenient about stray whitespace from config files.
+        """
+        print("Action: validating padded ARN...")
+        arn = "  arn:aws:codewhisperer:us-east-1:123456789012:profile/ABC  "
+        assert is_valid_profile_arn(arn) is True

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -1001,10 +1001,12 @@ class TestAnthropicHTTPClientSelection:
     requests use shared client for connection pooling.
     """
     
+    @patch('kiro.routes_anthropic.resolve_profile_arn', return_value="arn:aws:codewhisperer:us-east-1:123456789012:profile/TEST")
     @patch('kiro.routes_anthropic.KiroHttpClient')
     def test_streaming_uses_per_request_client(
         self,
         mock_kiro_http_client_class,
+        mock_resolve_arn,
         test_client,
         valid_proxy_api_key
     ):
@@ -1045,10 +1047,12 @@ class TestAnthropicHTTPClientSelection:
             "Streaming should use per-request client"
         print("✅ Anthropic streaming correctly uses per-request client")
     
+    @patch('kiro.routes_anthropic.resolve_profile_arn', return_value="arn:aws:codewhisperer:us-east-1:123456789012:profile/TEST")
     @patch('kiro.routes_anthropic.KiroHttpClient')
     def test_non_streaming_uses_shared_client(
         self,
         mock_kiro_http_client_class,
+        mock_resolve_arn,
         test_client,
         valid_proxy_api_key
     ):
@@ -2519,3 +2523,210 @@ class TestCountTokensEndpoint:
         assert data["input_tokens"] > 0
         
         print("✅ max_tokens is NOT required for count_tokens")
+
+
+# =============================================================================
+# Tests for Missing Profile ARN handling (request-validation-fixes)
+# =============================================================================
+
+class TestMessagesMissingProfileArn:
+    """
+    Tests for the Missing_Profile_Error on /v1/messages.
+
+    Requirements 1.1, 1.3, 1.4, 2.1, 2.3, 2.4: when no profileArn can be
+    resolved, the gateway must return an HTTP 400 Anthropic-format error
+    (error.type == "invalid_request_error") WITHOUT contacting the Kiro API,
+    in both streaming and non-streaming modes.
+    """
+
+    @patch("kiro.routes_anthropic.KiroHttpClient")
+    @patch("kiro.routes_anthropic.resolve_profile_arn", return_value="")
+    def test_non_streaming_missing_profile_returns_400(
+        self, mock_resolve, mock_http_client, test_client, valid_proxy_api_key
+    ):
+        """
+        What it does: Non-streaming request with no profileArn returns 400.
+        Purpose: Requirements 1.4, 2.1 - Anthropic-format error, no upstream call.
+        """
+        print("Action: POST /v1/messages with empty resolved profileArn...")
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-4-5",
+                "max_tokens": 1024,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": False,
+            },
+        )
+
+        print(f"Status: {response.status_code}, body: {response.json()}")
+        assert response.status_code == 400
+        body = response.json()
+        assert body["type"] == "error"
+        assert body["error"]["type"] == "invalid_request_error"
+        assert "PROFILE_ARN" in body["error"]["message"]
+        assert not mock_http_client.called
+
+    @patch("kiro.routes_anthropic.KiroHttpClient")
+    @patch("kiro.routes_anthropic.resolve_profile_arn", return_value="")
+    def test_streaming_missing_profile_returns_400(
+        self, mock_resolve, mock_http_client, test_client, valid_proxy_api_key
+    ):
+        """
+        What it does: Streaming request with no profileArn returns 400.
+        Purpose: Requirements 1.3, 2.1 - no streaming connection opened.
+        """
+        print("Action: POST /v1/messages stream=true, empty profileArn...")
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-4-5",
+                "max_tokens": 1024,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+            },
+        )
+
+        print(f"Status: {response.status_code}, body: {response.json()}")
+        assert response.status_code == 400
+        body = response.json()
+        assert body["error"]["type"] == "invalid_request_error"
+        assert "PROFILE_ARN" in body["error"]["message"]
+        assert not mock_http_client.called
+
+    @patch("kiro.routes_anthropic.KiroHttpClient")
+    @patch("kiro.routes_anthropic.resolve_profile_arn", return_value="")
+    def test_missing_profile_error_excludes_secrets(
+        self, mock_resolve, mock_http_client, test_client, valid_proxy_api_key
+    ):
+        """
+        What it does: The error message contains no credential values.
+        Purpose: Requirement 2.4 - exclude tokens/keys from the error.
+        """
+        print("Action: POST /v1/messages with empty profileArn...")
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-4-5",
+                "max_tokens": 1024,
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        )
+
+        message = response.json()["error"]["message"].lower()
+        print(f"Message: {message}")
+        for forbidden in ("token", "secret", "access-key", "bearer", "password"):
+            assert forbidden not in message
+
+
+class TestMessagesInlineSystemEndpoint:
+    """
+    Endpoint-level test that an inline system role no longer yields a 422.
+
+    Requirement 4.1: the request must validate (no 422) when a message has
+    role="system" inside the messages array.
+    """
+
+    @patch("kiro.routes_anthropic.KiroHttpClient")
+    def test_inline_system_role_not_422(
+        self, mock_http_client, test_client, valid_proxy_api_key
+    ):
+        """
+        What it does: Inline system role does not cause a 422 validation error.
+        Purpose: Requirement 4.1 - graceful acceptance at the endpoint.
+        """
+        # Make the HTTP client raise so we don't depend on a full upstream mock;
+        # we only care that validation (422) is passed.
+        mock_instance = AsyncMock()
+        mock_instance.request_with_retry = AsyncMock(side_effect=Exception("blocked"))
+        mock_instance.close = AsyncMock()
+        mock_http_client.return_value = mock_instance
+
+        print("Action: POST /v1/messages with inline system role...")
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-4-5",
+                "max_tokens": 1024,
+                "messages": [
+                    {"role": "system", "content": "Be brief"},
+                    {"role": "user", "content": "Hello"},
+                ],
+            },
+        )
+
+        print(f"Status: {response.status_code}")
+        assert response.status_code != 422
+
+
+class TestMessagesMalformedProfileArn:
+    """
+    Tests for the Malformed_Profile_Error on /v1/messages.
+
+    When a profileArn is present but malformed (e.g. the '...' placeholder),
+    the gateway must return HTTP 400 with an actionable Anthropic-format error
+    WITHOUT contacting the Kiro API, in both streaming and non-streaming modes.
+    """
+
+    PLACEHOLDER = "arn:aws:codewhisperer:us-east-1:..."
+
+    @patch("kiro.routes_anthropic.KiroHttpClient")
+    @patch("kiro.routes_anthropic.resolve_profile_arn")
+    def test_non_streaming_malformed_profile_returns_400(
+        self, mock_resolve, mock_http_client, test_client, valid_proxy_api_key
+    ):
+        """
+        What it does: Non-streaming request with placeholder ARN returns 400.
+        Purpose: Actionable Anthropic-format error, no upstream call.
+        """
+        mock_resolve.return_value = self.PLACEHOLDER
+        print("Action: POST /v1/messages with placeholder profileArn...")
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-4-5",
+                "max_tokens": 1024,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": False,
+            },
+        )
+
+        print(f"Status: {response.status_code}, body: {response.json()}")
+        assert response.status_code == 400
+        body = response.json()
+        assert body["type"] == "error"
+        assert body["error"]["type"] == "invalid_request_error"
+        assert "PROFILE_ARN" in body["error"]["message"]
+        assert not mock_http_client.called
+
+    @patch("kiro.routes_anthropic.KiroHttpClient")
+    @patch("kiro.routes_anthropic.resolve_profile_arn")
+    def test_streaming_malformed_profile_returns_400(
+        self, mock_resolve, mock_http_client, test_client, valid_proxy_api_key
+    ):
+        """
+        What it does: Streaming request with placeholder ARN returns 400.
+        Purpose: No streaming connection opened on malformed ARN.
+        """
+        mock_resolve.return_value = self.PLACEHOLDER
+        print("Action: POST /v1/messages stream=true, placeholder ARN...")
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-4-5",
+                "max_tokens": 1024,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+            },
+        )
+
+        print(f"Status: {response.status_code}, body: {response.json()}")
+        assert response.status_code == 400
+        assert response.json()["error"]["type"] == "invalid_request_error"
+        assert not mock_http_client.called

--- a/tests/unit/test_routes_openai.py
+++ b/tests/unit/test_routes_openai.py
@@ -892,10 +892,12 @@ class TestHTTPClientSelection:
     requests use shared client for connection pooling.
     """
     
+    @patch('kiro.routes_openai.resolve_profile_arn', return_value="arn:aws:codewhisperer:us-east-1:123456789012:profile/TEST")
     @patch('kiro.routes_openai.KiroHttpClient')
     def test_streaming_uses_per_request_client(
         self,
         mock_kiro_http_client_class,
+        mock_resolve_arn,
         test_client,
         valid_proxy_api_key
     ):
@@ -935,10 +937,12 @@ class TestHTTPClientSelection:
             "Streaming should use per-request client"
         print("✅ Streaming correctly uses per-request client")
     
+    @patch('kiro.routes_openai.resolve_profile_arn', return_value="arn:aws:codewhisperer:us-east-1:123456789012:profile/TEST")
     @patch('kiro.routes_openai.KiroHttpClient')
     def test_non_streaming_uses_shared_client(
         self,
         mock_kiro_http_client_class,
+        mock_resolve_arn,
         test_client,
         valid_proxy_api_key
     ):
@@ -1998,3 +2002,164 @@ class TestChatCompletionsLegacyMode:
         
         assert failover_enabled is False
         print("✅ Legacy mode correctly skips failover loop")
+
+
+
+# =============================================================================
+# Tests for Missing Profile ARN handling (request-validation-fixes)
+# =============================================================================
+
+class TestChatCompletionsMissingProfileArn:
+    """
+    Tests for the Missing_Profile_Error on /v1/chat/completions.
+
+    Requirements 1.2, 1.3, 1.4, 2.2, 2.3, 2.4: when no profileArn can be
+    resolved, the gateway must return an HTTP 400 OpenAI-format error WITHOUT
+    contacting the Kiro API, in both streaming and non-streaming modes.
+    """
+
+    @patch("kiro.routes_openai.KiroHttpClient")
+    @patch("kiro.routes_openai.resolve_profile_arn", return_value="")
+    def test_non_streaming_missing_profile_returns_400(
+        self, mock_resolve, mock_http_client, test_client, valid_proxy_api_key
+    ):
+        """
+        What it does: Non-streaming request with no profileArn returns 400.
+        Purpose: Requirements 1.4, 2.2 - actionable error, no upstream call.
+        """
+        print("Action: POST /v1/chat/completions with empty resolved profileArn...")
+        response = test_client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
+            json={
+                "model": "claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": False,
+            },
+        )
+
+        print(f"Status: {response.status_code}, body: {response.json()}")
+        assert response.status_code == 400
+        body = response.json()
+        assert "error" in body
+        assert body["error"]["type"] == "invalid_request_error"
+        assert "PROFILE_ARN" in body["error"]["message"]
+        # The Kiro HTTP client must never be constructed.
+        assert not mock_http_client.called
+
+    @patch("kiro.routes_openai.KiroHttpClient")
+    @patch("kiro.routes_openai.resolve_profile_arn", return_value="")
+    def test_streaming_missing_profile_returns_400(
+        self, mock_resolve, mock_http_client, test_client, valid_proxy_api_key
+    ):
+        """
+        What it does: Streaming request with no profileArn returns 400.
+        Purpose: Requirements 1.3, 2.2 - no streaming connection opened.
+        """
+        print("Action: POST /v1/chat/completions stream=true, empty profileArn...")
+        response = test_client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
+            json={
+                "model": "claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+            },
+        )
+
+        print(f"Status: {response.status_code}, body: {response.json()}")
+        assert response.status_code == 400
+        body = response.json()
+        assert body["error"]["type"] == "invalid_request_error"
+        assert "PROFILE_ARN" in body["error"]["message"]
+        assert not mock_http_client.called
+
+    @patch("kiro.routes_openai.KiroHttpClient")
+    @patch("kiro.routes_openai.resolve_profile_arn", return_value="")
+    def test_missing_profile_error_excludes_secrets(
+        self, mock_resolve, mock_http_client, test_client, valid_proxy_api_key
+    ):
+        """
+        What it does: The error message contains no credential values.
+        Purpose: Requirement 2.4 - exclude tokens/keys from the error.
+        """
+        print("Action: POST /v1/chat/completions with empty profileArn...")
+        response = test_client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
+            json={
+                "model": "claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        )
+
+        message = response.json()["error"]["message"].lower()
+        print(f"Message: {message}")
+        for forbidden in ("token", "secret", "access-key", "bearer", "password"):
+            assert forbidden not in message
+
+
+class TestChatCompletionsMalformedProfileArn:
+    """
+    Tests for the Malformed_Profile_Error on /v1/chat/completions.
+
+    When a profileArn is present but malformed (e.g. the '...' placeholder),
+    the gateway must return HTTP 400 with an actionable OpenAI-format error
+    WITHOUT contacting the Kiro API, in both streaming and non-streaming modes.
+    """
+
+    PLACEHOLDER = "arn:aws:codewhisperer:us-east-1:..."
+
+    @patch("kiro.routes_openai.KiroHttpClient")
+    @patch("kiro.routes_openai.resolve_profile_arn")
+    def test_non_streaming_malformed_profile_returns_400(
+        self, mock_resolve, mock_http_client, test_client, valid_proxy_api_key
+    ):
+        """
+        What it does: Non-streaming request with placeholder ARN returns 400.
+        Purpose: Actionable error, no upstream call.
+        """
+        mock_resolve.return_value = self.PLACEHOLDER
+        print("Action: POST /v1/chat/completions with placeholder profileArn...")
+        response = test_client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
+            json={
+                "model": "claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": False,
+            },
+        )
+
+        print(f"Status: {response.status_code}, body: {response.json()}")
+        assert response.status_code == 400
+        body = response.json()
+        assert body["error"]["type"] == "invalid_request_error"
+        assert "PROFILE_ARN" in body["error"]["message"]
+        assert not mock_http_client.called
+
+    @patch("kiro.routes_openai.KiroHttpClient")
+    @patch("kiro.routes_openai.resolve_profile_arn")
+    def test_streaming_malformed_profile_returns_400(
+        self, mock_resolve, mock_http_client, test_client, valid_proxy_api_key
+    ):
+        """
+        What it does: Streaming request with placeholder ARN returns 400.
+        Purpose: No streaming connection opened on malformed ARN.
+        """
+        mock_resolve.return_value = self.PLACEHOLDER
+        print("Action: POST /v1/chat/completions stream=true, placeholder ARN...")
+        response = test_client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
+            json={
+                "model": "claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+            },
+        )
+
+        print(f"Status: {response.status_code}, body: {response.json()}")
+        assert response.status_code == 400
+        assert response.json()["error"]["type"] == "invalid_request_error"
+        assert not mock_http_client.called

--- a/tests/unit/test_streaming_anthropic.py
+++ b/tests/unit/test_streaming_anthropic.py
@@ -16,6 +16,9 @@ import json
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
+from fastapi import HTTPException
+
 from kiro.streaming_anthropic import (
     generate_message_id,
     generate_thinking_signature,
@@ -1667,3 +1670,73 @@ class TestStreamingAnthropicTruncationDetection:
         # Should detect truncation and set max_tokens
         assert result["stop_reason"] == "max_tokens"
         print("✓ collect_anthropic_response detects truncation correctly")
+
+
+class TestCollectAnthropicResponseConnectionDrop:
+    """
+    Tests that Anthropic non-streaming collection classifies upstream connection drops.
+
+    A RemoteProtocolError raised while reading the response body must become an
+    HTTPException(502), not a generic 500, so the route treats it as a recoverable
+    network error (account-system mode fails over to the next account).
+    """
+
+    @pytest.mark.asyncio
+    async def test_remote_protocol_error_becomes_http_502(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        """
+        What it does: Upstream closes the connection mid-body during collection.
+        Goal: Verify collect_anthropic_response raises HTTPException(502) with a
+              classified, actionable detail instead of leaking a raw 500.
+        """
+        with patch(
+            'kiro.streaming_anthropic.collect_stream_to_result',
+            side_effect=httpx.RemoteProtocolError(
+                "peer closed connection without sending complete message body (incomplete chunked read)"
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await collect_anthropic_response(
+                    mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                )
+
+        assert exc_info.value.status_code == 502
+        assert "connection" in str(exc_info.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_read_error_becomes_http_502(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        """
+        What it does: Upstream connection breaks (httpx.ReadError) during collection.
+        Goal: Verify any httpx.RequestError subclass is classified to 502.
+        """
+        with patch(
+            'kiro.streaming_anthropic.collect_stream_to_result',
+            side_effect=httpx.ReadError("connection broken"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await collect_anthropic_response(
+                    mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                )
+
+        assert exc_info.value.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_non_network_error_is_not_swallowed(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        """
+        What it does: A generic (non-httpx) error must NOT be converted to 502.
+        Goal: Ensure the new except clause only targets transport errors and lets
+              genuine internal errors propagate (route returns 500 for those).
+        """
+        with patch(
+            'kiro.streaming_anthropic.collect_stream_to_result',
+            side_effect=ValueError("some internal bug"),
+        ):
+            with pytest.raises(ValueError):
+                await collect_anthropic_response(
+                    mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                )

--- a/tests/unit/test_streaming_openai.py
+++ b/tests/unit/test_streaming_openai.py
@@ -16,6 +16,9 @@ import json
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
+from fastapi import HTTPException
+
 from kiro.streaming_openai import (
     stream_kiro_to_openai,
     stream_kiro_to_openai_internal,
@@ -1485,3 +1488,84 @@ class TestStreamingOpenaiTruncationDetection:
         # Should extract "length" from streaming chunks
         assert result["choices"][0]["finish_reason"] == "length"
         print("✓ collect_stream_response extracts finish_reason correctly")
+
+
+class TestCollectStreamResponseConnectionDrop:
+    """
+    Tests that non-streaming collection classifies upstream connection drops.
+
+    A RemoteProtocolError raised while reading the response body (after the
+    initial HTTP 200) must become an HTTPException(502), not a generic 500,
+    so the route's failover/error handling treats it as a network error.
+    """
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_remote_protocol_error_becomes_http_502(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        """
+        What it does: Upstream yields partial content then drops the connection.
+        Goal: Verify collect_stream_response raises HTTPException(502) with a
+              classified, actionable detail instead of leaking the raw error.
+        """
+        async def mock_parse_kiro_stream(*args, **kwargs):
+            yield KiroEvent(type="content", content="partial ")
+            raise httpx.RemoteProtocolError(
+                "peer closed connection without sending complete message body (incomplete chunked read)"
+            )
+
+        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
+            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+                with pytest.raises(HTTPException) as exc_info:
+                    await collect_stream_response(
+                        mock_http_client, mock_response, "claude-sonnet-4",
+                        mock_model_cache, mock_auth_manager
+                    )
+
+        assert exc_info.value.status_code == 502
+        assert "connection" in str(exc_info.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_read_error_before_any_content_becomes_http_502(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        """
+        What it does: Upstream drops before sending any content (httpx.ReadError).
+        Goal: Verify any httpx.RequestError subclass is classified to 502, not 500.
+        """
+        async def mock_parse_kiro_stream(*args, **kwargs):
+            if False:
+                yield  # make this an async generator
+            raise httpx.ReadError("connection broken")
+
+        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
+            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+                with pytest.raises(HTTPException) as exc_info:
+                    await collect_stream_response(
+                        mock_http_client, mock_response, "claude-sonnet-4",
+                        mock_model_cache, mock_auth_manager
+                    )
+
+        assert exc_info.value.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_first_token_timeout_still_propagates_unchanged(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        """
+        What it does: Ensures the new httpx.RequestError handling does NOT swallow
+                      FirstTokenTimeoutError (which must keep propagating for retry).
+        Goal: Guard against the new except clause changing timeout-retry behavior.
+        """
+        async def mock_parse_kiro_stream(*args, **kwargs):
+            if False:
+                yield
+            raise FirstTokenTimeoutError("no response within 15 seconds")
+
+        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
+            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+                with pytest.raises(FirstTokenTimeoutError):
+                    await collect_stream_response(
+                        mock_http_client, mock_response, "claude-sonnet-4",
+                        mock_model_cache, mock_auth_manager
+                    )


### PR DESCRIPTION
## Summary

Hardens request validation and `profileArn` handling so several requests that
previously failed with opaque upstream errors now work, and any remaining
misconfiguration produces an actionable message instead of Kiro's cryptic
`REQUEST_BODY_INVALID`.

All changes follow the project philosophy: shared core fixes applied to **both**
the OpenAI and Anthropic surfaces and **both** streaming and non-streaming
paths, with paranoid test coverage.

## What it fixes

These all surfaced as `HTTP 400 Improperly formed request (REQUEST_BODY_INVALID)`
or hard `422`s when proxying Claude Code traffic:

1. **Inline `system` role in the Anthropic `messages` array** — some clients
   (Claude Code) inline `{"role": "system", ...}` instead of using the
   top-level `system` field. This was rejected with a Pydantic `422`. Now the
   role is accepted and folded into the system prompt (order preserved,
   combined with any top-level `system`, excluded from history).

2. **`$schema` (and other JSON Schema meta keywords) in tool `input_schema`** —
   Claude Code sends `"$schema"` on every tool. Kiro/Bedrock rejects it. The
   sanitizer now strips `$schema`, `$id`, `$anchor`, `$comment` recursively
   (preserving structural `$ref`/`$defs`).

3. **Tool schema root type** — Bedrock requires every tool
   `inputSchema.json.type` to be `"object"` (error:
   `toolConfig.tools.N.toolSpec.inputSchema.json.type must be one of [object]`).
   No-argument / malformed tool schemas are now normalized to a valid object
   schema with a `properties` map.

4. **`profileArn` handling** — a shared `Profile_Resolver`
   (auth manager → `PROFILE_ARN` → empty) with:
   - early, actionable error when no profileArn can be resolved (instead of an
     opaque upstream 400), and
   - format validation that rejects the `...` documentation placeholder with a
     clear message telling the user to set a real ARN.

## New

- `kiro/profile_resolver.py` — shared resolution + ARN validation
- Exceptions: `MissingProfileArnError`, `MalformedProfileArnError`

## Tests

Comprehensive unit + integration coverage across both APIs and both streaming
modes: schema sanitization, object-type normalization, inline-system folding
and ordering, resolver rules, ARN validation, and route-level error responses.
Full suite passes locally.

## Note for maintainers

The README states AWS SSO / Builder ID users don't need a `profileArn`. The
missing/malformed `profileArn` guards here were validated against an
**Enterprise / IAM Identity Center** account where the Kiro runtime *does*
require it. Happy to gate the strictness (e.g. only error for auth types that
require a profileArn) if you'd prefer — let me know.
