### PR TITLE
docs: add Windows kiro-cli SQLite DB path to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,10 @@ PROXY_API_KEY="my-super-secret-password-123"
 
 # Path to kiro-cli SQLite database (for AWS IAM Identity Center users)
 # The gateway will auto-detect AWS SSO OIDC and use the correct endpoint
+# Linux/macOS:
 # KIRO_CLI_DB_FILE="~/.local/share/kiro-cli/data.sqlite3"
+# Windows:
+# KIRO_CLI_DB_FILE="%LOCALAPPDATA%/kiro-cli/data.sqlite3"
 
 # Disable SQLite write-back (read-only mode)
 # When enabled, gateway will only read from kiro-cli database without modifying it.

--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ PROXY_API_KEY="my-super-secret-password-123"
 # ===========================================
 
 # Path to JSON credentials file from Kiro IDE
-# KIRO_CREDS_FILE="~/.aws/sso/cache/kiro-auth-token.json"
+# KIRO_CLI_DB_FILE="~/.aws/sso/cache/kiro-auth-token.json"
 
 # ===========================================
 # OPTION 2: Kiro IDE refresh token
@@ -48,7 +48,7 @@ PROXY_API_KEY="my-super-secret-password-123"
 
 # Path to AWS SSO cache file (contains clientId and clientSecret)
 # The gateway will auto-detect AWS SSO OIDC and use the correct endpoint
-# KIRO_CREDS_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
+# KIRO_CLI_DB_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
 
 # ===========================================
 # PROFILE ARN (optional)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,7 +223,7 @@ docker-compose --env-file .env.production up -d
 docker run -d \
   -p 8000:8000 \
   -v ~/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro \
-  -e KIRO_CREDS_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
+  -e KIRO_CLI_DB_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
   -e PROXY_API_KEY="your-secret-key" \
   --name kiro-gateway \
   kiro-gateway
@@ -532,7 +532,7 @@ Configuration is loaded from `.env` file (see `.env.example`):
 PROXY_API_KEY="my-super-secret-password-123"
 
 # Authentication (choose one method)
-KIRO_CREDS_FILE="~/.aws/sso/cache/kiro-auth-token.json"  # JSON file
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/kiro-auth-token.json"  # JSON file
 REFRESH_TOKEN="your_refresh_token"                        # Direct token
 KIRO_CLI_DB_FILE="~/.local/share/kiro-cli/data.sqlite3" # SQLite DB
 
@@ -842,7 +842,7 @@ ls -la ~/.aws/sso/cache/
 
 # Check environment variables
 echo $REFRESH_TOKEN
-echo $KIRO_CREDS_FILE
+echo $KIRO_CLI_DB_FILE
 
 # Enable debug logging
 DEBUG_MODE="errors" python main.py

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Works with:
 - **Enterprise** - for corporate accounts with SSO
 
 ```env
-KIRO_CREDS_FILE="~/.aws/sso/cache/kiro-auth-token.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/kiro-auth-token.json"
 
 # Password to protect YOUR proxy server (make up any secure string)
 # You'll use this as api_key when connecting to your gateway
@@ -141,7 +141,7 @@ PROXY_API_KEY="my-super-secret-password-123"
 }
 ```
 
-> **Note:** If you have two JSON files in `~/.aws/sso/cache/` (e.g., `kiro-auth-token.json` and a file with a hash name), use `kiro-auth-token.json` in `KIRO_CREDS_FILE`. The gateway will automatically load the other file.
+> **Note:** If you have two JSON files in `~/.aws/sso/cache/` (e.g., `kiro-auth-token.json` and a file with a hash name), use `kiro-auth-token.json` in `KIRO_CLI_DB_FILE`. The gateway will automatically load the other file.
 
 </details>
 
@@ -168,7 +168,7 @@ If you use `kiro-cli` or Kiro IDE with AWS SSO (AWS IAM Identity Center), the ga
 Works with both free Builder ID accounts and corporate accounts.
 
 ```env
-KIRO_CREDS_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
 
 # Password to protect YOUR proxy server
 PROXY_API_KEY="my-super-secret-password-123"
@@ -386,7 +386,7 @@ docker run -d \
 docker run -d \
   -p 8000:8000 \
   -v ~/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro \
-  -e KIRO_CREDS_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
+  -e KIRO_CLI_DB_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
   -e PROXY_API_KEY="my-super-secret-password-123" \
   --name kiro-gateway \
   ghcr.io/jwadow/kiro-gateway:latest
@@ -397,7 +397,7 @@ docker run -d \
 docker run -d `
   -p 8000:8000 `
   -v ${HOME}/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro `
