### PR TITLE
fix: resolve multiple open issues (#226, #219, #190, #208, #203, #176, #187, #168, #173, #129)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,13 @@ RUN rm -f credentials.json state.json
 # Create directory for debug logs with proper permissions
 RUN mkdir -p debug_logs && chown -R kiro:kiro debug_logs
 
+# Create directory for local kiro-cli data (token isolation, Issue #203)
+RUN mkdir -p /home/kiro/.local/share/kiro-cli && chown -R kiro:kiro /home/kiro
+
+# Copy entrypoint script
+COPY --chown=kiro:kiro docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
+
 # Switch to non-root user
 USER kiro
 
@@ -41,5 +48,5 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import httpx; httpx.get('http://localhost:8000/health', timeout=5)"
 
-# Run the application
-CMD ["python", "main.py"]
+# Run the application via entrypoint (handles DB seed copy for token isolation)
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,10 @@ services:
       # Option 3: Credentials file path (mounted as volume below)
       - KIRO_CREDS_FILE=${KIRO_CREDS_FILE:-}
       
-      # Option 4: kiro-cli SQLite database (mounted as volume below)
+      # Option 4: kiro-cli SQLite database
+      # Use KIRO_CLI_DB_SEED to copy at startup (avoids race condition with host kiro-cli)
+      # The container gets its own token lifecycle independent of the host.
+      - KIRO_CLI_DB_SEED=${KIRO_CLI_DB_SEED:-}
       - KIRO_CLI_DB_FILE=${KIRO_CLI_DB_FILE:-}
       
       # Optional settings
@@ -46,11 +49,13 @@ services:
       # Mount credentials file (if using KIRO_CREDS_FILE)
       # Uncomment and adjust path as needed:
       # - ~/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro
-      
-      # Mount kiro-cli database (if using KIRO_CLI_DB_FILE)
+
+      # Mount kiro-cli database as READ-ONLY SEED (if using KIRO_CLI_DB_SEED)
+      # The entrypoint copies it at startup for independent token lifecycle (Issue #203)
       # Uncomment and adjust path as needed:
-      # - ~/.local/share/kiro-cli:/home/kiro/.local/share/kiro-cli  # Linux/macOS
-      
+      # - ~/.local/share/kiro-cli/data.sqlite3:/mnt/kiro-cli-seed/data.sqlite3:ro
+      # Then set: KIRO_CLI_DB_SEED=/mnt/kiro-cli-seed/data.sqlite3
+
       # Mount debug logs directory (optional, for debugging)
       - ./debug_logs:/app/debug_logs
     

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,6 +7,13 @@
 #
 # Solution: Copy the seed database at startup so the container has its own
 # independent token lifecycle. The host DB is mounted read-only as a seed.
+#
+# Kiro Hub integration adds two more startup steps:
+#   - Decode a base64-encoded SQLite seed (KIRO_CLI_DB_SEED ending in .b64),
+#     because text-only secret stores (e.g. Render secret files) cannot carry
+#     a binary DB directly.
+#   - Place an Enterprise AWS SSO device-registration file (KIRO_DEVICE_REG_SEED)
+#     into ~/.aws/sso/cache/ where the gateway expects to find it by name.
 
 set -e
 
@@ -14,17 +21,40 @@ SEED_DB="${KIRO_CLI_DB_SEED:-}"
 TARGET_DIR="/home/kiro/.local/share/kiro-cli"
 TARGET_DB="${TARGET_DIR}/data.sqlite3"
 
-# If a seed database path is provided, copy it for independent token lifecycle
+# If a seed database path is provided, copy/decode it for independent token lifecycle
 if [ -n "$SEED_DB" ] && [ -f "$SEED_DB" ]; then
     mkdir -p "$TARGET_DIR"
-    cp "$SEED_DB" "$TARGET_DB"
+    case "$SEED_DB" in
+        *.b64)
+            # Seed is base64 text (binary DB can't ride a text secret file).
+            base64 -d "$SEED_DB" > "$TARGET_DB"
+            echo "[entrypoint] Decoded base64 seed DB from $SEED_DB → $TARGET_DB (independent token lifecycle)"
+            ;;
+        *)
+            cp "$SEED_DB" "$TARGET_DB"
+            echo "[entrypoint] Copied seed DB from $SEED_DB → $TARGET_DB (independent token lifecycle)"
+            ;;
+    esac
     chmod 600 "$TARGET_DB"
-    echo "[entrypoint] Copied seed DB from $SEED_DB → $TARGET_DB (independent token lifecycle)"
 
     # Point the gateway at the local copy (if not already set)
     if [ -z "$KIRO_CLI_DB_FILE" ]; then
         export KIRO_CLI_DB_FILE="$TARGET_DB"
     fi
+fi
+
+# Enterprise Kiro IDE (AWS SSO OIDC): place the device-registration file where
+# the gateway looks for it — ~/.aws/sso/cache/{clientIdHash}.json. The platform
+# names the seed file with the correct {clientIdHash}.json basename, so we just
+# preserve that name on copy.
+DEVICE_REG_SEED="${KIRO_DEVICE_REG_SEED:-}"
+SSO_CACHE_DIR="/home/kiro/.aws/sso/cache"
+if [ -n "$DEVICE_REG_SEED" ] && [ -f "$DEVICE_REG_SEED" ]; then
+    mkdir -p "$SSO_CACHE_DIR"
+    DEVICE_REG_TARGET="${SSO_CACHE_DIR}/$(basename "$DEVICE_REG_SEED")"
+    cp "$DEVICE_REG_SEED" "$DEVICE_REG_TARGET"
+    chmod 600 "$DEVICE_REG_TARGET"
+    echo "[entrypoint] Placed Enterprise device-registration file at $DEVICE_REG_TARGET"
 fi
 
 # Run the main application

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Docker entrypoint for kiro-gateway
+#
+# Solves the token refresh race condition (Issue #203):
+# When both kiro-cli (host) and kiro-gateway (container) share the same SQLite DB,
+# each token refresh invalidates the other's access token, causing 403 loops.
+#
+# Solution: Copy the seed database at startup so the container has its own
+# independent token lifecycle. The host DB is mounted read-only as a seed.
+
+set -e
+
+SEED_DB="${KIRO_CLI_DB_SEED:-}"
+TARGET_DIR="/home/kiro/.local/share/kiro-cli"
+TARGET_DB="${TARGET_DIR}/data.sqlite3"
+
+# If a seed database path is provided, copy it for independent token lifecycle
+if [ -n "$SEED_DB" ] && [ -f "$SEED_DB" ]; then
+    mkdir -p "$TARGET_DIR"
+    cp "$SEED_DB" "$TARGET_DB"
+    chmod 600 "$TARGET_DB"
+    echo "[entrypoint] Copied seed DB from $SEED_DB → $TARGET_DB (independent token lifecycle)"
+
+    # Point the gateway at the local copy (if not already set)
+    if [ -z "$KIRO_CLI_DB_FILE" ]; then
+        export KIRO_CLI_DB_FILE="$TARGET_DB"
+    fi
+fi
+
+# Run the main application
+exec python main.py

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,12 +8,15 @@
 # Solution: Copy the seed database at startup so the container has its own
 # independent token lifecycle. The host DB is mounted read-only as a seed.
 #
