### PR TITLE
fix(parsers): merge dict tool_input fragments instead of concatenating

### DIFF
--- a/kiro/parsers.py
+++ b/kiro/parsers.py
@@ -349,49 +349,42 @@ class AwsEventStreamParser:
     
     def _process_tool_start_event(self, data: dict) -> Optional[Dict[str, Any]]:
         """Processes tool call start."""
-        # Finalize previous tool call if exists
         if self.current_tool_call:
             self._finalize_tool_call()
-        
-        # input can be string or object
+
         input_data = data.get('input', '')
-        if isinstance(input_data, dict):
-            if input_data:
-                # Non-empty dict: serialize it
-                input_str = json.dumps(input_data)
-            else:
-                # Empty dict {}: fragments will follow, use empty string
-                input_str = ''
-        else:
-            input_str = str(input_data) if input_data else ''
-        
+
         self.current_tool_call = {
             "id": data.get('toolUseId', generate_tool_call_id()),
             "type": "function",
             "function": {
                 "name": data.get('name', ''),
-                "arguments": input_str
-            }
+                "arguments": ''
+            },
+            "_args_dict": input_data if isinstance(input_data, dict) else None
         }
-        
+        # If input was a non-dict string, seed the string buffer
+        if not isinstance(input_data, dict):
+            self.current_tool_call['function']['arguments'] = str(input_data) if input_data else ''
+
         if data.get('stop'):
             self._finalize_tool_call()
-        
+
         return None
-    
+
     def _process_tool_input_event(self, data: dict) -> Optional[Dict[str, Any]]:
         """Processes input continuation for tool call."""
-        if self.current_tool_call:
-            # input can be string or object
-            input_data = data.get('input', '')
-            if isinstance(input_data, dict):
-                if input_data:
-                    input_str = json.dumps(input_data)
-                else:
-                    input_str = ''
-            else:
-                input_str = str(input_data) if input_data else ''
-            self.current_tool_call['function']['arguments'] += input_str
+        if not self.current_tool_call:
+            return None
+        input_data = data.get('input', '')
+        if isinstance(input_data, dict) and input_data:
+            if self.current_tool_call['_args_dict'] is None:
+                self.current_tool_call['_args_dict'] = {}
+            self.current_tool_call['_args_dict'].update(input_data)
+        else:
+            input_str = str(input_data) if input_data else ''
+            if input_str:
+                self.current_tool_call['function']['arguments'] += input_str
         return None
     
     def _process_tool_stop_event(self, data: dict) -> Optional[Dict[str, Any]]:
@@ -404,7 +397,12 @@ class AwsEventStreamParser:
         """Finalizes current tool call and adds to list."""
         if not self.current_tool_call:
             return
-        
+
+        # Remove internal accumulator — serialize if populated
+        args_dict = self.current_tool_call.pop('_args_dict', None)
+        if args_dict:
+            self.current_tool_call['function']['arguments'] = json.dumps(args_dict)
+
         # Try to parse and normalize arguments as JSON
         args = self.current_tool_call['function']['arguments']
         tool_name = self.current_tool_call['function'].get('name', 'unknown')


### PR DESCRIPTION
## Summary

- Fix false "Tool call truncated by Kiro API" errors on `Write` tool calls with large content
- Root cause: when Kiro API sends tool arguments split across multiple `tool_input` events as dicts, the parser serialized each dict independently and concatenated the JSON strings — producing invalid JSON like `{"file_path":"..."}{"content":"..."}`
- The brace-counting diagnostic then misidentified this ~130-150 byte invalid JSON as upstream truncation
- Fix accumulates dict fragments via `.update()` and serializes once at finalize time

## Test plan

- [x] All 73 existing parser unit tests pass
- [x] Verified dict fragment scenario (empty start + multiple dict inputs with brace-containing content)
- [x] Verified single dict with stop (immediate finalization)
- [x] Verified string fragment path unchanged
- [x] Live test: large `Write` tool call with JSON-like patterns in content succeeds without truncation error

Fixes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)