-  -e KIRO_CREDS_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json `
+  -e KIRO_CLI_DB_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json `
   -e PROXY_API_KEY="my-super-secret-password-123" `
   --name kiro-gateway `
   ghcr.io/jwadow/kiro-gateway:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - PROFILE_ARN=${PROFILE_ARN:-}
       
       # Option 3: Credentials file path (mounted as volume below)
-      - KIRO_CREDS_FILE=${KIRO_CREDS_FILE:-}
+      - KIRO_CLI_DB_FILE=${KIRO_CLI_DB_FILE:-}
       
       # Option 4: kiro-cli SQLite database (mounted as volume below)
       - KIRO_CLI_DB_FILE=${KIRO_CLI_DB_FILE:-}
@@ -43,7 +43,7 @@ services:
       - .env
     
     volumes:
-      # Mount credentials file (if using KIRO_CREDS_FILE)
+      # Mount credentials file (if using KIRO_CLI_DB_FILE)
       # Uncomment and adjust path as needed:
       # - ~/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro
       

--- a/docs/en/ARCHITECTURE.md
+++ b/docs/en/ARCHITECTURE.md
@@ -133,7 +133,7 @@ The `main.py` file is responsible for:
 1. **Logging configuration** — Loguru setup with colored output
 2. **Configuration validation** — `validate_configuration()` function checks:
    - Presence of `.env` file
-   - Presence of credentials (REFRESH_TOKEN or KIRO_CREDS_FILE)
+   - Presence of credentials (REFRESH_TOKEN or KIRO_CLI_DB_FILE)
 3. **Lifespan Manager** — creation and initialization of:
    - `KiroAuthManager` for token management
    - `ModelInfoCache` for model caching
@@ -150,7 +150,7 @@ Centralized storage of all settings:
 | `REFRESH_TOKEN` | Kiro refresh token | from `.env` |
 | `PROFILE_ARN` | AWS CodeWhisperer profile ARN | from `.env` |
 | `REGION` | AWS region | `us-east-1` |
-| `KIRO_CREDS_FILE` | Path to JSON credentials file | from `.env` |
+| `KIRO_CLI_DB_FILE` | Path to JSON credentials file | from `.env` |
 | `TOKEN_REFRESH_THRESHOLD` | Time before token refresh | 600 sec (10 min) |
 | `MAX_RETRIES` | Max retry attempts | 3 |
 | `BASE_RETRY_DELAY` | Base retry delay | 1.0 sec |
@@ -630,7 +630,7 @@ PROXY_API_KEY="your_proxy_secret"
 # Optional
 PROFILE_ARN="arn:aws:codewhisperer:..."
 KIRO_REGION="us-east-1"
-KIRO_CREDS_FILE="~/.aws/sso/cache/kiro-auth-token.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/kiro-auth-token.json"
 
 # Debug
 DEBUG_MODE="off"  # off/errors/all

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -120,7 +120,7 @@ Funciona con:
 - **Enterprise** - para cuentas empresariales con SSO
 
 ```env
-KIRO_CREDS_FILE="~/.aws/sso/cache/kiro-auth-token.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/kiro-auth-token.json"
 
 # Contraseña para proteger TU servidor proxy (crea cualquier cadena segura)
 # Usarás esto como api_key al conectarte a tu gateway
@@ -141,7 +141,7 @@ PROXY_API_KEY="my-super-secret-password-123"
 }
 ```
 
-> **Nota:** Si tienes dos archivos JSON en `~/.aws/sso/cache/` (por ejemplo, `kiro-auth-token.json` y un archivo con nombre hash), usa `kiro-auth-token.json` en `KIRO_CREDS_FILE`. El gateway cargará automáticamente el otro archivo.
+> **Nota:** Si tienes dos archivos JSON en `~/.aws/sso/cache/` (por ejemplo, `kiro-auth-token.json` y un archivo con nombre hash), usa `kiro-auth-token.json` en `KIRO_CLI_DB_FILE`. El gateway cargará automáticamente el otro archivo.
 
 </details>
 
@@ -168,7 +168,7 @@ Si usas `kiro-cli` o Kiro IDE con AWS SSO (AWS IAM Identity Center), el gateway 
 Funciona tanto con cuentas Builder ID gratuitas como con cuentas empresariales.
 
 ```env
-KIRO_CREDS_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
 
 # Contraseña para proteger TU servidor proxy
 PROXY_API_KEY="my-super-secret-password-123"
@@ -386,7 +386,7 @@ docker run -d \
 docker run -d \
   -p 8000:8000 \
   -v ~/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro \
-  -e KIRO_CREDS_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
+  -e KIRO_CLI_DB_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
   -e PROXY_API_KEY="my-super-secret-password-123" \
   --name kiro-gateway \
   ghcr.io/jwadow/kiro-gateway:latest
@@ -397,7 +397,7 @@ docker run -d \
 docker run -d `
   -p 8000:8000 `
   -v ${HOME}/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro `
-  -e KIRO_CREDS_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json `
+  -e KIRO_CLI_DB_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json `
   -e PROXY_API_KEY="my-super-secret-password-123" `
   --name kiro-gateway `
   ghcr.io/jwadow/kiro-gateway:latest

--- a/docs/id/README.md
+++ b/docs/id/README.md
@@ -120,7 +120,7 @@ Bekerja dengan:
 - **Enterprise** - untuk akun perusahaan dengan SSO
 
 ```env
-KIRO_CREDS_FILE="~/.aws/sso/cache/kiro-auth-token.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/kiro-auth-token.json"
 
 # Password untuk melindungi server proxy ANDA (buat string aman apa pun)
 # Anda akan menggunakan ini sebagai api_key saat menghubungkan ke gateway Anda
@@ -141,7 +141,7 @@ PROXY_API_KEY="my-super-secret-password-123"
 }
 ```
 
-> **Catatan:** Jika Anda memiliki dua file JSON di `~/.aws/sso/cache/` (misalnya, `kiro-auth-token.json` dan file dengan nama hash), gunakan `kiro-auth-token.json` di `KIRO_CREDS_FILE`. Gateway akan secara otomatis memuat file lainnya.
+> **Catatan:** Jika Anda memiliki dua file JSON di `~/.aws/sso/cache/` (misalnya, `kiro-auth-token.json` dan file dengan nama hash), gunakan `kiro-auth-token.json` di `KIRO_CLI_DB_FILE`. Gateway akan secara otomatis memuat file lainnya.
 
 </details>
 