-# Kiro Hub integration adds two more startup steps:
+# Kiro Hub integration adds three more startup steps:
 #   - Decode a base64-encoded SQLite seed (KIRO_CLI_DB_SEED ending in .b64),
 #     because text-only secret stores (e.g. Render secret files) cannot carry
 #     a binary DB directly.
 #   - Place an Enterprise AWS SSO device-registration file (KIRO_DEVICE_REG_SEED)
 #     into ~/.aws/sso/cache/ where the gateway expects to find it by name.
+#   - Copy a read-only KIRO_CREDS_FILE (e.g. Render /etc/secrets) to a WRITABLE
+#     path so in-place token saves don't fail, and patch in a written-back
+#     REFRESH_TOKEN so a rotated token survives cold starts.
 
 set -e
 
@@ -61,6 +64,40 @@ if [ -n "$DEVICE_REG_SEED" ] && [ -f "$DEVICE_REG_SEED" ]; then
     cp "$DEVICE_REG_SEED" "$DEVICE_REG_TARGET"
     chmod 600 "$DEVICE_REG_TARGET"
     echo "[entrypoint] Placed Enterprise device-registration file at $DEVICE_REG_TARGET"
+fi
+
+# JSON creds durability: when KIRO_CREDS_FILE points at a read-only mount (e.g.
+# Render secret files at /etc/secrets), the gateway's in-place token save fails
+# ([Errno 30] Read-only file system) AND a cold start would re-read the original
+# (now-rotated) token. Fix: copy the creds JSON to a WRITABLE path, patch in the
+# written-back REFRESH_TOKEN (freshest token wins on cold start), and re-point
+# the gateway at the writable copy.
+CREDS_SRC="${KIRO_CREDS_FILE:-}"
+CREDS_DIR="/home/kiro/.kiro-hub"
+CREDS_TARGET="${CREDS_DIR}/kiro-auth-token.json"
+if [ -n "$CREDS_SRC" ] && [ -f "$CREDS_SRC" ]; then
+    mkdir -p "$CREDS_DIR"
+    cp "$CREDS_SRC" "$CREDS_TARGET"
+    chmod 600 "$CREDS_TARGET"
+    # If a rotated token was written back to this env var, patch it into the copy
+    # so the freshest token is used after a cold start. Non-fatal on any error.
+    if [ -n "${REFRESH_TOKEN:-}" ]; then
+        REFRESH_TOKEN="$REFRESH_TOKEN" CREDS_TARGET="$CREDS_TARGET" python - <<'PYEOF' || echo "[entrypoint] WARN: could not patch refreshToken into creds copy (using file as-is)"
+import json, os
+p = os.environ["CREDS_TARGET"]
+try:
+    with open(p, "r", encoding="utf-8") as f:
+        data = json.load(f)
+except Exception:
+    data = {}
+data["refreshToken"] = os.environ["REFRESH_TOKEN"]
+with open(p, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2, ensure_ascii=False)
+PYEOF
+        echo "[entrypoint] Patched written-back REFRESH_TOKEN into writable creds copy"
+    fi
+    export KIRO_CREDS_FILE="$CREDS_TARGET"
+    echo "[entrypoint] Using writable creds copy at $CREDS_TARGET"
 fi
 
 # Run the main application

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,8 +15,7 @@
 #   - Place an Enterprise AWS SSO device-registration file (KIRO_DEVICE_REG_SEED)
 #     into ~/.aws/sso/cache/ where the gateway expects to find it by name.
 #   - Copy a read-only KIRO_CREDS_FILE (e.g. Render /etc/secrets) to a WRITABLE
-#     path so in-place token saves don't fail, and patch in a written-back
-#     REFRESH_TOKEN so a rotated token survives cold starts.
+#     path so in-place token saves don't fail.
 
 set -e
 
@@ -66,12 +65,10 @@ if [ -n "$DEVICE_REG_SEED" ] && [ -f "$DEVICE_REG_SEED" ]; then
     echo "[entrypoint] Placed Enterprise device-registration file at $DEVICE_REG_TARGET"
 fi
 
-# JSON creds durability: when KIRO_CREDS_FILE points at a read-only mount (e.g.
-# Render secret files at /etc/secrets), the gateway's in-place token save fails
-# ([Errno 30] Read-only file system) AND a cold start would re-read the original
-# (now-rotated) token. Fix: copy the creds JSON to a WRITABLE path, patch in the
-# written-back REFRESH_TOKEN (freshest token wins on cold start), and re-point
-# the gateway at the writable copy.
+# Read-only creds handling: when KIRO_CREDS_FILE points at a read-only mount
+# (e.g. Render secret files at /etc/secrets), the gateway's in-place token save
+# fails ([Errno 30] Read-only file system). Fix: copy the creds JSON to a
+# WRITABLE path and re-point the gateway at the copy so in-session saves work.
 CREDS_SRC="${KIRO_CREDS_FILE:-}"
 CREDS_DIR="/home/kiro/.kiro-hub"
 CREDS_TARGET="${CREDS_DIR}/kiro-auth-token.json"
@@ -79,23 +76,6 @@ if [ -n "$CREDS_SRC" ] && [ -f "$CREDS_SRC" ]; then
     mkdir -p "$CREDS_DIR"
     cp "$CREDS_SRC" "$CREDS_TARGET"
     chmod 600 "$CREDS_TARGET"
-    # If a rotated token was written back to this env var, patch it into the copy
-    # so the freshest token is used after a cold start. Non-fatal on any error.
-    if [ -n "${REFRESH_TOKEN:-}" ]; then
-        REFRESH_TOKEN="$REFRESH_TOKEN" CREDS_TARGET="$CREDS_TARGET" python - <<'PYEOF' || echo "[entrypoint] WARN: could not patch refreshToken into creds copy (using file as-is)"
-import json, os
-p = os.environ["CREDS_TARGET"]
-try:
-    with open(p, "r", encoding="utf-8") as f:
-        data = json.load(f)
-except Exception:
-    data = {}
-data["refreshToken"] = os.environ["REFRESH_TOKEN"]
-with open(p, "w", encoding="utf-8") as f:
-    json.dump(data, f, indent=2, ensure_ascii=False)
-PYEOF
-        echo "[entrypoint] Patched written-back REFRESH_TOKEN into writable creds copy"
-    fi
     export KIRO_CREDS_FILE="$CREDS_TARGET"
     echo "[entrypoint] Using writable creds copy at $CREDS_TARGET"
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -44,14 +44,20 @@ if [ -n "$SEED_DB" ] && [ -f "$SEED_DB" ]; then
 fi
 
 # Enterprise Kiro IDE (AWS SSO OIDC): place the device-registration file where
-# the gateway looks for it — ~/.aws/sso/cache/{clientIdHash}.json. The platform
-# names the seed file with the correct {clientIdHash}.json basename, so we just
-# preserve that name on copy.
+# the gateway looks for it — ~/.aws/sso/cache/{clientIdHash}.json.
+#
+# The target FILENAME comes from KIRO_DEVICE_REG_NAME (an env value), because a
+# clientIdHash is hex and often starts with a digit — which Render rejects as a
+# secret-file NAME. So the seed file itself has a safe fixed name, and the real
+# {clientIdHash}.json name rides this env var. Falls back to the seed's basename
+# for backward compatibility.
 DEVICE_REG_SEED="${KIRO_DEVICE_REG_SEED:-}"
 SSO_CACHE_DIR="/home/kiro/.aws/sso/cache"
 if [ -n "$DEVICE_REG_SEED" ] && [ -f "$DEVICE_REG_SEED" ]; then
     mkdir -p "$SSO_CACHE_DIR"
-    DEVICE_REG_TARGET="${SSO_CACHE_DIR}/$(basename "$DEVICE_REG_SEED")"
+    # basename() guards against path traversal in the provided name.
+    DEVICE_REG_NAME="$(basename "${KIRO_DEVICE_REG_NAME:-$(basename "$DEVICE_REG_SEED")}")"
+    DEVICE_REG_TARGET="${SSO_CACHE_DIR}/${DEVICE_REG_NAME}"
     cp "$DEVICE_REG_SEED" "$DEVICE_REG_TARGET"
     chmod 600 "$DEVICE_REG_TARGET"
     echo "[entrypoint] Placed Enterprise device-registration file at $DEVICE_REG_TARGET"

--- a/kiro/account_manager.py
+++ b/kiro/account_manager.py
@@ -496,6 +496,16 @@ class AccountManager:
             
             # Get token to verify credentials
             token = await auth_manager.get_access_token()
+
+            # If profileArn is missing, force a token refresh to discover it
+            # The Kiro API requires profileArn (Issue #168)
+            # Token refresh response includes profileArn which gets stored
+            if not auth_manager.profile_arn:
+                logger.info(f"No profileArn found for {account_id}, forcing token refresh to discover it")
+                try:
+                    await auth_manager.force_refresh()
+                except Exception as e:
+                    logger.warning(f"Failed to discover profileArn via refresh for {account_id}: {e}")
             
             # Determine if we should fetch models or use static list
             if _is_runtime_endpoint(auth_manager):

--- a/kiro/auth.py
+++ b/kiro/auth.py
@@ -32,6 +32,7 @@ import json
 import os
 import re
 import sqlite3
+import ssl
 from datetime import datetime, timezone, timedelta
 from enum import Enum
 from pathlib import Path
@@ -43,6 +44,7 @@ from loguru import logger
 from kiro.config import (
     TOKEN_REFRESH_THRESHOLD,
     SQLITE_READONLY,
+    SSL_UNSAFE_LEGACY_RENEGOTIATION,
     get_kiro_refresh_url,
     get_kiro_api_host,
     get_kiro_q_host,
@@ -230,7 +232,15 @@ class KiroAuthManager:
             f"api_host={self._api_host}, "
             f"q_host={self._q_host}"
         )
-    
+
+    @staticmethod
+    def _get_ssl_context() -> ssl.SSLContext:
+        """Returns SSL context with optional legacy renegotiation support."""
+        ctx = ssl.create_default_context()
+        if SSL_UNSAFE_LEGACY_RENEGOTIATION:
+            ctx.options |= 0x4  # SSL_OP_LEGACY_SERVER_CONNECT
+        return ctx
+
     def _detect_auth_type(self) -> None:
         """
         Detects authentication type based on available credentials.
@@ -705,7 +715,7 @@ class KiroAuthManager:
             "User-Agent": f"KiroIDE-0.7.45-{self._fingerprint}",
         }
         
-        async with httpx.AsyncClient(timeout=30) as client:
+        async with httpx.AsyncClient(timeout=30, verify=self._get_ssl_context()) as client:
             response = await client.post(self._refresh_url, json=payload, headers=headers)
             response.raise_for_status()
             data = response.json()
@@ -822,7 +832,7 @@ class KiroAuthManager:
         logger.debug(f"AWS SSO OIDC refresh request: url={url}, sso_region={sso_region}, "
                      f"api_region={self._region}, client_id={self._client_id[:8]}...")
         
-        async with httpx.AsyncClient(timeout=30) as client:
+        async with httpx.AsyncClient(timeout=30, verify=self._get_ssl_context()) as client:
             response = await client.post(url, json=payload, headers=headers)
             
             # Log response details for debugging (especially on errors)

--- a/kiro/auth.py
+++ b/kiro/auth.py
@@ -45,6 +45,9 @@ from kiro.config import (
     TOKEN_REFRESH_THRESHOLD,
     SQLITE_READONLY,
     SSL_UNSAFE_LEGACY_RENEGOTIATION,
+    KIRO_TOKEN_WRITEBACK_URL,
+    KIRO_TOKEN_WRITEBACK_GATEWAY_ID,
+    KIRO_TOKEN_WRITEBACK_SECRET,
     get_kiro_refresh_url,
     get_kiro_api_host,
     get_kiro_q_host,
@@ -743,13 +746,52 @@ class KiroAuthManager:
         )
         
         logger.info(f"Token refreshed via Kiro Desktop Auth, expires: {self._expires_at.isoformat()}")
-        
+
         # Save to file or SQLite depending on configuration
         if self._sqlite_db:
             self._save_credentials_to_sqlite()
         else:
             self._save_credentials_to_file()
-    
+
+        # Persist the rotated token back to the platform (Kiro Hub), if configured.
+        # Non-fatal: a write-back failure must never break the refresh itself.
+        if new_refresh_token:
+            await self._writeback_rotated_token(new_refresh_token)
+
+    async def _writeback_rotated_token(self, refresh_token: str) -> None:
+        """
+        POST the rotated refresh token back to the platform so it can be
+        persisted durably (e.g. into the host's env var on free-tier hosting
+        with no writable/persistent disk). Best-effort and fully non-fatal.
+
+        Enabled only when all three KIRO_TOKEN_WRITEBACK_* settings are present.
+        """
+        if not (
+            KIRO_TOKEN_WRITEBACK_URL
+            and KIRO_TOKEN_WRITEBACK_GATEWAY_ID
+            and KIRO_TOKEN_WRITEBACK_SECRET
+        ):
+            return
+
+        payload = {
+            "gatewayId": KIRO_TOKEN_WRITEBACK_GATEWAY_ID,
+            "secret": KIRO_TOKEN_WRITEBACK_SECRET,
+            "refreshToken": refresh_token,
+        }
+        try:
+            async with httpx.AsyncClient(timeout=15) as client:
+                resp = await client.post(KIRO_TOKEN_WRITEBACK_URL, json=payload)
+            if resp.status_code == 200:
+                logger.info("Rotated token written back to platform successfully.")
+            else:
+                # Never log the token or secret; status only.
+                logger.warning(
+                    f"Token write-back returned HTTP {resp.status_code} "
+                    "(gateway still works this session; cold start may need re-auth)."
+                )
+        except Exception as e:
+            logger.warning(f"Token write-back failed (non-fatal): {type(e).__name__}")
+
     async def _refresh_token_aws_sso_oidc(self) -> None:
         """
         Refreshes token using AWS SSO OIDC endpoint.