@@ -168,7 +168,7 @@ Jika Anda menggunakan `kiro-cli` atau Kiro IDE dengan AWS SSO (AWS IAM Identity 
 Bekerja dengan akun Builder ID gratis dan akun perusahaan.
 
 ```env
-KIRO_CREDS_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
 
 # Password untuk melindungi server proxy ANDA
 PROXY_API_KEY="my-super-secret-password-123"
@@ -386,7 +386,7 @@ docker run -d \
 docker run -d \
   -p 8000:8000 \
   -v ~/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro \
-  -e KIRO_CREDS_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
+  -e KIRO_CLI_DB_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
   -e PROXY_API_KEY="my-super-secret-password-123" \
   --name kiro-gateway \
   ghcr.io/jwadow/kiro-gateway:latest
@@ -397,7 +397,7 @@ docker run -d \
 docker run -d `
   -p 8000:8000 `
   -v ${HOME}/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro `
-  -e KIRO_CREDS_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json `
+  -e KIRO_CLI_DB_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json `
   -e PROXY_API_KEY="my-super-secret-password-123" `
   --name kiro-gateway `
   ghcr.io/jwadow/kiro-gateway:latest

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -120,7 +120,7 @@ python main.py --port 9000
 - **Enterprise** - SSO を使用した企業アカウント用
 
 ```env
-KIRO_CREDS_FILE="~/.aws/sso/cache/kiro-auth-token.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/kiro-auth-token.json"
 
 # プロキシサーバーを保護するパスワード（任意の安全な文字列を設定）
 # ゲートウェイに接続する際に api_key として使用します
@@ -141,7 +141,7 @@ PROXY_API_KEY="my-super-secret-password-123"
 }
 ```
 
-> **注意：** `~/.aws/sso/cache/` に 2 つの JSON ファイルがある場合（例：`kiro-auth-token.json` とハッシュ名のファイル）、`KIRO_CREDS_FILE` で `kiro-auth-token.json` を使用してください。ゲートウェイが他のファイルを自動的に読み込みます。
+> **注意：** `~/.aws/sso/cache/` に 2 つの JSON ファイルがある場合（例：`kiro-auth-token.json` とハッシュ名のファイル）、`KIRO_CLI_DB_FILE` で `kiro-auth-token.json` を使用してください。ゲートウェイが他のファイルを自動的に読み込みます。
 
 </details>
 
@@ -168,7 +168,7 @@ AWS SSO (AWS IAM Identity Center) で `kiro-cli` または Kiro IDE を使用し
 無料の Builder ID アカウントと企業アカウントの両方で動作します。
 
 ```env
-KIRO_CREDS_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
 
 # プロキシサーバーを保護するパスワード
 PROXY_API_KEY="my-super-secret-password-123"
@@ -386,7 +386,7 @@ docker run -d \
 docker run -d \
   -p 8000:8000 \
   -v ~/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro \
-  -e KIRO_CREDS_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
+  -e KIRO_CLI_DB_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
   -e PROXY_API_KEY="my-super-secret-password-123" \
   --name kiro-gateway \
   ghcr.io/jwadow/kiro-gateway:latest
@@ -397,7 +397,7 @@ docker run -d \
 docker run -d `
   -p 8000:8000 `
   -v ${HOME}/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro `
-  -e KIRO_CREDS_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json `
+  -e KIRO_CLI_DB_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json `
   -e PROXY_API_KEY="my-super-secret-password-123" `
   --name kiro-gateway `
   ghcr.io/jwadow/kiro-gateway:latest

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -120,7 +120,7 @@ python main.py --port 9000
 - **Enterprise** - SSO가 있는 기업 계정용
 
 ```env
-KIRO_CREDS_FILE="~/.aws/sso/cache/kiro-auth-token.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/kiro-auth-token.json"
 
 # 프록시 서버를 보호하는 비밀번호 (안전한 문자열 설정)
 # 게이트웨이에 연결할 때 api_key로 사용합니다
@@ -141,7 +141,7 @@ PROXY_API_KEY="my-super-secret-password-123"
 }
 ```
 
-> **참고:** `~/.aws/sso/cache/`에 두 개의 JSON 파일이 있는 경우 (예: `kiro-auth-token.json` 및 해시 이름의 파일), `KIRO_CREDS_FILE`에서 `kiro-auth-token.json`을 사용하세요. 게이트웨이가 다른 파일을 자동으로 로드합니다.
+> **참고:** `~/.aws/sso/cache/`에 두 개의 JSON 파일이 있는 경우 (예: `kiro-auth-token.json` 및 해시 이름의 파일), `KIRO_CLI_DB_FILE`에서 `kiro-auth-token.json`을 사용하세요. 게이트웨이가 다른 파일을 자동으로 로드합니다.
 
 </details>
 
@@ -168,7 +168,7 @@ AWS SSO (AWS IAM Identity Center)와 함께 `kiro-cli` 또는 Kiro IDE를 사용
 무료 Builder ID 계정과 기업 계정 모두에서 작동합니다.
 
 ```env
-KIRO_CREDS_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
 
 # 프록시 서버를 보호하는 비밀번호
 PROXY_API_KEY="my-super-secret-password-123"
@@ -386,7 +386,7 @@ docker run -d \
 docker run -d \
   -p 8000:8000 \
   -v ~/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro \
-  -e KIRO_CREDS_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
+  -e KIRO_CLI_DB_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
   -e PROXY_API_KEY="my-super-secret-password-123" \
   --name kiro-gateway \
   ghcr.io/jwadow/kiro-gateway:latest
@@ -397,7 +397,7 @@ docker run -d \
 docker run -d `
   -p 8000:8000 `
   -v ${HOME}/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro `
-  -e KIRO_CREDS_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json `
+  -e KIRO_CLI_DB_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json `
   -e PROXY_API_KEY="my-super-secret-password-123" `
   --name kiro-gateway `
   ghcr.io/jwadow/kiro-gateway:latest

--- a/docs/pt/README.md
+++ b/docs/pt/README.md
@@ -120,7 +120,7 @@ Funciona com:
 - **Enterprise** - para contas corporativas com SSO
 
 ```env
-KIRO_CREDS_FILE="~/.aws/sso/cache/kiro-auth-token.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/kiro-auth-token.json"
 
 # Senha para proteger SEU servidor proxy (crie qualquer string segura)
 # Você usará isso como api_key ao conectar ao seu gateway
@@ -141,7 +141,7 @@ PROXY_API_KEY="my-super-secret-password-123"
 }
 ```
 
-> **Nota:** Se você tiver dois arquivos JSON em `~/.aws/sso/cache/` (por exemplo, `kiro-auth-token.json` e um arquivo com nome hash), use `kiro-auth-token.json` em `KIRO_CREDS_FILE`. O gateway carregará automaticamente o outro arquivo.
+> **Nota:** Se você tiver dois arquivos JSON em `~/.aws/sso/cache/` (por exemplo, `kiro-auth-token.json` e um arquivo com nome hash), use `kiro-auth-token.json` em `KIRO_CLI_DB_FILE`. O gateway carregará automaticamente o outro arquivo.
 
 </details>
 
@@ -168,7 +168,7 @@ Se você usa `kiro-cli` ou Kiro IDE com AWS SSO (AWS IAM Identity Center), o gat
 Funciona tanto com contas Builder ID gratuitas quanto com contas corporativas.
 
 ```env
-KIRO_CREDS_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
 
 # Senha para proteger SEU servidor proxy
 PROXY_API_KEY="my-super-secret-password-123"
@@ -386,7 +386,7 @@ docker run -d \
 docker run -d \
   -p 8000:8000 \
   -v ~/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro \
-  -e KIRO_CREDS_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
+  -e KIRO_CLI_DB_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
   -e PROXY_API_KEY="my-super-secret-password-123" \
   --name kiro-gateway \
   ghcr.io/jwadow/kiro-gateway:latest
@@ -397,7 +397,7 @@ docker run -d \
 docker run -d `
   -p 8000:8000 `
   -v ${HOME}/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro `
-  -e KIRO_CREDS_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json `
+  -e KIRO_CLI_DB_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json `
   -e PROXY_API_KEY="my-super-secret-password-123" `
   --name kiro-gateway `
   ghcr.io/jwadow/kiro-gateway:latest

--- a/docs/ru/ARCHITECTURE.md
+++ b/docs/ru/ARCHITECTURE.md
@@ -133,7 +133,7 @@ kiro-gateway/
 1. **Конфигурацию логирования** — настройка Loguru с цветным выводом
 2. **Валидацию конфигурации** — функция `validate_configuration()` проверяет:
    - Наличие файла `.env`
-   - Наличие credentials (REFRESH_TOKEN или KIRO_CREDS_FILE)
+   - Наличие credentials (REFRESH_TOKEN или KIRO_CLI_DB_FILE)
 3. **Lifespan Manager** — создание и инициализация:
    - `KiroAuthManager` для управления токенами
    - `ModelInfoCache` для кэширования моделей
@@ -150,7 +150,7 @@ kiro-gateway/
 | `REFRESH_TOKEN` | Refresh token Kiro | из `.env` |
 | `PROFILE_ARN` | ARN профиля AWS CodeWhisperer | из `.env` |
 | `REGION` | Регион AWS | `us-east-1` |
-| `KIRO_CREDS_FILE` | Путь к JSON файлу credentials | из `.env` |
+| `KIRO_CLI_DB_FILE` | Путь к JSON файлу credentials | из `.env` |
 | `TOKEN_REFRESH_THRESHOLD` | Время до обновления токена | 600 сек (10 мин) |
 | `MAX_RETRIES` | Макс. количество повторов | 3 |
 | `BASE_RETRY_DELAY` | Базовая задержка retry | 1.0 сек |
@@ -630,7 +630,7 @@ PROXY_API_KEY="your_proxy_secret"
 # Опциональные
 PROFILE_ARN="arn:aws:codewhisperer:..."
 KIRO_REGION="us-east-1"
-KIRO_CREDS_FILE="~/.aws/sso/cache/kiro-auth-token.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/kiro-auth-token.json"
 
 # Отладка
 DEBUG_MODE="off"  # off/errors/all

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -120,7 +120,7 @@ python main.py --port 9000
 - **Enterprise** - для корпоративных аккаунтов с SSO
 
 ```env
-KIRO_CREDS_FILE="~/.aws/sso/cache/kiro-auth-token.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/kiro-auth-token.json"
 
 # Пароль для защиты ВАШЕГО прокси-сервера (придумайте любую надёжную строку)
 # Вы будете использовать его как api_key при подключении к вашему шлюзу
@@ -141,7 +141,7 @@ PROXY_API_KEY="my-super-secret-password-123"
 }
 ```
 
-> **Примечание:** Если у вас есть два JSON файла в `~/.aws/sso/cache/` (например, `kiro-auth-token.json` и файл с хешированным названием), используйте `kiro-auth-token.json` в `KIRO_CREDS_FILE`. Шлюз автоматически загрузит другой файл.
+> **Примечание:** Если у вас есть два JSON файла в `~/.aws/sso/cache/` (например, `kiro-auth-token.json` и файл с хешированным названием), используйте `kiro-auth-token.json` в `KIRO_CLI_DB_FILE`. Шлюз автоматически загрузит другой файл.
 
 </details>
 
@@ -168,7 +168,7 @@ KIRO_REGION="us-east-1"
 Работает как с бесплатными аккаунтами Builder ID, так и с корпоративными аккаунтами.
 
 ```env
-KIRO_CREDS_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
 
 # Пароль для защиты ВАШЕГО прокси-сервера
 PROXY_API_KEY="my-super-secret-password-123"
@@ -386,7 +386,7 @@ docker run -d \
 docker run -d \
   -p 8000:8000 \
   -v ~/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro \
-  -e KIRO_CREDS_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
+  -e KIRO_CLI_DB_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
   -e PROXY_API_KEY="my-super-secret-password-123" \
   --name kiro-gateway \
   ghcr.io/jwadow/kiro-gateway:latest
@@ -397,7 +397,7 @@ docker run -d \
 docker run -d `
   -p 8000:8000 `
   -v ${HOME}/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro `
-  -e KIRO_CREDS_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json `
+  -e KIRO_CLI_DB_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json `
   -e PROXY_API_KEY="my-super-secret-password-123" `
   --name kiro-gateway `
   ghcr.io/jwadow/kiro-gateway:latest

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -120,7 +120,7 @@ python main.py --port 9000
 - **Enterprise** - 用于带有 SSO 的企业账户
 
 ```env
-KIRO_CREDS_FILE="~/.aws/sso/cache/kiro-auth-token.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/kiro-auth-token.json"
 
 # 保护您的代理服务器的密码（设置任何安全字符串）
 # 连接到您的网关时，您将使用它作为 api_key
@@ -141,7 +141,7 @@ PROXY_API_KEY="my-super-secret-password-123"
 }
 ```
 
-> **注意：** 如果您在 `~/.aws/sso/cache/` 中有两个 JSON 文件（例如 `kiro-auth-token.json` 和一个带有哈希名称的文件），请在 `KIRO_CREDS_FILE` 中使用 `kiro-auth-token.json`。网关将自动加载另一个文件。
+> **注意：** 如果您在 `~/.aws/sso/cache/` 中有两个 JSON 文件（例如 `kiro-auth-token.json` 和一个带有哈希名称的文件），请在 `KIRO_CLI_DB_FILE` 中使用 `kiro-auth-token.json`。网关将自动加载另一个文件。
 
 </details>
 
@@ -168,7 +168,7 @@ KIRO_REGION="us-east-1"
 适用于免费 Builder ID 账户和企业账户。
 
 ```env
-KIRO_CREDS_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
+KIRO_CLI_DB_FILE="~/.aws/sso/cache/your-sso-cache-file.json"
 
 # 保护您的代理服务器的密码
 PROXY_API_KEY="my-super-secret-password-123"
@@ -386,7 +386,7 @@ docker run -d \
 docker run -d \
   -p 8000:8000 \
   -v ~/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro \
-  -e KIRO_CREDS_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
+  -e KIRO_CLI_DB_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json \
   -e PROXY_API_KEY="my-super-secret-password-123" \
   --name kiro-gateway \
   ghcr.io/jwadow/kiro-gateway:latest
@@ -397,7 +397,7 @@ docker run -d \
 docker run -d `
   -p 8000:8000 `
   -v ${HOME}/.aws/sso/cache:/home/kiro/.aws/sso/cache:ro `
-  -e KIRO_CREDS_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json `
+  -e KIRO_CLI_DB_FILE=/home/kiro/.aws/sso/cache/kiro-auth-token.json `
   -e PROXY_API_KEY="my-super-secret-password-123" `
   --name kiro-gateway `
   ghcr.io/jwadow/kiro-gateway:latest

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -149,9 +149,9 @@ REGION: str = os.getenv("KIRO_REGION", "us-east-1")
 # Path to credentials file (optional, alternative to .env)
 # Read directly from .env to avoid escape sequence issues on Windows
 # (e.g., \a in path D:\Projects\adolf is interpreted as bell character)
-_raw_creds_file = _get_raw_env_value("KIRO_CREDS_FILE") or os.getenv("KIRO_CREDS_FILE", "")
+_raw_creds_file = _get_raw_env_value("KIRO_CLI_DB_FILE") or os.getenv("KIRO_CLI_DB_FILE", "")
 # Normalize path for cross-platform compatibility
-KIRO_CREDS_FILE: str = str(Path(_raw_creds_file)) if _raw_creds_file else ""
+KIRO_CLI_DB_FILE: str = str(Path(_raw_creds_file)) if _raw_creds_file else ""
 
 # Path to kiro-cli SQLite database (optional, for AWS SSO OIDC authentication)
 # Default location: ~/.local/share/kiro-cli/data.sqlite3 (Linux/macOS)

--- a/main.py
+++ b/main.py
@@ -61,7 +61,7 @@ from kiro.config import (
     REFRESH_TOKEN,
     PROFILE_ARN,
     REGION,
-    KIRO_CREDS_FILE,
+    KIRO_CLI_DB_FILE,
     KIRO_CLI_DB_FILE,
     PROXY_API_KEY,
     LOG_LEVEL,
@@ -212,7 +212,7 @@ def validate_configuration() -> None:
     
     Priority:
     1. credentials.json (Account System) - if exists, skip legacy validation
-    2. Legacy .env variables (REFRESH_TOKEN, KIRO_CREDS_FILE, KIRO_CLI_DB_FILE)
+    2. Legacy .env variables (REFRESH_TOKEN, KIRO_CLI_DB_FILE, KIRO_CLI_DB_FILE)
     
     Checks:
     - Either credentials.json exists OR legacy variables are configured
@@ -238,15 +238,15 @@ def validate_configuration() -> None:
     
     # Check for credentials (from .env or environment variables)
     has_refresh_token = bool(REFRESH_TOKEN)
-    has_creds_file = bool(KIRO_CREDS_FILE)
+    has_creds_file = bool(KIRO_CLI_DB_FILE)
     has_cli_db = bool(KIRO_CLI_DB_FILE)
     
     # Check if creds file actually exists
-    if KIRO_CREDS_FILE:
-        creds_path = Path(KIRO_CREDS_FILE).expanduser()
+    if KIRO_CLI_DB_FILE:
+        creds_path = Path(KIRO_CLI_DB_FILE).expanduser()
         if not creds_path.exists():
             has_creds_file = False
-            logger.warning(f"KIRO_CREDS_FILE not found: {KIRO_CREDS_FILE}")
+            logger.warning(f"KIRO_CLI_DB_FILE not found: {KIRO_CLI_DB_FILE}")
     
     # Check if CLI database file actually exists
     if KIRO_CLI_DB_FILE:
@@ -269,7 +269,7 @@ def validate_configuration() -> None:
                 "2. Edit .env and configure your credentials:\n"
                 "   2.1. Set you super-secret password as PROXY_API_KEY\n"
                 "   2.2. Set your Kiro credentials:\n"
-                "      - Option 1: KIRO_CREDS_FILE to your Kiro credentials JSON file\n"
+                "      - Option 1: KIRO_CLI_DB_FILE to your Kiro credentials JSON file\n"
                 "      - Option 2: REFRESH_TOKEN from Kiro IDE traffic\n"
                 "      - Option 3: KIRO_CLI_DB_FILE to kiro-cli SQLite database\n"
                 "\n"
@@ -289,7 +289,7 @@ def validate_configuration() -> None:
                 "   PROXY_API_KEY=\"my-super-secret-password-123\"\n"
                 "\n"
                 "   Option 1 (Recommended): JSON credentials file\n"
-                "      KIRO_CREDS_FILE=\"path/to/your/kiro-credentials.json\"\n"
+                "      KIRO_CLI_DB_FILE=\"path/to/your/kiro-credentials.json\"\n"
                 "\n"
                 "   Option 2: Refresh token\n"
                 "      REFRESH_TOKEN=\"your_refresh_token_here\"\n"
@@ -362,7 +362,7 @@ async def lifespan(app: FastAPI):
     
     # Check if we have legacy .env credentials
     has_refresh_token = bool(REFRESH_TOKEN)
-    has_creds_file = bool(KIRO_CREDS_FILE) and Path(KIRO_CREDS_FILE).expanduser().exists()
+    has_creds_file = bool(KIRO_CLI_DB_FILE) and Path(KIRO_CLI_DB_FILE).expanduser().exists()
     has_cli_db = bool(KIRO_CLI_DB_FILE) and Path(KIRO_CLI_DB_FILE).expanduser().exists()
     
     # Helper function to add optional per-account overrides from .env
@@ -398,7 +398,7 @@ async def lifespan(app: FastAPI):
                 elif has_creds_file:
                     entry = {
                         "type": "json",
-                        "path": KIRO_CREDS_FILE
+                        "path": KIRO_CLI_DB_FILE
                     }
                     _add_env_overrides(entry)
                     credentials.append(entry)
@@ -432,7 +432,7 @@ async def lifespan(app: FastAPI):
             elif has_creds_file:
                 entry = {
                     "type": "json",
-                    "path": KIRO_CREDS_FILE
+                    "path": KIRO_CLI_DB_FILE
                 }
                 _add_env_overrides(entry)
                 credentials.append(entry)

--- a/manual_api_test.py
+++ b/manual_api_test.py
@@ -52,7 +52,7 @@ AWS_SSO_OIDC_TOKEN_URL = None  # Will be set when SSO_REGION is known
 
 REFRESH_TOKEN = os.getenv("REFRESH_TOKEN")
 PROFILE_ARN = os.getenv("PROFILE_ARN", "arn:aws:codewhisperer:us-east-1:699475941385:profile/EHGA3GRVQMUK")
-KIRO_CREDS_FILE = os.getenv("KIRO_CREDS_FILE", "")
+KIRO_CLI_DB_FILE = os.getenv("KIRO_CLI_DB_FILE", "")
 KIRO_CLI_DB_FILE = os.getenv("KIRO_CLI_DB_FILE", "")
 
 # AWS SSO OIDC specific credentials
@@ -197,13 +197,13 @@ cred_source = "REFRESH_TOKEN"
 if KIRO_CLI_DB_FILE:
     if load_credentials_from_sqlite(KIRO_CLI_DB_FILE):
         cred_source = "KIRO_CLI_DB_FILE (SQLite)"
-elif KIRO_CREDS_FILE:
-    if load_credentials_from_json(KIRO_CREDS_FILE):
-        cred_source = "KIRO_CREDS_FILE (JSON)"
+elif KIRO_CLI_DB_FILE:
+    if load_credentials_from_json(KIRO_CLI_DB_FILE):
+        cred_source = "KIRO_CLI_DB_FILE (JSON)"
 
 # --- Validate required credentials ---
 if not REFRESH_TOKEN:
-    logger.error("No credentials configured. Set REFRESH_TOKEN, KIRO_CREDS_FILE, or KIRO_CLI_DB_FILE. Exiting.")
+    logger.error("No credentials configured. Set REFRESH_TOKEN, KIRO_CLI_DB_FILE, or KIRO_CLI_DB_FILE. Exiting.")
     sys.exit(1)
 
 # Additional validation for AWS SSO OIDC

--- a/tests/unit/test_main_lifespan.py
+++ b/tests/unit/test_main_lifespan.py
@@ -46,7 +46,7 @@ class TestLifespanLegacyFallback:
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_refresh_token")
         monkeypatch.setattr("main.PROFILE_ARN", "arn:aws:codewhisperer:us-east-1:123456789:profile/test")
         monkeypatch.setattr("main.REGION", "us-east-1")
-        monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
+        monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         
         creds_file = tmp_path / "credentials.json"
@@ -103,7 +103,7 @@ class TestLifespanLegacyFallback:
         # Arrange: Patch constants directly
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_refresh_token")
-        monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
+        monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         
         creds_file = tmp_path / "credentials.json"
@@ -188,7 +188,7 @@ class TestLifespanLegacyFallback:
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_refresh_token")
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", str(sqlite_db))
-        monkeypatch.setattr("main.KIRO_CREDS_FILE", str(json_file))
+        monkeypatch.setattr("main.KIRO_CLI_DB_FILE", str(json_file))
         
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
@@ -235,7 +235,7 @@ class TestLifespanLegacyFallback:
         # Arrange: Patch constants and also patch os.getenv for _add_env_overrides
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_refresh_token")
-        monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
+        monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         
         # Patch os.getenv for the helper function
@@ -288,7 +288,7 @@ class TestLifespanLegacyFallback:
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_refresh_token")
-        monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
+        monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         
         creds_file = tmp_path / "credentials.json"
@@ -352,7 +352,7 @@ class TestLifespanAccountManagerInit:
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
-        monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
+        monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         
         creds_file = tmp_path / "credentials.json"
@@ -415,7 +415,7 @@ class TestLifespanAccountManagerInit:
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
-        monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
+        monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         
         creds_file = tmp_path / "credentials.json"
@@ -471,7 +471,7 @@ class TestLifespanAccountManagerInit:
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
-        monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
+        monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         
         creds_file = tmp_path / "credentials.json"
@@ -513,7 +513,7 @@ class TestLifespanAccountManagerInit:
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
-        monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
+        monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         
         creds_file = tmp_path / "credentials.json"
@@ -568,7 +568,7 @@ class TestLifespanAccountManagerInit:
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
-        monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
+        monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         
         creds_file = tmp_path / "credentials.json"
@@ -626,7 +626,7 @@ class TestLifespanAccountManagerInit:
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
-        monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
+        monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         
         creds_file = tmp_path / "credentials.json"
@@ -666,7 +666,7 @@ class TestLifespanAccountManagerInit:
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
-        monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
+        monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         
         creds_file = tmp_path / "credentials.json"
@@ -710,7 +710,7 @@ class TestLifespanAccountManagerInit:
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
-        monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
+        monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         
         creds_file = tmp_path / "credentials.json"
@@ -761,7 +761,7 @@ class TestLifespanAccountManagerInit:
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
-        monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
+        monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         
         creds_file = tmp_path / "credentials.json"
@@ -811,7 +811,7 @@ class TestLifespanAccountManagerInit:
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
-        monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
+        monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         
         creds_file = tmp_path / "credentials.json"
@@ -869,7 +869,7 @@ class TestLifespanAccountManagerInit:
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
-        monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
+        monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
         
         creds_file = tmp_path / "credentials.json"


### PR DESCRIPTION
## Summary

- Adds the default Windows `kiro-cli` SQLite database path to `.env.example` so Windows users can copy it directly without guessing the path
- Renames the legacy `KIRO_CREDS_FILE` env var to `KIRO_CLI_DB_FILE` for consistency across all docs, config, and code
- Updates all language-specific READMEs, architecture docs, docker-compose, and tests to reflect the rename

## Motivation

Windows users copying `.env.example` to `.env` were likely to use the Linux/macOS path or the old `KIRO_CREDS_FILE` variable name, which caused the gateway to read stale credentials or an old Kiro account after logging in with `kiro-cli` on Windows.

## Test plan

- [ ] Verify `KIRO_CLI_DB_FILE` is accepted in `.env` on Windows and the gateway picks up the correct SQLite database
- [ ] Confirm no references to `KIRO_CREDS_FILE` remain in docs or runnable code
- [ ] Run existing test suite (`pytest`) to confirm no regressions