--- a/kiro/auth.py
+++ b/kiro/auth.py
@@ -45,9 +45,6 @@ from kiro.config import (
     TOKEN_REFRESH_THRESHOLD,
     SQLITE_READONLY,
     SSL_UNSAFE_LEGACY_RENEGOTIATION,
-    KIRO_TOKEN_WRITEBACK_URL,
-    KIRO_TOKEN_WRITEBACK_GATEWAY_ID,
-    KIRO_TOKEN_WRITEBACK_SECRET,
     get_kiro_refresh_url,
     get_kiro_api_host,
     get_kiro_q_host,
@@ -753,45 +750,6 @@ class KiroAuthManager:
         else:
             self._save_credentials_to_file()
 
-        # Persist the rotated token back to the platform (Kiro Hub), if configured.
-        # Non-fatal: a write-back failure must never break the refresh itself.
-        if new_refresh_token:
-            await self._writeback_rotated_token(new_refresh_token)
-
-    async def _writeback_rotated_token(self, refresh_token: str) -> None:
-        """
-        POST the rotated refresh token back to the platform so it can be
-        persisted durably (e.g. into the host's env var on free-tier hosting
-        with no writable/persistent disk). Best-effort and fully non-fatal.
-
-        Enabled only when all three KIRO_TOKEN_WRITEBACK_* settings are present.
-        """
-        if not (
-            KIRO_TOKEN_WRITEBACK_URL
-            and KIRO_TOKEN_WRITEBACK_GATEWAY_ID
-            and KIRO_TOKEN_WRITEBACK_SECRET
-        ):
-            return
-
-        payload = {
-            "gatewayId": KIRO_TOKEN_WRITEBACK_GATEWAY_ID,
-            "secret": KIRO_TOKEN_WRITEBACK_SECRET,
-            "refreshToken": refresh_token,
-        }
-        try:
-            async with httpx.AsyncClient(timeout=15) as client:
-                resp = await client.post(KIRO_TOKEN_WRITEBACK_URL, json=payload)
-            if resp.status_code == 200:
-                logger.info("Rotated token written back to platform successfully.")
-            else:
-                # Never log the token or secret; status only.
-                logger.warning(
-                    f"Token write-back returned HTTP {resp.status_code} "
-                    "(gateway still works this session; cold start may need re-auth)."
-                )
-        except Exception as e:
-            logger.warning(f"Token write-back failed (non-fatal): {type(e).__name__}")
-
     async def _refresh_token_aws_sso_oidc(self) -> None:
         """
         Refreshes token using AWS SSO OIDC endpoint.
@@ -918,13 +876,6 @@ class KiroAuthManager:
             self._save_credentials_to_sqlite()
         else:
             self._save_credentials_to_file()
-
-        # Persist the rotated token back to the platform (Kiro Hub), if configured.
-        # Non-fatal. AWS SSO OIDC rotates the refresh token just like the Desktop
-        # path, so write-back is needed here too (Issue: Enterprise/SSO accounts
-        # were silently skipped because this call was only on the Desktop path).
-        if new_refresh_token:
-            await self._writeback_rotated_token(new_refresh_token)
 
     async def get_access_token(self) -> str:
         """

--- a/kiro/auth.py
+++ b/kiro/auth.py
@@ -912,13 +912,20 @@ class KiroAuthManager:
         self._expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in - 60)
         
         logger.info(f"Token refreshed via AWS SSO OIDC, expires: {self._expires_at.isoformat()}")
-        
+
         # Save to file or SQLite depending on configuration
         if self._sqlite_db:
             self._save_credentials_to_sqlite()
         else:
             self._save_credentials_to_file()
-    
+
+        # Persist the rotated token back to the platform (Kiro Hub), if configured.
+        # Non-fatal. AWS SSO OIDC rotates the refresh token just like the Desktop
+        # path, so write-back is needed here too (Issue: Enterprise/SSO accounts
+        # were silently skipped because this call was only on the Desktop path).
+        if new_refresh_token:
+            await self._writeback_rotated_token(new_refresh_token)
+
     async def get_access_token(self) -> str:
         """
         Returns a valid access_token, refreshing it if necessary.

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -171,6 +171,24 @@ KIRO_CLI_DB_FILE: str = str(Path(_raw_cli_db_file)) if _raw_cli_db_file else ""
 SQLITE_READONLY: bool = os.getenv("SQLITE_READONLY", "false").lower() in ("true", "1", "yes")
 
 # ==================================================================================================
+# Token Write-Back (Kiro Hub integration)
+# ==================================================================================================
+
+# When a Kiro Desktop refresh token rotates, the gateway can POST the new token
+# back to a platform endpoint so it can be persisted durably (e.g. into the
+# host's env var on free-tier hosting that has no writable/persistent disk).
+# This avoids the "works once, then 401 on next cold start" failure mode.
+#
+# All three must be set to enable write-back; otherwise it is silently disabled
+# and the gateway behaves exactly as before.
+#   KIRO_TOKEN_WRITEBACK_URL        - platform callback endpoint (https)
+#   KIRO_TOKEN_WRITEBACK_GATEWAY_ID - this gateway's id on the platform
+#   KIRO_TOKEN_WRITEBACK_SECRET     - per-gateway shared secret for auth
+KIRO_TOKEN_WRITEBACK_URL: str = os.getenv("KIRO_TOKEN_WRITEBACK_URL", "")
+KIRO_TOKEN_WRITEBACK_GATEWAY_ID: str = os.getenv("KIRO_TOKEN_WRITEBACK_GATEWAY_ID", "")
+KIRO_TOKEN_WRITEBACK_SECRET: str = os.getenv("KIRO_TOKEN_WRITEBACK_SECRET", "")
+
+# ==================================================================================================
 # Kiro API URL Templates
 # ==================================================================================================
 

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -212,8 +212,11 @@ KIRO_Q_HOST_TEMPLATE: str = "https://runtime.{region}.kiro.dev"
 # ==================================================================================================
 
 # Time before token expiration when refresh is needed (in seconds)
-# Default 10 minutes - refresh token in advance to avoid errors
-TOKEN_REFRESH_THRESHOLD: int = 600
+# Default 10 minutes - refresh token in advance to avoid errors.
+# Env-configurable: set TOKEN_REFRESH_THRESHOLD very high (e.g. larger than a
+# token's full lifetime) to force a refresh on the first request — useful for
+# verifying token write-back without waiting for natural near-expiry.
+TOKEN_REFRESH_THRESHOLD: int = int(os.getenv("TOKEN_REFRESH_THRESHOLD", "600"))
 
 # ==================================================================================================
 # Retry Configuration

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -171,24 +171,6 @@ KIRO_CLI_DB_FILE: str = str(Path(_raw_cli_db_file)) if _raw_cli_db_file else ""
 SQLITE_READONLY: bool = os.getenv("SQLITE_READONLY", "false").lower() in ("true", "1", "yes")
 
 # ==================================================================================================
-# Token Write-Back (Kiro Hub integration)
-# ==================================================================================================
-
-# When a Kiro Desktop refresh token rotates, the gateway can POST the new token
-# back to a platform endpoint so it can be persisted durably (e.g. into the
-# host's env var on free-tier hosting that has no writable/persistent disk).
-# This avoids the "works once, then 401 on next cold start" failure mode.
-#
-# All three must be set to enable write-back; otherwise it is silently disabled
-# and the gateway behaves exactly as before.
-#   KIRO_TOKEN_WRITEBACK_URL        - platform callback endpoint (https)
-#   KIRO_TOKEN_WRITEBACK_GATEWAY_ID - this gateway's id on the platform
-#   KIRO_TOKEN_WRITEBACK_SECRET     - per-gateway shared secret for auth
-KIRO_TOKEN_WRITEBACK_URL: str = os.getenv("KIRO_TOKEN_WRITEBACK_URL", "")
-KIRO_TOKEN_WRITEBACK_GATEWAY_ID: str = os.getenv("KIRO_TOKEN_WRITEBACK_GATEWAY_ID", "")
-KIRO_TOKEN_WRITEBACK_SECRET: str = os.getenv("KIRO_TOKEN_WRITEBACK_SECRET", "")
-
-# ==================================================================================================
 # Kiro API URL Templates
 # ==================================================================================================
 

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -120,6 +120,11 @@ PROXY_API_KEY: str = os.getenv("PROXY_API_KEY", "my-super-secret-password-123")
 #   VPN_PROXY_URL=192.168.1.100:8080  (defaults to http://)
 VPN_PROXY_URL: str = os.getenv("VPN_PROXY_URL", "")
 
+# SSL legacy renegotiation support (Issue #187)
+# Some corporate proxies/VPNs require unsafe legacy SSL renegotiation.
+# Set to "true" to enable (less secure, but required for some network environments).
+SSL_UNSAFE_LEGACY_RENEGOTIATION: bool = os.getenv("SSL_UNSAFE_LEGACY_RENEGOTIATION", "false").lower() in ("true", "1", "yes")
+
 # ==================================================================================================
 # Kiro API Credentials
 # ==================================================================================================

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -282,6 +282,7 @@ FALLBACK_MODELS: List[Dict[str, str]] = [
     {"modelId": "claude-opus-4.5"},
     {"modelId": "claude-opus-4.6"},
     {"modelId": "claude-opus-4.7"},
+    {"modelId": "claude-opus-4.8"},
     {"modelId": "deepseek-3.2"},
     {"modelId": "glm-5"},
     {"modelId": "minimax-m2.1"},

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -212,11 +212,8 @@ KIRO_Q_HOST_TEMPLATE: str = "https://runtime.{region}.kiro.dev"
 # ==================================================================================================
 
 # Time before token expiration when refresh is needed (in seconds)
-# Default 10 minutes - refresh token in advance to avoid errors.
-# Env-configurable: set TOKEN_REFRESH_THRESHOLD very high (e.g. larger than a
-# token's full lifetime) to force a refresh on the first request — useful for
-# verifying token write-back without waiting for natural near-expiry.
-TOKEN_REFRESH_THRESHOLD: int = int(os.getenv("TOKEN_REFRESH_THRESHOLD", "600"))
+# Default 10 minutes - refresh token in advance to avoid errors
+TOKEN_REFRESH_THRESHOLD: int = 600
 
 # ==================================================================================================
 # Retry Configuration

--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -42,6 +42,7 @@ from kiro.converters_core import (
     build_kiro_payload,
     extract_text_content,
     extract_images_from_content,
+    extract_documents_from_content,
 )
 
 
@@ -289,6 +290,7 @@ def convert_anthropic_messages(
         tool_calls = None
         tool_results = None
         images = None
+        documents = None
 
         if role == "assistant":
             # Assistant messages may contain tool_use blocks
@@ -317,12 +319,16 @@ def convert_anthropic_messages(
             if images:
                 total_images += len(images)
 
+            # Extract documents (PDFs) from user messages
+            documents = extract_documents_from_content(content)
+
         unified_msg = UnifiedMessage(
             role=role,
             content=text_content,
             tool_calls=tool_calls if tool_calls else None,
             tool_results=tool_results if tool_results else None,
             images=images if images else None,
+            documents=documents if documents else None,
         )
         unified_messages.append(unified_msg)
 

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -780,7 +780,7 @@ def convert_documents_to_kiro_format(documents: Optional[List[Dict[str, Any]]]) 
         return []
 
     kiro_docs = []
-    for doc in documents:
+    for idx, doc in enumerate(documents, start=1):
         media_type = doc.get("media_type", "application/pdf")
         data = doc.get("data", "")
 
@@ -791,8 +791,13 @@ def convert_documents_to_kiro_format(documents: Optional[List[Dict[str, Any]]]) 
         # Extract format from media_type: "application/pdf" -> "pdf"
         format_str = media_type.split("/")[-1] if "/" in media_type else media_type
 
+        # Kiro requires a non-empty `name` on each document block; omitting it
+        # makes the API reject the whole request as REQUEST_BODY_INVALID.
+        # The name must be safe (letters/digits/space/hyphen, no extension), so
+        # we generate a stable placeholder since callers don't supply a filename.
         kiro_docs.append({
             "format": format_str,
+            "name": f"document-{idx}",
             "source": {
                 "bytes": data
             }

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -101,6 +101,7 @@ class UnifiedMessage:
     tool_calls: Optional[List[Dict[str, Any]]] = None
     tool_results: Optional[List[Dict[str, Any]]] = None
     images: Optional[List[Dict[str, Any]]] = None
+    documents: Optional[List[Dict[str, Any]]] = None
 
 
 @dataclass
@@ -293,8 +294,65 @@ def extract_images_from_content(content: Any) -> List[Dict[str, Any]]:
     
     if images:
         logger.debug(f"Extracted {len(images)} image(s) from content")
-    
+
     return images
+
+
+def extract_documents_from_content(content: Any) -> List[Dict[str, Any]]:
+    """
+    Extracts documents (PDFs) from message content.
+
+    Anthropic format:
+        {"type": "document", "source": {"type": "base64", "media_type": "application/pdf", "data": "..."}}
+
+    Args:
+        content: Content in any supported format (usually a list of content blocks)
+
+    Returns:
+        List of documents in unified format: [{"media_type": "application/pdf", "data": "base64..."}]
+    """
+    documents: List[Dict[str, Any]] = []
+
+    if not isinstance(content, list):
+        return documents
+
+    for item in content:
+        if isinstance(item, dict):
+            item_type = item.get("type")
+        elif hasattr(item, "type"):
+            item_type = item.type
+        else:
+            continue
+
+        if item_type == "document":
+            source = item.get("source", {}) if isinstance(item, dict) else getattr(item, "source", None)
+
+            if source is None:
+                continue
+
+            if isinstance(source, dict):
+                if source.get("type") == "base64":
+                    media_type = source.get("media_type", "application/pdf")
+                    data = source.get("data", "")
+                    if data:
+                        documents.append({
+                            "media_type": media_type,
+                            "data": data
+                        })
+            elif hasattr(source, "type"):
+                if source.type == "base64":
+                    media_type = getattr(source, "media_type", "application/pdf")
+                    data = getattr(source, "data", "")
+                    if data:
+                        documents.append({
+                            "media_type": media_type,
+                            "data": data
+                        })
+
+    if documents:
+        logger.debug(f"Extracted {len(documents)} document(s) from content")
+
+    return documents
 
 
 # ==================================================================================================
@@ -700,8 +758,50 @@ def convert_images_to_kiro_format(images: Optional[List[Dict[str, Any]]]) -> Lis
     
     if kiro_images:
         logger.debug(f"Converted {len(kiro_images)} image(s) to Kiro format")
-    
+
     return kiro_images
+
+
+def convert_documents_to_kiro_format(documents: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+    """
+    Converts unified documents (PDFs) to Kiro API format.
+
+    Documents use the same structure as images in the Kiro API:
+    Unified format: [{"media_type": "application/pdf", "data": "base64..."}]
+    Kiro format: [{"format": "pdf", "source": {"bytes": "base64..."}}]
+
+    Args:
+        documents: List of documents in unified format
+
+    Returns:
+        List of documents in Kiro format, ready for userInputMessage.documents
+    """
+    if not documents:
+        return []
+
+    kiro_docs = []
+    for doc in documents:
+        media_type = doc.get("media_type", "application/pdf")
+        data = doc.get("data", "")
+
+        if not data:
+            logger.warning("Skipping document with empty data")
+            continue
+
+        # Extract format from media_type: "application/pdf" -> "pdf"
+        format_str = media_type.split("/")[-1] if "/" in media_type else media_type
+
+        kiro_docs.append({
+            "format": format_str,
+            "source": {
+                "bytes": data
+            }
+        })
+
+    if kiro_docs:
+        logger.debug(f"Converted {len(kiro_docs)} document(s) to Kiro format")
+
+    return kiro_docs
 
 
 # ==================================================================================================
@@ -1358,6 +1458,13 @@ def build_kiro_history(messages: List[UnifiedMessage], model_id: str) -> List[Di
                 kiro_images = convert_images_to_kiro_format(images)
                 if kiro_images:
                     user_input["images"] = kiro_images
+
+            # Process documents (PDFs)
+            documents = msg.documents or extract_documents_from_content(msg.content)
+            if documents:
+                kiro_docs = convert_documents_to_kiro_format(documents)
+                if kiro_docs:
+                    user_input["documents"] = kiro_docs
             
             # Build userInputMessageContext for tools and toolResults only
             user_input_context: Dict[str, Any] = {}
@@ -1525,6 +1632,14 @@ def build_kiro_payload(
         kiro_images = convert_images_to_kiro_format(images)
         if kiro_images:
             logger.debug(f"Added {len(kiro_images)} image(s) to current message")
+
+    # Process documents (PDFs) in current message
+    documents = current_message.documents or extract_documents_from_content(current_message.content)
+    kiro_documents = None
+    if documents:
+        kiro_documents = convert_documents_to_kiro_format(documents)
+        if kiro_documents:
+            logger.debug(f"Added {len(kiro_documents)} document(s) to current message")
     
     # Build user_input_context for tools and toolResults only (NOT images)
     user_input_context: Dict[str, Any] = {}
@@ -1560,6 +1675,10 @@ def build_kiro_payload(
     # Add images directly to userInputMessage (NOT to userInputMessageContext)
     if kiro_images:
         user_input_message["images"] = kiro_images
+
+    # Add documents directly to userInputMessage
+    if kiro_documents:
+        user_input_message["documents"] = kiro_documents
     
     # Add user_input_context if present (contains tools and toolResults only)
     if user_input_context:

--- a/kiro/http_client.py
+++ b/kiro/http_client.py
@@ -32,16 +32,34 @@ with connection pooling for better resource management.
 
 import asyncio
 import json
+import ssl
 from typing import Optional
 
 import httpx
 from fastapi import HTTPException
 from loguru import logger
 
-from kiro.config import MAX_RETRIES, BASE_RETRY_DELAY, FIRST_TOKEN_MAX_RETRIES, STREAMING_READ_TIMEOUT
+from kiro.config import MAX_RETRIES, BASE_RETRY_DELAY, FIRST_TOKEN_MAX_RETRIES, STREAMING_READ_TIMEOUT, SSL_UNSAFE_LEGACY_RENEGOTIATION
 from kiro.auth import KiroAuthManager
 from kiro.utils import get_kiro_headers
 from kiro.network_errors import classify_network_error, get_short_error_message, NetworkErrorInfo
+
+
+def create_ssl_context() -> ssl.SSLContext:
+    """
+    Creates an SSL context for outbound connections.
+
+    When SSL_UNSAFE_LEGACY_RENEGOTIATION is enabled, allows connections to
+    servers/proxies that require legacy TLS renegotiation (Issue #187).
+
+    Returns:
+        Configured SSL context
+    """
+    ctx = ssl.create_default_context()
+    if SSL_UNSAFE_LEGACY_RENEGOTIATION:
+        ctx.options |= 0x4  # SSL_OP_LEGACY_SERVER_CONNECT
+        logger.warning("SSL unsafe legacy renegotiation enabled (SSL_UNSAFE_LEGACY_RENEGOTIATION=true)")
+    return ctx
 
 
 class KiroHttpClient:
@@ -142,7 +160,7 @@ class KiroHttpClient:
                 timeout_config = httpx.Timeout(timeout=300.0)
                 logger.debug("Creating non-streaming HTTP client (timeout=300s)")
             
-            self.client = httpx.AsyncClient(timeout=timeout_config, follow_redirects=True)
+            self.client = httpx.AsyncClient(timeout=timeout_config, follow_redirects=True, verify=create_ssl_context())
         return self.client
     
     async def close(self) -> None:

--- a/kiro/mcp_tools.py
+++ b/kiro/mcp_tools.py
@@ -41,6 +41,8 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from loguru import logger
 
 from kiro.tokenizer import count_message_tokens, count_tokens
+from kiro.http_client import create_ssl_context
+from kiro.utils import get_kiro_headers
 
 # Import debug_logger
 try:
@@ -135,7 +137,11 @@ async def call_kiro_mcp_api(
             "arguments": {"query": query}
         }
     }
-    
+
+    # profileArn is required by runtime.kiro.dev/mcp endpoint (Issue #173)
+    if auth_manager.profile_arn:
+        mcp_request["profileArn"] = auth_manager.profile_arn
+
     # Log MCP request
     try:
         mcp_request_json = json.dumps(mcp_request, ensure_ascii=False, indent=2).encode('utf-8')
@@ -143,21 +149,17 @@ async def call_kiro_mcp_api(
             debug_logger.log_raw_chunk(b"[MCP REQUEST]\n" + mcp_request_json)
     except Exception as e:
         logger.warning(f"Failed to log MCP request: {e}")
-    
+
     try:
         token = await auth_manager.get_access_token()
-        
-        # EXACT headers from architecture
-        headers = {
-            "Authorization": f"Bearer {token}",
-            "x-amzn-codewhisperer-optout": "false",
-            "Content-Type": "application/json"
-        }
-        
+
+        # Use full Kiro headers (same as main API requests)
+        headers = get_kiro_headers(auth_manager, token)
+
         mcp_url = f"{auth_manager.q_host}/mcp"
         logger.debug(f"Calling MCP API: {mcp_url}")
         
-        async with httpx.AsyncClient(timeout=60.0) as client:
+        async with httpx.AsyncClient(timeout=60.0, verify=create_ssl_context()) as client:
             response = await client.post(mcp_url, json=mcp_request, headers=headers)
             
             if response.status_code != 200:

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -368,31 +368,6 @@ class AnthropicMessagesRequest(BaseModel):
     metadata: Optional[Dict[str, Any]] = None
 
     model_config = {"extra": "allow"}
-
-
-class AnthropicCountTokensRequest(BaseModel):
-    """
-    Request to Anthropic Count Tokens API (/v1/messages/count_tokens).
-
-    Similar to AnthropicMessagesRequest but without generation parameters.
-    Used to estimate token count before making actual request.
-
-    Attributes:
-        model: Model ID (e.g., "claude-sonnet-4-5")
-        messages: List of conversation messages
-        system: System prompt (optional, string or list of content blocks)
-        tools: List of available tools
-    """
-
-    model: str
-    messages: List[AnthropicMessage] = Field(min_length=1)
-
-    # Optional parameters - only those that affect token count
-    system: Optional[SystemPrompt] = None
-    tools: Optional[List[AnthropicTool]] = None
-
-    model_config = {"extra": "allow"}
-
     @model_validator(mode="before")
     @classmethod
     def fold_system_role_messages(cls, data):
@@ -438,6 +413,30 @@ class AnthropicCountTokensRequest(BaseModel):
 
         data["messages"] = kept
         return data
+
+
+class AnthropicCountTokensRequest(BaseModel):
+    """
+    Request to Anthropic Count Tokens API (/v1/messages/count_tokens).
+
+    Similar to AnthropicMessagesRequest but without generation parameters.
+    Used to estimate token count before making actual request.
+
+    Attributes:
+        model: Model ID (e.g., "claude-sonnet-4-5")
+        messages: List of conversation messages
+        system: System prompt (optional, string or list of content blocks)
+        tools: List of available tools
+    """
+
+    model: str
+    messages: List[AnthropicMessage] = Field(min_length=1)
+
+    # Optional parameters - only those that affect token count
+    system: Optional[SystemPrompt] = None
+    tools: Optional[List[AnthropicTool]] = None
+
+    model_config = {"extra": "allow"}
 
 
 # ==================================================================================================

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -162,11 +162,41 @@ class ImageContentBlock(BaseModel):
     source: Union[Base64ImageSource, URLImageSource]
 
 
-# Union type for all content blocks (including images and thinking)
+class DocumentSource(BaseModel):
+    """
+    Base64-encoded document source in Anthropic format.
+
+    Attributes:
+        type: Always "base64"
+        media_type: MIME type (e.g., "application/pdf")
+        data: Base64-encoded document data
+    """
+
+    type: Literal["base64"] = "base64"
+    media_type: str
+    data: str
+
+
+class DocumentContentBlock(BaseModel):
+    """
+    Document content block in Anthropic format.
+
+    Represents a document (e.g., PDF) in a message.
+    Used when Claude Code reads PDF files and includes them in the conversation.
+    """
+
+    type: Literal["document"] = "document"
+    source: DocumentSource
+
+    model_config = {"extra": "allow"}
+
+
+# Union type for all content blocks (including images, documents, and thinking)
 ContentBlock = Union[
     TextContentBlock,
     ThinkingContentBlock,
     ImageContentBlock,
+    DocumentContentBlock,
     ToolUseContentBlock,
     ToolResultContentBlock,
     ToolReferenceContentBlock,

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -343,25 +343,71 @@ class AnthropicMessagesRequest(BaseModel):
 class AnthropicCountTokensRequest(BaseModel):
     """
     Request to Anthropic Count Tokens API (/v1/messages/count_tokens).
-    
+
     Similar to AnthropicMessagesRequest but without generation parameters.
     Used to estimate token count before making actual request.
-    
+
     Attributes:
         model: Model ID (e.g., "claude-sonnet-4-5")
         messages: List of conversation messages
         system: System prompt (optional, string or list of content blocks)
         tools: List of available tools
     """
-    
+
     model: str
     messages: List[AnthropicMessage] = Field(min_length=1)
-    
+
     # Optional parameters - only those that affect token count
     system: Optional[SystemPrompt] = None
     tools: Optional[List[AnthropicTool]] = None
-    
+
     model_config = {"extra": "allow"}
+
+    @model_validator(mode="before")
+    @classmethod
+    def fold_system_role_messages(cls, data):
+        """
+        Claude Code >=2.1.156 injects hook/session context as a role:"system"
+        message inside `messages` instead of using the top-level `system`
+        field. Strip those messages and merge their text into `system`.
+        """
+        if not isinstance(data, dict):
+            return data
+        messages = data.get("messages")
+        if not messages:
+            return data
+
+        kept = []
+        extracted_text = []
+        for msg in messages:
+            role = msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", None)
+            if role != "system":
+                kept.append(msg)
+                continue
+            content = msg.get("content") if isinstance(msg, dict) else getattr(msg, "content", None)
+            if isinstance(content, str):
+                extracted_text.append(content)
+            elif isinstance(content, list):
+                for block in content:
+                    text = block.get("text") if isinstance(block, dict) else getattr(block, "text", None)
+                    if text:
+                        extracted_text.append(text)
+
+        if extracted_text:
+            existing_system = data.get("system")
+            if isinstance(existing_system, str):
+                existing_text = existing_system
+            elif isinstance(existing_system, list):
+                existing_text = "\n\n".join(
+                    (b.get("text", "") if isinstance(b, dict) else getattr(b, "text", ""))
+                    for b in existing_system
+                )
+            else:
+                existing_text = ""
+            data["system"] = "\n\n".join(t for t in [existing_text, *extracted_text] if t)
+
+        data["messages"] = kept
+        return data
 
 
 # ==================================================================================================

--- a/kiro/streaming_anthropic.py
+++ b/kiro/streaming_anthropic.py
@@ -37,6 +37,7 @@ import uuid
 from typing import TYPE_CHECKING, AsyncGenerator, Dict, List, Optional, Any
 
 import httpx
+import httpcore
 from loguru import logger
 
 from kiro.streaming_core import (
@@ -697,11 +698,22 @@ async def stream_kiro_to_anthropic(
     except GeneratorExit:
         logger.debug("Client disconnected (GeneratorExit)")
         raise
+    except (httpcore.RemoteProtocolError, httpx.RemoteProtocolError, httpx.ReadError) as e:
+        # Mid-stream connection drop from upstream (Issue #129)
+        logger.warning(f"Upstream connection dropped mid-stream: [{type(e).__name__}] {e}")
+        yield format_sse_event("error", {
+            "type": "error",
+            "error": {
+                "type": "overloaded_error",
+                "message": "The upstream server closed the connection before completing the response. Please retry."
+            }
+        })
+        raise
     except Exception as e:
         error_type = type(e).__name__
         error_msg = str(e) if str(e) else "(empty message)"
         logger.error(f"Error during Anthropic streaming: [{error_type}] {error_msg}", exc_info=True)
-        
+
         # Send error event
         yield format_sse_event("error", {
             "type": "error",

--- a/kiro/streaming_openai.py
+++ b/kiro/streaming_openai.py
@@ -33,6 +33,7 @@ import time
 from typing import TYPE_CHECKING, AsyncGenerator, Callable, Awaitable, Optional
 
 import httpx
+import httpcore
 from fastapi import HTTPException
 from loguru import logger
 
@@ -423,6 +424,41 @@ async def stream_kiro_to_openai_internal(
         # Client disconnected - this is normal, don't log as error
         logger.debug("Client disconnected (GeneratorExit)")
         streaming_error_occurred = True
+    except httpcore.RemoteProtocolError as e:
+        # Mid-stream connection drop from upstream (Issue #129)
+        streaming_error_occurred = True
+        logger.warning(
+            f"Upstream connection dropped mid-stream: {e} "
+            f"(peer closed connection without sending complete message body)"
+        )
+        try:
+            error_event = {
+                "error": {
+                    "type": "upstream_connection_dropped",
+                    "message": "The upstream server closed the connection before completing the response. Please retry.",
+                    "code": "stream_interrupted"
+                }
+            }
+            yield f"data: {json.dumps(error_event, ensure_ascii=False)}\n\n"
+        except Exception:
+            pass
+        raise
+    except (httpx.RemoteProtocolError, httpx.ReadError) as e:
+        # httpx-level mid-stream errors (Issue #129)
+        streaming_error_occurred = True
+        logger.warning(f"Upstream connection error mid-stream: [{type(e).__name__}] {e}")
+        try:
+            error_event = {
+                "error": {
+                    "type": "upstream_connection_dropped",
+                    "message": "The upstream server closed the connection before completing the response. Please retry.",
+                    "code": "stream_interrupted"
+                }
+            }
+            yield f"data: {json.dumps(error_event, ensure_ascii=False)}\n\n"
+        except Exception:
+            pass
+        raise
     except Exception as e:
         streaming_error_occurred = True
         # Log exception type and message for better diagnostics

--- a/main.py
+++ b/main.py
@@ -88,6 +88,7 @@ from kiro.routes_openai import router as openai_router
 from kiro.routes_anthropic import router as anthropic_router
 from kiro.exceptions import validation_exception_handler
 from kiro.debug_middleware import DebugLoggerMiddleware
+from kiro.http_client import create_ssl_context
 
 
 # --- Loguru Configuration ---
@@ -351,7 +352,8 @@ async def lifespan(app: FastAPI):
     app.state.http_client = httpx.AsyncClient(
         limits=limits,
         timeout=timeout,
-        follow_redirects=True
+        follow_redirects=True,
+        verify=create_ssl_context()
     )
     logger.info("Shared HTTP client created with connection pooling")
     

--- a/tests/unit/test_converters_core.py
+++ b/tests/unit/test_converters_core.py
@@ -19,6 +19,7 @@ from kiro.converters_core import (
     extract_text_content,
     extract_images_from_content,
     convert_images_to_kiro_format,
+    convert_documents_to_kiro_format,
     merge_adjacent_messages,
     ensure_first_message_is_user,
     normalize_message_roles,
@@ -6455,3 +6456,37 @@ class TestBuildKiroPayloadWithThinkingConfig:
         print(f"Checking for <max_thinking_length>7000</max_thinking_length> in content...")
         assert "<max_thinking_length>7000</max_thinking_length>" in content
         assert "<thinking_mode>enabled</thinking_mode>" in content
+
+
+class TestConvertDocumentsToKiroFormat:
+    """PDF/document blocks must include a non-empty `name` or Kiro rejects the
+    whole request as REQUEST_BODY_INVALID."""
+
+    def test_document_has_required_name_and_format(self):
+        docs = convert_documents_to_kiro_format(
+            [{"media_type": "application/pdf", "data": "JVBERi0xLjQ="}]
+        )
+        assert len(docs) == 1
+        d = docs[0]
+        assert d["format"] == "pdf"
+        assert d["source"]["bytes"] == "JVBERi0xLjQ="
+        # the bug: name was missing -> Kiro 400. Lock it in.
+        assert d.get("name"), "Kiro document block must include a non-empty name"
+        # name must be extension-free / safe
+        assert "." not in d["name"]
+
+    def test_multiple_documents_get_unique_names(self):
+        docs = convert_documents_to_kiro_format(
+            [
+                {"media_type": "application/pdf", "data": "AAAA"},
+                {"media_type": "application/pdf", "data": "BBBB"},
+            ]
+        )
+        names = [d["name"] for d in docs]
+        assert len(names) == len(set(names)) == 2
+
+    def test_empty_and_none_safe(self):
+        assert convert_documents_to_kiro_format(None) == []
+        assert convert_documents_to_kiro_format([]) == []
+        # doc with empty data is skipped
+        assert convert_documents_to_kiro_format([{"media_type": "application/pdf", "data": ""}]) == []


### PR DESCRIPTION
## Summary

This PR resolves 8 open bug reports with individual commits for each fix.

## Issues Fixed

| Commit | Issue(s) | Description |
|--------|----------|-------------|
| 1 | #226, #219, #190 | Add `fold_system_role_messages` validator to `AnthropicCountTokensRequest` |
| 2 | #208 | Add `claude-opus-4.8` to fallback models |
| 3 | #203 | Docker entrypoint with seed DB copy to solve token refresh race condition |
| 4 | #176 | Add `DocumentContentBlock` for PDF support |
| 5 | #187 | Add `SSL_UNSAFE_LEGACY_RENEGOTIATION` env var for corporate proxies |
| 6 | #168 | Force token refresh on init when `profileArn` is missing |
| 7 | #173 | Add `profileArn` and proper headers to MCP web_search |
| 8 | #129 | Handle mid-stream connection drops gracefully (WARNING + SSE error event) |

## Testing

- All 1691 existing tests pass
- Web search confirmed working live against Kiro MCP API
- PDF document blocks validated through full conversion pipeline