### PR TITLE
Fix newer Kiro model discovery and Anthropic adaptive thinking compatibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -270,6 +270,22 @@ PROXY_API_KEY="my-super-secret-password-123"
 # KIRO_MAX_PAYLOAD_BYTES=600000
 
 # ===========================================
+# MODEL LIST DISCOVERY
+# ===========================================
+
+# Enable entitlement-aware model discovery via kiro-cli for sqlite/kiro-cli accounts.
+# Runtime endpoints do not provide /ListAvailableModels, so this uses:
+# kiro-cli chat --list-models --format json
+# Falls back to the static model list if kiro-cli is unavailable or fails.
+# KIRO_CLI_LIST_MODELS_ENABLED=true
+
+# Kiro CLI executable name or absolute path.
+# KIRO_CLI_LIST_MODELS_COMMAND="kiro-cli"
+
+# Timeout in seconds for querying kiro-cli model list.
+# KIRO_CLI_LIST_MODELS_TIMEOUT_SECONDS=10.0
+
+# ===========================================
 # TRUNCATION RECOVERY
 # ===========================================
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ requests/
 .pytest_cache/
 .coverage
 htmlcov/
+
+# temporary files
+tmp/*

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,3 @@ requests/
 .pytest_cache/
 .coverage
 htmlcov/
-
-# temporary files
-tmp/*

--- a/kiro/account_manager.py
+++ b/kiro/account_manager.py
@@ -40,7 +40,7 @@ import random
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 from loguru import logger
@@ -52,6 +52,7 @@ from kiro.config import (
     HIDDEN_MODELS,
     MODEL_ALIASES,
     HIDDEN_FROM_LIST,
+    KIRO_CLI_LIST_MODELS_ENABLED,
     ACCOUNT_RECOVERY_TIMEOUT,
     ACCOUNT_MAX_BACKOFF_MULTIPLIER,
     ACCOUNT_PROBABILISTIC_RETRY_CHANCE,
@@ -62,6 +63,7 @@ from kiro.config import (
 from kiro.utils import get_kiro_headers
 from kiro.account_errors import ErrorType
 from kiro.http_client import KiroHttpClient
+from kiro.cli_models import KiroCliModelListError, fetch_kiro_cli_models
 
 
 def _is_runtime_endpoint(auth_manager: KiroAuthManager) -> bool:
@@ -91,6 +93,142 @@ def _is_runtime_endpoint(auth_manager: KiroAuthManager) -> bool:
         False
     """
     return "://runtime." in auth_manager.api_host
+
+
+def _extract_model_ids(models_data: List[Dict[str, Any]]) -> List[str]:
+    """
+    Extract model IDs from raw model metadata for diagnostics.
+
+    Args:
+        models_data: Raw model metadata list from Kiro or fallback config.
+
+    Returns:
+        Model IDs in source order, excluding malformed entries.
+    """
+    model_ids: List[str] = []
+    for model in models_data:
+        if not isinstance(model, dict):
+            continue
+        model_id = model.get("modelId")
+        if isinstance(model_id, str) and model_id:
+            model_ids.append(model_id)
+    return model_ids
+
+
+def _log_model_source_snapshot(
+    account_id: str,
+    source: str,
+    models_data: List[Dict[str, Any]],
+    raw_payload: Dict[str, Any],
+    endpoint: Optional[str] = None,
+    status_code: Optional[int] = None,
+    error: Optional[str] = None,
+) -> None:
+    """
+    Write a debug-only snapshot of the source used to populate model cache.
+
+    Args:
+        account_id: Account whose cache is being initialized or refreshed.
+        source: Source label, such as runtime_fallback or list_available_models.
+        models_data: Model metadata selected for the cache.
+        raw_payload: Raw source payload used for the decision.
+        endpoint: Optional upstream endpoint URL.
+        status_code: Optional upstream response status.
+        error: Optional error text if fallback was selected after failure.
+    """
+    try:
+        from kiro.debug_logger import debug_logger
+    except ImportError as exc:
+        logger.debug(f"Debug logger unavailable for model source snapshot: {exc}")
+        return
+
+    payload: Dict[str, Any] = {
+        "event": "model_source_snapshot",
+        "account_id": account_id,
+        "source": source,
+        "model_count": len(models_data),
+        "model_ids": _extract_model_ids(models_data),
+        "raw_payload": raw_payload,
+    }
+    if endpoint is not None:
+        payload["endpoint"] = endpoint
+    if status_code is not None:
+        payload["status_code"] = status_code
+    if error is not None:
+        payload["error"] = error
+
+    debug_logger.append_jsonl_artifact("model_source_snapshots.jsonl", payload)
+
+
+async def _load_runtime_endpoint_models(
+    account_id: str,
+    credential_type: Optional[str],
+    endpoint: str,
+) -> List[Dict[str, Any]]:
+    """
+    Load models for runtime.kiro.dev accounts.
+
+    The runtime endpoint does not provide /ListAvailableModels. For sqlite
+    accounts, kiro-cli can provide the user's actual entitlement-aware model
+    list. If that is unavailable, fall back to the static compatibility list.
+
+    Args:
+        account_id: Account whose models are being loaded.
+        credential_type: Credential type from credentials.json.
+        endpoint: Runtime endpoint URL.
+
+    Returns:
+        Model metadata list in ModelInfoCache format.
+    """
+    if KIRO_CLI_LIST_MODELS_ENABLED and credential_type == "sqlite":
+        try:
+            cli_model_list = await fetch_kiro_cli_models()
+        except KiroCliModelListError as exc:
+            logger.warning(
+                f"Failed to fetch runtime model list via kiro-cli for {account_id}: {exc}. "
+                "Using static fallback models."
+            )
+            _log_model_source_snapshot(
+                account_id=account_id,
+                source="runtime_fallback_after_kiro_cli_error",
+                models_data=FALLBACK_MODELS,
+                raw_payload={"models": FALLBACK_MODELS},
+                endpoint=endpoint,
+                error=str(exc),
+            )
+            return FALLBACK_MODELS
+
+        logger.info(
+            f"Loaded {len(cli_model_list.models)} runtime model(s) via kiro-cli "
+            f"for account {account_id}"
+        )
+        _log_model_source_snapshot(
+            account_id=account_id,
+            source="kiro_cli_list_models",
+            models_data=cli_model_list.models,
+            raw_payload=cli_model_list.raw_payload,
+            endpoint=endpoint,
+        )
+        return cli_model_list.models
+
+    if not KIRO_CLI_LIST_MODELS_ENABLED:
+        logger.debug(
+            f"Account {account_id}: kiro-cli model discovery disabled, using static fallback"
+        )
+    else:
+        logger.debug(
+            f"Account {account_id}: credential type '{credential_type}' cannot use "
+            "kiro-cli model discovery, using static fallback"
+        )
+
+    _log_model_source_snapshot(
+        account_id=account_id,
+        source="runtime_fallback",
+        models_data=FALLBACK_MODELS,
+        raw_payload={"models": FALLBACK_MODELS},
+        endpoint=endpoint,
+    )
+    return FALLBACK_MODELS
 
 
 def _format_duration(seconds: float) -> str:
@@ -146,6 +284,7 @@ class Account:
     Attributes:
         id: Unique identifier (path to credentials file)
         auth_manager: Authentication manager (lazy initialized)
+        credential_type: Credential type from credentials.json
         model_cache: Model metadata cache (lazy initialized)
         model_resolver: Model resolver (lazy initialized)
         failures: Consecutive failure count (for Circuit Breaker)
@@ -155,6 +294,7 @@ class Account:
     """
     id: str
     auth_manager: Optional[KiroAuthManager] = None
+    credential_type: Optional[str] = None
     model_cache: Optional[ModelInfoCache] = None
     model_resolver: Optional[ModelResolver] = None
     failures: int = 0
@@ -469,6 +609,7 @@ class AccountManager:
             
             # Create KiroAuthManager based on type
             cred_type = creds_config.get("type")
+            account.credential_type = cred_type
             if cred_type == "json":
                 auth_manager = KiroAuthManager(
                     creds_file=account_id,
@@ -500,9 +641,16 @@ class AccountManager:
             # Determine if we should fetch models or use static list
             if _is_runtime_endpoint(auth_manager):
                 # New runtime endpoint does not provide /ListAvailableModels (AWS limitation)
-                # Use static list without attempting request
-                logger.debug(f"Account {account_id}: Using static model list for runtime.kiro.dev endpoint")
-                models_list = FALLBACK_MODELS
+                # Use kiro-cli entitlement list for sqlite accounts when available,
+                # then fall back to the static compatibility list.
+                logger.debug(
+                    f"Account {account_id}: Loading model list for runtime.kiro.dev endpoint"
+                )
+                models_list = await _load_runtime_endpoint_models(
+                    account_id=account_id,
+                    credential_type=cred_type,
+                    endpoint=auth_manager.api_host,
+                )
             else:
                 # Old endpoint - attempt to fetch dynamic model list
                 # Fetch models list with retry + fallback
@@ -527,6 +675,14 @@ class AccountManager:
                     if response.status_code == 200:
                         data = response.json()
                         models_list = data.get("models", [])
+                        _log_model_source_snapshot(
+                            account_id=account_id,
+                            source="list_available_models",
+                            models_data=models_list,
+                            raw_payload=data,
+                            endpoint=list_models_url,
+                            status_code=response.status_code,
+                        )
                     else:
                         # Shouldn't happen (retry handles non-200), but keep for safety
                         raise Exception(f"HTTP {response.status_code}")
@@ -536,6 +692,14 @@ class AccountManager:
                     logger.error(f"Failed to fetch models for {account_id} after retries: {e}")
                     logger.warning("Using pre-configured fallback models. Models will be refreshed on next TTL cycle when network recovers.")
                     models_list = FALLBACK_MODELS
+                    _log_model_source_snapshot(
+                        account_id=account_id,
+                        source="fallback_after_list_available_models_error",
+                        models_data=models_list,
+                        raw_payload={"models": models_list},
+                        endpoint=list_models_url,
+                        error=str(e),
+                    )
                 
                 finally:
                     await http_client.close()
@@ -592,10 +756,27 @@ class AccountManager:
         # Check if using runtime endpoint (no dynamic model list available)
         if _is_runtime_endpoint(account.auth_manager):
             # Runtime endpoint does not provide /ListAvailableModels
-            # Use static list and update cache timestamp
-            logger.debug(f"Account {account_id}: Skipping model refresh for runtime.kiro.dev endpoint (using static list)")
-            await account.model_cache.update(FALLBACK_MODELS)
+            # Use kiro-cli entitlement list for sqlite accounts when available,
+            # then fall back to the static compatibility list.
+            logger.debug(
+                f"Account {account_id}: Refreshing model list for runtime.kiro.dev endpoint"
+            )
+            models_list = await _load_runtime_endpoint_models(
+                account_id=account_id,
+                credential_type=account.credential_type,
+                endpoint=account.auth_manager.api_host,
+            )
+            await account.model_cache.update(models_list)
             account.models_cached_at = time.time()
+
+            # Update model_to_accounts mapping (new models may have appeared)
+            available_models = account.model_resolver.get_available_models()
+            for model in available_models:
+                if model not in self._model_to_accounts:
+                    self._model_to_accounts[model] = ModelAccountList()
+                if account_id not in self._model_to_accounts[model].accounts:
+                    self._model_to_accounts[model].accounts.append(account_id)
+
             self._dirty = True
             return
         
@@ -622,6 +803,14 @@ class AccountManager:
                 data = response.json()
                 models_list = data.get("models", [])
                 await account.model_cache.update(models_list)
+                _log_model_source_snapshot(
+                    account_id=account_id,
+                    source="list_available_models_refresh",
+                    models_data=models_list,
+                    raw_payload=data,
+                    endpoint=list_models_url,
+                    status_code=response.status_code,
+                )
                 account.models_cached_at = time.time()
                 
                 # Update model_to_accounts mapping (new models may have appeared)
@@ -638,6 +827,14 @@ class AccountManager:
         except Exception as e:
             # All retries exhausted - keep using stale cache
             logger.warning(f"Failed to refresh models for {account_id} after retries: {e}")
+            _log_model_source_snapshot(
+                account_id=account_id,
+                source="list_available_models_refresh_error_keep_stale",
+                models_data=[],
+                raw_payload={},
+                endpoint=list_models_url,
+                error=str(e),
+            )
         
         finally:
             await http_client.close()

--- a/kiro/cli_models.py
+++ b/kiro/cli_models.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+
+# Kiro Gateway
+# https://github.com/jwadow/kiro-gateway
+# Copyright (C) 2025 Jwadow
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Kiro CLI model list provider.
+
+The runtime Kiro endpoint does not expose /ListAvailableModels, but kiro-cli can
+query the user's actual model entitlement list via `kiro-cli chat --list-models`.
+This module isolates that CLI dependency and converts its JSON output into the
+ModelInfoCache format used by the gateway.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from asyncio.subprocess import PIPE
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from loguru import logger
+
+from kiro.config import (
+    DEFAULT_MAX_INPUT_TOKENS,
+    KIRO_CLI_LIST_MODELS_COMMAND,
+    KIRO_CLI_LIST_MODELS_TIMEOUT_SECONDS,
+)
+
+
+class KiroCliModelListError(RuntimeError):
+    """Raised when the Kiro CLI model list cannot be retrieved or parsed."""
+
+
+@dataclass(frozen=True)
+class KiroCliModelList:
+    """
+    Parsed Kiro CLI model list.
+
+    Attributes:
+        models: Model metadata converted to ModelInfoCache format.
+        default_model: Default model ID reported by kiro-cli, if present.
+        raw_payload: Raw JSON payload decoded from kiro-cli output.
+    """
+
+    models: List[Dict[str, Any]]
+    default_model: Optional[str]
+    raw_payload: Dict[str, Any]
+
+
+def _positive_int_or_default(value: Any, default: int) -> int:
+    """
+    Convert a value to a positive integer or return a default.
+
+    Args:
+        value: Candidate numeric value.
+        default: Fallback value.
+
+    Returns:
+        Positive integer value or the default.
+    """
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, int) and value > 0:
+        return value
+    return default
+
+
+def parse_kiro_cli_models_json(output: str) -> KiroCliModelList:
+    """
+    Parse `kiro-cli chat --list-models --format json` output.
+
+    Args:
+        output: Raw stdout from kiro-cli.
+
+    Returns:
+        Parsed model list with metadata converted to gateway cache format.
+
+    Raises:
+        KiroCliModelListError: If output is not valid JSON or contains no
+            usable model entries.
+    """
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise KiroCliModelListError(f"kiro-cli returned invalid JSON: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise KiroCliModelListError("kiro-cli model payload must be a JSON object")
+
+    raw_models = payload.get("models")
+    if not isinstance(raw_models, list):
+        raise KiroCliModelListError("kiro-cli model payload missing models array")
+
+    default_model = payload.get("default_model")
+    if not isinstance(default_model, str):
+        default_model = None
+
+    models: List[Dict[str, Any]] = []
+    for raw_model in raw_models:
+        if not isinstance(raw_model, dict):
+            continue
+
+        model_id = raw_model.get("model_id")
+        if not isinstance(model_id, str) or not model_id:
+            continue
+
+        model_name = raw_model.get("model_name")
+        if not isinstance(model_name, str) or not model_name:
+            model_name = model_id
+
+        description = raw_model.get("description")
+        if not isinstance(description, str):
+            description = ""
+
+        max_input_tokens = _positive_int_or_default(
+            raw_model.get("context_window_tokens"),
+            DEFAULT_MAX_INPUT_TOKENS,
+        )
+
+        converted_model: Dict[str, Any] = {
+            "modelId": model_id,
+            "modelName": model_name,
+            "description": description,
+            "tokenLimits": {"maxInputTokens": max_input_tokens},
+            "_source": "kiro_cli",
+        }
+
+        if model_id == default_model:
+            converted_model["_is_default"] = True
+
+        rate_multiplier = raw_model.get("rate_multiplier")
+        if isinstance(rate_multiplier, (int, float)) and not isinstance(rate_multiplier, bool):
+            converted_model["rateMultiplier"] = float(rate_multiplier)
+
+        rate_unit = raw_model.get("rate_unit")
+        if isinstance(rate_unit, str) and rate_unit:
+            converted_model["rateUnit"] = rate_unit
+
+        models.append(converted_model)
+
+    if not models:
+        raise KiroCliModelListError("kiro-cli returned no usable models")
+
+    return KiroCliModelList(
+        models=models,
+        default_model=default_model,
+        raw_payload=payload,
+    )
+
+
+async def fetch_kiro_cli_models(
+    command: str = KIRO_CLI_LIST_MODELS_COMMAND,
+    timeout_seconds: float = KIRO_CLI_LIST_MODELS_TIMEOUT_SECONDS,
+) -> KiroCliModelList:
+    """
+    Fetch available models from kiro-cli.
+
+    Args:
+        command: Executable name or path for kiro-cli.
+        timeout_seconds: Maximum time to wait for the CLI command.
+
+    Returns:
+        Parsed Kiro CLI model list.
+
+    Raises:
+        KiroCliModelListError: If the command cannot be executed, times out,
+            exits with an error, or returns malformed output.
+    """
+    if not command:
+        raise KiroCliModelListError("kiro-cli command is empty")
+
+    args = [command, "chat", "--list-models", "--format", "json"]
+    logger.debug(f"Fetching model list via {' '.join(args)}")
+
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *args,
+            stdout=PIPE,
+            stderr=PIPE,
+        )
+    except FileNotFoundError as exc:
+        raise KiroCliModelListError(f"kiro-cli command not found: {command}") from exc
+    except PermissionError as exc:
+        raise KiroCliModelListError(f"kiro-cli command is not executable: {command}") from exc
+    except OSError as exc:
+        raise KiroCliModelListError(f"failed to start kiro-cli: {exc}") from exc
+
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            process.communicate(),
+            timeout=timeout_seconds,
+        )
+    except asyncio.TimeoutError as exc:
+        try:
+            process.kill()
+            await process.wait()
+        except ProcessLookupError:
+            pass
+        raise KiroCliModelListError(
+            f"kiro-cli model list timed out after {timeout_seconds}s"
+        ) from exc
+
+    stdout_text = stdout.decode("utf-8", errors="replace")
+    stderr_text = stderr.decode("utf-8", errors="replace").strip()
+
+    if process.returncode != 0:
+        detail = stderr_text or stdout_text.strip() or f"exit code {process.returncode}"
+        raise KiroCliModelListError(f"kiro-cli model list failed: {detail}")
+
+    return parse_kiro_cli_models_json(stdout_text)

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -261,6 +261,12 @@ HIDDEN_MODELS: Dict[str, str] = {
 # Default: {"auto-kiro": "auto"} to avoid Cursor IDE conflict
 MODEL_ALIASES: Dict[str, str] = {
     "auto-kiro": "auto",  # Default alias to avoid Cursor's "auto" model conflict
+    "claude-opus-4-8": "claude-opus-4.8",  # Explicit alias for clarity
+    "claude-opus-4-7": "claude-opus-4.7",  # Explicit alias for clarity
+    "claude-opus-4-6": "claude-opus-4.6",  # Explicit alias for clarity
+    "claude-opus-4-5": "claude-opus-4.5",  # Explicit alias for clarity
+    "claude-sonnet-4-6": "claude-sonnet-4.6",  # Explicit alias for clarity
+    "claude-sonnet-4-5": "claude-sonnet-4.5",  # Explicit alias for clarity
 }
 
 # Models to hide from /v1/models endpoint.

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -76,6 +76,19 @@ def _get_raw_env_value(var_name: str, env_file: str = ".env") -> Optional[str]:
     
     return None
 
+
+def _normalize_path_value(path_value: str) -> str:
+    """
+    Normalize a configured filesystem path.
+
+    Args:
+        path_value: Raw path value from environment or .env.
+
+    Returns:
+        Normalized path string with user home expansion applied.
+    """
+    return str(Path(path_value).expanduser())
+
 # ==================================================================================================
 # Server Settings
 # ==================================================================================================
@@ -151,13 +164,13 @@ REGION: str = os.getenv("KIRO_REGION", "us-east-1")
 # (e.g., \a in path D:\Projects\adolf is interpreted as bell character)
 _raw_creds_file = _get_raw_env_value("KIRO_CREDS_FILE") or os.getenv("KIRO_CREDS_FILE", "")
 # Normalize path for cross-platform compatibility
-KIRO_CREDS_FILE: str = str(Path(_raw_creds_file)) if _raw_creds_file else ""
+KIRO_CREDS_FILE: str = _normalize_path_value(_raw_creds_file) if _raw_creds_file else ""
 
 # Path to kiro-cli SQLite database (optional, for AWS SSO OIDC authentication)
 # Default location: ~/.local/share/kiro-cli/data.sqlite3 (Linux/macOS)
 # or ~/.local/share/amazon-q/data.sqlite3 (amazon-q-developer-cli)
 _raw_cli_db_file = _get_raw_env_value("KIRO_CLI_DB_FILE") or os.getenv("KIRO_CLI_DB_FILE", "")
-KIRO_CLI_DB_FILE: str = str(Path(_raw_cli_db_file)) if _raw_cli_db_file else ""
+KIRO_CLI_DB_FILE: str = _normalize_path_value(_raw_cli_db_file) if _raw_cli_db_file else ""
 
 # Disable SQLite write-back (read-only mode)
 # When enabled, gateway will only read from kiro-cli database without modifying it.
@@ -261,6 +274,21 @@ MODEL_ALIASES: Dict[str, str] = {
 #
 # Default: ["auto"] to show only "auto-kiro" alias
 HIDDEN_FROM_LIST: List[str] = ["auto"]
+
+# ==================================================================================================
+# Kiro CLI Model List Configuration
+# ==================================================================================================
+
+# When enabled, sqlite/kiro-cli accounts using runtime.kiro.dev will query
+# `kiro-cli chat --list-models --format json` for the actual entitlement-aware
+# model list before falling back to the static fallback list.
+KIRO_CLI_LIST_MODELS_ENABLED: bool = os.getenv("KIRO_CLI_LIST_MODELS_ENABLED", "true").lower() in ("true", "1", "yes")
+
+# Kiro CLI executable used for model list discovery.
+KIRO_CLI_LIST_MODELS_COMMAND: str = os.getenv("KIRO_CLI_LIST_MODELS_COMMAND", "kiro-cli")
+
+# Timeout for model list discovery via kiro-cli.
+KIRO_CLI_LIST_MODELS_TIMEOUT_SECONDS: float = float(os.getenv("KIRO_CLI_LIST_MODELS_TIMEOUT_SECONDS", "10.0"))
 
 # ==================================================================================================
 # Fallback Models Configuration (DNS Failure Recovery)

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -261,12 +261,6 @@ HIDDEN_MODELS: Dict[str, str] = {
 # Default: {"auto-kiro": "auto"} to avoid Cursor IDE conflict
 MODEL_ALIASES: Dict[str, str] = {
     "auto-kiro": "auto",  # Default alias to avoid Cursor's "auto" model conflict
-    "claude-opus-4-8": "claude-opus-4.8",  # Explicit alias for clarity
-    "claude-opus-4-7": "claude-opus-4.7",  # Explicit alias for clarity
-    "claude-opus-4-6": "claude-opus-4.6",  # Explicit alias for clarity
-    "claude-opus-4-5": "claude-opus-4.5",  # Explicit alias for clarity
-    "claude-sonnet-4-6": "claude-sonnet-4.6",  # Explicit alias for clarity
-    "claude-sonnet-4-5": "claude-sonnet-4.5",  # Explicit alias for clarity
 }
 
 # Models to hide from /v1/models endpoint.

--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -29,7 +29,7 @@ from typing import Any, Dict, List, Optional
 from loguru import logger
 
 from kiro.config import HIDDEN_MODELS
-from kiro.model_resolver import get_model_id_for_kiro
+from kiro.model_resolver import get_model_id_for_kiro, model_supports_native_thinking
 from kiro.models_anthropic import (
     AnthropicMessagesRequest,
     AnthropicMessage,
@@ -372,30 +372,35 @@ def convert_anthropic_tools(
 
 def extract_thinking_config_from_anthropic(request: AnthropicMessagesRequest) -> ThinkingConfig:
     """
-    Extract thinking configuration from Anthropic request.
-    
+    Extract thinking configuration from Anthropic request (legacy fake-reasoning path).
+
+    This is only used for older models that do NOT support native adaptive thinking.
+    Newer models forward `thinking`/`output_config` verbatim instead (see
+    anthropic_to_kiro and model_supports_native_thinking).
+
     Handles thinking parameter:
     - {"type": "enabled", "budget_tokens": N} → enabled with budget
+    - {"type": "adaptive"} → enabled with default budget (no explicit budget on this path)
     - {"type": "disabled"} → disabled
     - None → enabled with default budget
-    
+
     Args:
         request: Anthropic MessagesRequest
-    
+
     Returns:
         ThinkingConfig for core layer
-    
+
     Examples:
         >>> # No thinking specified → use defaults
         >>> request = AnthropicMessagesRequest(model="claude-sonnet-4.5", messages=[...], max_tokens=4096)
         >>> extract_thinking_config_from_anthropic(request)
         ThinkingConfig(enabled=True, budget_tokens=None)
-        
+
         >>> # Explicitly disabled
         >>> request.thinking = {"type": "disabled"}
         >>> extract_thinking_config_from_anthropic(request)
         ThinkingConfig(enabled=False, budget_tokens=None)
-        
+
         >>> # Enabled with custom budget
         >>> request.thinking = {"type": "enabled", "budget_tokens": 8000}
         >>> extract_thinking_config_from_anthropic(request)
@@ -404,25 +409,25 @@ def extract_thinking_config_from_anthropic(request: AnthropicMessagesRequest) ->
     if not request.thinking:
         # No thinking specified → use defaults
         return ThinkingConfig(enabled=True, budget_tokens=None)
-    
+
     if not isinstance(request.thinking, dict):
         # Invalid format → use defaults
         return ThinkingConfig(enabled=True, budget_tokens=None)
-    
+
     thinking_type = request.thinking.get("type")
-    
+
     if thinking_type == "disabled":
         # Explicitly disabled
         return ThinkingConfig(enabled=False, budget_tokens=None)
-    
+
     if thinking_type == "enabled":
         # Extract budget_tokens
         budget = request.thinking.get("budget_tokens")
         if budget:
             logger.debug(f"Extracted thinking config from Anthropic: type='enabled', budget={budget}")
         return ThinkingConfig(enabled=True, budget_tokens=budget)
-    
-    # Unknown type → use defaults
+
+    # Unknown type (including "adaptive" reaching the legacy path) → enabled with defaults
     return ThinkingConfig(enabled=True, budget_tokens=None)
 
 
@@ -464,15 +469,38 @@ def anthropic_to_kiro(
     # Pass-through principle: we normalize and send to Kiro, Kiro decides if valid
     model_id = get_model_id_for_kiro(request.model, HIDDEN_MODELS)
 
-    # Extract thinking configuration from thinking parameter
+    # Decide path by model generation:
+    # - Newer adaptive-thinking models (Opus/Sonnet >= 4.6, Fable, Mythos):
+    #   forward the original `thinking` and `output_config` verbatim so the
+    #   backend Claude model handles reasoning natively.
+    # - Older models: fall back to the legacy fake-reasoning budget path.
+    use_native = model_supports_native_thinking(request.model)
+
+    native_thinking = None
+    native_output_config = None
     thinking_config = extract_thinking_config_from_anthropic(request)
 
-    logger.debug(
-        f"Converting Anthropic request: model={request.model} -> {model_id}, "
-        f"messages={len(unified_messages)}, tools={len(unified_tools) if unified_tools else 0}, "
-        f"system_prompt_length={len(system_prompt)}, "
-        f"thinking_enabled={thinking_config.enabled}, thinking_budget={thinking_config.budget_tokens}"
-    )
+    if use_native:
+        # Forward raw dicts (only if the client actually sent them)
+        if isinstance(request.thinking, dict):
+            native_thinking = request.thinking
+        native_output_config = getattr(request, "output_config", None)
+        if not isinstance(native_output_config, dict):
+            native_output_config = None
+
+        logger.debug(
+            f"Converting Anthropic request (native thinking): model={request.model} -> {model_id}, "
+            f"messages={len(unified_messages)}, tools={len(unified_tools) if unified_tools else 0}, "
+            f"system_prompt_length={len(system_prompt)}, "
+            f"thinking={native_thinking}, output_config={native_output_config}"
+        )
+    else:
+        logger.debug(
+            f"Converting Anthropic request (legacy budget): model={request.model} -> {model_id}, "
+            f"messages={len(unified_messages)}, tools={len(unified_tools) if unified_tools else 0}, "
+            f"system_prompt_length={len(system_prompt)}, "
+            f"thinking_enabled={thinking_config.enabled}, thinking_budget={thinking_config.budget_tokens}"
+        )
 
     # Use core function to build payload
     result = build_kiro_payload(
@@ -483,6 +511,8 @@ def anthropic_to_kiro(
         conversation_id=conversation_id,
         profile_arn=profile_arn,
         thinking_config=thinking_config,
+        native_thinking=native_thinking,
+        native_output_config=native_output_config,
     )
 
     return result.payload

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -1402,6 +1402,42 @@ def build_kiro_history(messages: List[UnifiedMessage], model_id: str) -> List[Di
 # Main Payload Building
 # ==================================================================================================
 
+def _build_additional_model_request_fields(
+    native_thinking: Optional[Dict[str, Any]],
+    native_output_config: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """
+    Build Kiro Runtime native model parameters.
+
+    Kiro CLI sends adaptive-thinking fields on the command-level
+    ``additionalModelRequestFields`` object, not inside
+    ``conversationState.currentMessage.userInputMessage``.
+
+    Args:
+        native_thinking: Raw Anthropic ``thinking`` dict from the client.
+        native_output_config: Raw Anthropic ``output_config`` dict from the client.
+
+    Returns:
+        Command-level additional model fields, or None when no native fields exist.
+    """
+    additional_fields: Dict[str, Any] = {}
+
+    if native_thinking is not None:
+        thinking = dict(native_thinking)
+        if (
+            thinking.get("type") == "adaptive"
+            and "display" not in thinking
+        ):
+            # Kiro CLI defaults adaptive thinking to summarized display.
+            thinking["display"] = "summarized"
+        additional_fields["thinking"] = thinking
+
+    if native_output_config is not None:
+        additional_fields["output_config"] = dict(native_output_config)
+
+    return additional_fields or None
+
+
 def build_kiro_payload(
     messages: List[UnifiedMessage],
     system_prompt: str,
@@ -1427,11 +1463,11 @@ def build_kiro_payload(
         conversation_id: Unique conversation ID
         profile_arn: AWS CodeWhisperer profile ARN
         thinking_config: Thinking configuration from API adapter (legacy fake-reasoning path)
-        native_thinking: Raw Anthropic ``thinking`` dict to forward verbatim to the
-            Kiro backend (newer adaptive-thinking models). When provided, fake-reasoning
-            tag injection is skipped.
+        native_thinking: Raw Anthropic ``thinking`` dict to forward to the Kiro backend
+            through command-level ``additionalModelRequestFields``. When provided,
+            fake-reasoning tag injection is skipped.
         native_output_config: Raw Anthropic ``output_config`` dict (e.g. ``{"effort": ...}``)
-            to forward verbatim alongside native_thinking.
+            to forward through command-level ``additionalModelRequestFields``.
 
     Returns:
         KiroPayloadResult with payload and tool documentation
@@ -1572,19 +1608,6 @@ def build_kiro_payload(
         "origin": "AI_EDITOR",
     }
 
-    # Forward native thinking / output_config verbatim for newer models.
-    # Placed alongside modelId in userInputMessage so the Kiro backend can read
-    # them next to the model selection.
-    if native_thinking is not None:
-        user_input_message["thinking"] = native_thinking
-    if native_output_config is not None:
-        user_input_message["output_config"] = native_output_config
-    if use_native_thinking:
-        logger.debug(
-            f"Forwarding native thinking/output_config to Kiro: "
-            f"thinking={native_thinking}, output_config={native_output_config}"
-        )
-
     # Add images directly to userInputMessage (NOT to userInputMessageContext)
     if kiro_images:
         user_input_message["images"] = kiro_images
@@ -1611,6 +1634,19 @@ def build_kiro_payload(
     # Add profileArn
     if profile_arn:
         payload["profileArn"] = profile_arn
+
+    # Forward native thinking / output_config for newer models. Kiro Runtime expects
+    # these fields at the command level, matching Kiro CLI's GenerateAssistantResponseCommand.
+    additional_model_request_fields = _build_additional_model_request_fields(
+        native_thinking=native_thinking,
+        native_output_config=native_output_config,
+    )
+    if additional_model_request_fields is not None:
+        payload["additionalModelRequestFields"] = additional_model_request_fields
+        logger.debug(
+            "Forwarding native thinking/output_config to Kiro additionalModelRequestFields: "
+            f"{additional_model_request_fields}"
+        )
 
     # Payload size guard — auto-trim if enabled
     if AUTO_TRIM_PAYLOAD:

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -1423,14 +1423,7 @@ def _build_additional_model_request_fields(
     additional_fields: Dict[str, Any] = {}
 
     if native_thinking is not None:
-        thinking = dict(native_thinking)
-        if (
-            thinking.get("type") == "adaptive"
-            and "display" not in thinking
-        ):
-            # Kiro CLI defaults adaptive thinking to summarized display.
-            thinking["display"] = "summarized"
-        additional_fields["thinking"] = thinking
+        additional_fields["thinking"] = dict(native_thinking)
 
     if native_output_config is not None:
         additional_fields["output_config"] = dict(native_output_config)

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -1409,14 +1409,16 @@ def build_kiro_payload(
     tools: Optional[List[UnifiedTool]],
     conversation_id: str,
     profile_arn: str,
-    thinking_config: ThinkingConfig
+    thinking_config: ThinkingConfig,
+    native_thinking: Optional[Dict[str, Any]] = None,
+    native_output_config: Optional[Dict[str, Any]] = None,
 ) -> KiroPayloadResult:
     """
     Builds complete payload for Kiro API from unified data.
-    
+
     This is the main function that assembles the Kiro API payload from
     API-agnostic unified message and tool formats.
-    
+
     Args:
         messages: List of messages in unified format (without system messages)
         system_prompt: Already extracted system prompt
@@ -1424,14 +1426,23 @@ def build_kiro_payload(
         tools: List of tools in unified format (or None)
         conversation_id: Unique conversation ID
         profile_arn: AWS CodeWhisperer profile ARN
-        thinking_config: Thinking configuration from API adapter
-    
+        thinking_config: Thinking configuration from API adapter (legacy fake-reasoning path)
+        native_thinking: Raw Anthropic ``thinking`` dict to forward verbatim to the
+            Kiro backend (newer adaptive-thinking models). When provided, fake-reasoning
+            tag injection is skipped.
+        native_output_config: Raw Anthropic ``output_config`` dict (e.g. ``{"effort": ...}``)
+            to forward verbatim alongside native_thinking.
+
     Returns:
         KiroPayloadResult with payload and tool documentation
-    
+
     Raises:
         ValueError: If there are no messages to send
     """
+    # When native thinking/output_config are forwarded, the model handles
+    # reasoning itself — do NOT inject fake-reasoning tags or the legitimizing
+    # system prompt addition.
+    use_native_thinking = native_thinking is not None or native_output_config is not None
     # Process tools with long descriptions
     processed_tools, tool_documentation = process_tools_with_long_descriptions(tools)
     
@@ -1443,10 +1454,13 @@ def build_kiro_payload(
     if tool_documentation:
         full_system_prompt = full_system_prompt + tool_documentation if full_system_prompt else tool_documentation.strip()
     
-    # Add thinking mode legitimization to system prompt if enabled
-    thinking_system_addition = get_thinking_system_prompt_addition()
-    if thinking_system_addition:
-        full_system_prompt = full_system_prompt + thinking_system_addition if full_system_prompt else thinking_system_addition.strip()
+    # Add thinking mode legitimization to system prompt if enabled.
+    # Skip when forwarding native thinking — the model reasons natively and
+    # the fake-reasoning legitimization is irrelevant.
+    if not use_native_thinking:
+        thinking_system_addition = get_thinking_system_prompt_addition()
+        if thinking_system_addition:
+            full_system_prompt = full_system_prompt + thinking_system_addition if full_system_prompt else thinking_system_addition.strip()
     
     # Add truncation recovery legitimization to system prompt if enabled
     truncation_system_addition = get_truncation_recovery_system_addition()
@@ -1546,25 +1560,39 @@ def build_kiro_payload(
         if tool_results:
             user_input_context["toolResults"] = tool_results
     
-    # Inject thinking tags if enabled (only for the current/last user message)
-    if current_message.role == "user":
+    # Inject thinking tags if enabled (only for the current/last user message).
+    # Skip when forwarding native thinking — the backend model reasons natively.
+    if current_message.role == "user" and not use_native_thinking:
         current_content = inject_thinking_tags(current_content, thinking_config)
-    
+
     # Build userInputMessage
     user_input_message = {
         "content": current_content,
         "modelId": model_id,
         "origin": "AI_EDITOR",
     }
-    
+
+    # Forward native thinking / output_config verbatim for newer models.
+    # Placed alongside modelId in userInputMessage so the Kiro backend can read
+    # them next to the model selection.
+    if native_thinking is not None:
+        user_input_message["thinking"] = native_thinking
+    if native_output_config is not None:
+        user_input_message["output_config"] = native_output_config
+    if use_native_thinking:
+        logger.debug(
+            f"Forwarding native thinking/output_config to Kiro: "
+            f"thinking={native_thinking}, output_config={native_output_config}"
+        )
+
     # Add images directly to userInputMessage (NOT to userInputMessageContext)
     if kiro_images:
         user_input_message["images"] = kiro_images
-    
+
     # Add user_input_context if present (contains tools and toolResults only)
     if user_input_context:
         user_input_message["userInputMessageContext"] = user_input_context
-    
+
     # Assemble final payload
     payload = {
         "conversationState": {

--- a/kiro/debug_logger.py
+++ b/kiro/debug_logger.py
@@ -36,7 +36,7 @@ import io
 import json
 import shutil
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 from loguru import logger
 
 from kiro.config import DEBUG_MODE, DEBUG_DIR
@@ -216,6 +216,39 @@ class DebugLogger:
         else:
             # "errors" mode - buffer
             self._modified_chunks_buffer.extend(chunk)
+
+    def append_jsonl_artifact(self, file_name: str, payload: Any) -> None:
+        """
+        Append a structured diagnostic record to a debug JSONL artifact.
+
+        This is intended for source-data investigation. It writes only in
+        DEBUG_MODE=all so the existing DEBUG_MODE=errors behavior remains
+        "flush on failure" for request logs.
+
+        Args:
+            file_name: Debug artifact file name inside the debug directory.
+            payload: JSON-serializable diagnostic payload.
+        """
+        if not self._is_immediate_write():
+            return
+
+        if Path(file_name).name != file_name:
+            logger.warning(f"[DebugLogger] Refusing unsafe artifact file name: {file_name}")
+            return
+
+        try:
+            serialized = json.dumps(payload, ensure_ascii=False, default=str)
+        except (TypeError, ValueError) as exc:
+            logger.warning(f"[DebugLogger] Failed to serialize artifact {file_name}: {exc}")
+            return
+
+        try:
+            self.debug_dir.mkdir(parents=True, exist_ok=True)
+            file_path = self.debug_dir / file_name
+            with open(file_path, "a", encoding="utf-8") as f:
+                f.write(serialized + "\n")
+        except OSError as exc:
+            logger.error(f"[DebugLogger] Error writing artifact {file_name}: {exc}")
     
     def log_error_info(self, status_code: int, error_message: str = ""):
         """

--- a/kiro/exceptions.py
+++ b/kiro/exceptions.py
@@ -85,6 +85,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     # Sanitize errors for JSON serialization
     sanitized_errors = sanitize_validation_errors(exc.errors())
     
+    logger.error(f"Error at {request.url.path} in: {exc.endpoint_file}:{exc.endpoint_line}")
     logger.error(f"Validation error (422): {sanitized_errors}")
     # Log body at DEBUG level to avoid cluttering console with potentially large payloads
     # logger.debug(f"Request body: {body_str[:500]}...")

--- a/kiro/exceptions.py
+++ b/kiro/exceptions.py
@@ -85,7 +85,6 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     # Sanitize errors for JSON serialization
     sanitized_errors = sanitize_validation_errors(exc.errors())
     
-    logger.error(f"Error at {request.url.path} in: {exc.endpoint_file}:{exc.endpoint_line}")
     logger.error(f"Validation error (422): {sanitized_errors}")
     # Log body at DEBUG level to avoid cluttering console with potentially large payloads
     # logger.debug(f"Request body: {body_str[:500]}...")

--- a/kiro/model_resolver.py
+++ b/kiro/model_resolver.py
@@ -219,6 +219,70 @@ def get_model_id_for_kiro(model_name: str, hidden_models: Dict[str, str]) -> str
     return to_runtime_model_id(internal)
 
 
+def model_supports_native_thinking(model_name: str) -> bool:
+    """
+    Determine whether a model belongs to the "adaptive thinking" generation.
+
+    Newer models accept the native Anthropic ``thinking`` (``{"type": "adaptive"}``)
+    and ``output_config`` (``{"effort": ...}``) parameters instead of the legacy
+    ``thinking.budget_tokens``. For these models the gateway passes the original
+    parameters through to the Kiro backend instead of injecting fake-reasoning tags.
+
+    Generation rules (per Anthropic docs):
+    - Opus  >= 4.6  (4.6, 4.7, 4.8, ...)
+    - Sonnet >= 4.6
+    - Fable / Mythos family (e.g. fable-5, mythos-5, mythos-preview)
+
+    Everything else (Opus/Sonnet 4.5 and earlier, Haiku, 3.x, unknown) uses the
+    legacy budget_tokens path.
+
+    Args:
+        model_name: Model name from the client (any format; normalized internally)
+
+    Returns:
+        True if the model accepts native thinking/output_config parameters.
+
+    Examples:
+        >>> model_supports_native_thinking("claude-opus-4-8")
+        True
+        >>> model_supports_native_thinking("claude-opus-4.6")
+        True
+        >>> model_supports_native_thinking("claude-sonnet-4-6")
+        True
+        >>> model_supports_native_thinking("claude-fable-5")
+        True
+        >>> model_supports_native_thinking("claude-opus-4.5")
+        False
+        >>> model_supports_native_thinking("claude-sonnet-4.5")
+        False
+        >>> model_supports_native_thinking("claude-3.7-sonnet")
+        False
+    """
+    if not model_name:
+        return False
+
+    normalized = normalize_model_name(model_name).lower()
+
+    # Fable / Mythos generations are always adaptive-thinking
+    if "fable" in normalized or "mythos" in normalized:
+        return True
+
+    family = extract_model_family(normalized)
+    if family not in ("opus", "sonnet"):
+        return False
+
+    # Extract major.minor version (e.g. "4.6" -> (4, 6))
+    version_match = re.search(r'(\d+)\.(\d+)', normalized)
+    if not version_match:
+        return False
+
+    major = int(version_match.group(1))
+    minor = int(version_match.group(2))
+
+    # Opus >= 4.6 and Sonnet >= 4.6 use adaptive thinking
+    return (major, minor) >= (4, 6)
+
+
 def extract_model_family(model_name: str) -> Optional[str]:
     """
     Extract model family from model name.

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -26,9 +26,11 @@ Anthropic's Messages API specification.
 Reference: https://docs.anthropic.com/en/api/messages
 """
 
+import json
 import time
 from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, Field, model_validator
+from loguru import logger
 
 
 # ==================================================================================================
@@ -294,6 +296,136 @@ class SystemContentBlock(BaseModel):
 SystemPrompt = Union[str, List[SystemContentBlock], List[Dict[str, Any]]]
 
 
+def _stringify_system_content(value: Any) -> str:
+    """
+    Convert unsupported system content values to readable text.
+
+    Args:
+        value: Raw value found in a system message content block.
+
+    Returns:
+        Text representation suitable for a top-level system text block.
+    """
+    if isinstance(value, str):
+        return value
+
+    if value is None:
+        return ""
+
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _system_content_to_blocks(content: Any) -> List[Dict[str, Any]]:
+    """
+    Convert raw system message content to Anthropic system text blocks.
+
+    Args:
+        content: Content from a raw message with role="system".
+
+    Returns:
+        List of top-level system text blocks.
+    """
+    if isinstance(content, list):
+        blocks = []
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "text":
+                    blocks.append(dict(block))
+                else:
+                    blocks.append(
+                        {
+                            "type": "text",
+                            "text": _stringify_system_content(block),
+                        }
+                    )
+            elif hasattr(block, "type") and getattr(block, "type") == "text":
+                if hasattr(block, "model_dump"):
+                    blocks.append(block.model_dump())
+                else:
+                    blocks.append(
+                        {
+                            "type": "text",
+                            "text": getattr(block, "text", ""),
+                        }
+                    )
+            else:
+                blocks.append(
+                    {
+                        "type": "text",
+                        "text": _stringify_system_content(block),
+                    }
+                )
+        return blocks
+
+    return [{"type": "text", "text": _stringify_system_content(content)}]
+
+
+def _system_prompt_to_blocks(system: Any) -> List[Dict[str, Any]]:
+    """
+    Convert an existing top-level system prompt to system text blocks.
+
+    Args:
+        system: Existing system prompt in string, block list, or model form.
+
+    Returns:
+        List of top-level system text blocks.
+    """
+    if system is None:
+        return []
+
+    return _system_content_to_blocks(system)
+
+
+def _merge_system_messages_into_system(data: Any) -> Any:
+    """
+    Move non-standard Anthropic system messages into the top-level system field.
+
+    Some Claude Code compatible clients may send role="system" inside
+    messages while also sending the official top-level system field. Anthropic's
+    Messages API only allows user/assistant roles in messages, so the gateway
+    normalizes that compatibility format before strict message validation.
+
+    Args:
+        data: Raw request data passed to the Pydantic model.
+
+    Returns:
+        Request data with system messages hoisted to top-level system.
+    """
+    if not isinstance(data, dict):
+        return data
+
+    messages = data.get("messages")
+    if not isinstance(messages, list):
+        return data
+
+    normalized_messages = []
+    hoisted_system_blocks = []
+
+    for message in messages:
+        role = message.get("role") if isinstance(message, dict) else getattr(message, "role", None)
+        if role == "system":
+            content = message.get("content") if isinstance(message, dict) else getattr(message, "content", "")
+            hoisted_system_blocks.extend(_system_content_to_blocks(content))
+            continue
+        normalized_messages.append(message)
+
+    if not hoisted_system_blocks:
+        return data
+
+    normalized_data = dict(data)
+    normalized_data["messages"] = normalized_messages
+    normalized_data["system"] = _system_prompt_to_blocks(data.get("system")) + hoisted_system_blocks
+
+    logger.info(
+        f"Normalized {len(hoisted_system_blocks)} Anthropic system message block(s) "
+        "into the top-level system field"
+    )
+    return normalized_data
+
+
 class AnthropicMessagesRequest(BaseModel):
     """
     Request to Anthropic Messages API (/v1/messages).
@@ -322,7 +454,12 @@ class AnthropicMessagesRequest(BaseModel):
     stream: bool = False
 
     # Extended thinking (official Anthropic parameter)
+    # Newer models use {"type": "adaptive"}; older ones {"type": "enabled", "budget_tokens": N}
     thinking: Optional[Dict[str, Any]] = None
+
+    # Output configuration (newer Anthropic parameter, e.g. {"effort": "high"})
+    # Replaces thinking.budget_tokens on Opus 4.6+, Sonnet 4.6, Opus 4.7/4.8, Fable 5, etc.
+    output_config: Optional[Dict[str, Any]] = None
 
     # Tools
     tools: Optional[List[AnthropicTool]] = None
@@ -338,6 +475,20 @@ class AnthropicMessagesRequest(BaseModel):
     metadata: Optional[Dict[str, Any]] = None
 
     model_config = {"extra": "allow"}
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_system_messages(cls, data: Any) -> Any:
+        """
+        Normalize compatibility system messages before strict validation.
+
+        Args:
+            data: Raw request payload.
+
+        Returns:
+            Payload with role="system" messages moved to top-level system.
+        """
+        return _merge_system_messages_into_system(data)
 
 
 class AnthropicCountTokensRequest(BaseModel):
@@ -362,6 +513,20 @@ class AnthropicCountTokensRequest(BaseModel):
     tools: Optional[List[AnthropicTool]] = None
     
     model_config = {"extra": "allow"}
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_system_messages(cls, data: Any) -> Any:
+        """
+        Normalize compatibility system messages before strict validation.
+
+        Args:
+            data: Raw count-tokens request payload.
+
+        Returns:
+            Payload with role="system" messages moved to top-level system.
+        """
+        return _merge_system_messages_into_system(data)
 
 
 # ==================================================================================================

--- a/kiro/parsers.py
+++ b/kiro/parsers.py
@@ -36,6 +36,38 @@ from loguru import logger
 from kiro.utils import generate_tool_call_id
 
 
+def _log_runtime_content_event(data: Dict[str, Any]) -> None:
+    """
+    Write a debug-only summary of runtime content events that carry modelId.
+
+    Args:
+        data: Parsed upstream content event data.
+    """
+    model_id = data.get("modelId")
+    if not isinstance(model_id, str) or not model_id:
+        return
+
+    content = data.get("content", "")
+    content_length = len(content) if isinstance(content, str) else None
+
+    try:
+        from kiro.debug_logger import debug_logger
+    except ImportError as exc:
+        logger.debug(f"Debug logger unavailable for runtime content event: {exc}")
+        return
+
+    debug_logger.append_jsonl_artifact(
+        "runtime_content_events.jsonl",
+        {
+            "event": "runtime_content",
+            "model_id": model_id,
+            "keys": sorted(data.keys()),
+            "content_length": content_length,
+            "followup_prompt": bool(data.get("followupPrompt")),
+        },
+    )
+
+
 def find_matching_brace(text: str, start_pos: int) -> int:
     """
     Finds the position of the closing brace considering nesting and strings.
@@ -333,6 +365,7 @@ class AwsEventStreamParser:
     
     def _process_content_event(self, data: dict) -> Optional[Dict[str, Any]]:
         """Processes content event."""
+        _log_runtime_content_event(data)
         content = data.get('content', '')
         
         # Skip followupPrompt

--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -138,11 +138,28 @@ async def get_models(request: Request):
     # Get available models based on mode
     if request.app.state.account_system:
         # Account system: collect models from all initialized accounts
+        model_source = "account_system"
         available_model_ids = request.app.state.account_manager.get_all_available_models()
     else:
         # Legacy: use resolver from first account
+        model_source = "legacy"
         account = request.app.state.account_manager.get_first_account()
         available_model_ids = account.model_resolver.get_available_models()
+
+    try:
+        from kiro.debug_logger import debug_logger
+    except ImportError as exc:
+        logger.debug(f"Debug logger unavailable for /v1/models snapshot: {exc}")
+    else:
+        debug_logger.append_jsonl_artifact(
+            "models_endpoint_snapshots.jsonl",
+            {
+                "event": "v1_models_response",
+                "source": model_source,
+                "model_count": len(available_model_ids),
+                "model_ids": available_model_ids,
+            },
+        )
     
     # Build OpenAI-compatible model list
     openai_models = [

--- a/tests/unit/test_account_manager.py
+++ b/tests/unit/test_account_manager.py
@@ -23,12 +23,81 @@ from kiro.account_manager import (
     AccountStats,
     ModelAccountList,
     AccountManager,
+    _extract_model_ids,
+    _log_model_source_snapshot,
     _format_duration
 )
 from kiro.account_errors import ErrorType
 from kiro.auth import KiroAuthManager, AuthType
 from kiro.cache import ModelInfoCache
+from kiro.cli_models import KiroCliModelList, KiroCliModelListError
 from kiro.model_resolver import ModelResolver
+
+
+class TestModelSourceDiagnostics:
+    """
+    Tests for debug-only model source diagnostic helpers.
+    """
+
+    def test_extract_model_ids_skips_malformed_entries(self):
+        """
+        What it does: Extracts only valid model IDs from mixed source data.
+        Purpose: Keep diagnostic snapshots stable with malformed upstream data.
+        """
+        model_ids = _extract_model_ids([
+            {"modelId": "claude-sonnet-4.5"},
+            {"modelId": ""},
+            {"modelId": None},
+            {"name": "missing-id"},
+            "not-a-dict",
+            {"modelId": "claude-opus-4.8"},
+        ])
+
+        assert model_ids == ["claude-sonnet-4.5", "claude-opus-4.8"]
+
+    def test_log_model_source_snapshot_writes_selected_source_data(self, tmp_path):
+        """
+        What it does: Writes the selected model source snapshot to JSONL.
+        Purpose: Preserve the exact source used to populate the model cache.
+        """
+        debug_dir = tmp_path / "debug_logs"
+        models_data = [
+            {"modelId": "claude-sonnet-4.5"},
+            {"modelId": "claude-opus-4.8"},
+        ]
+        raw_payload = {"models": models_data}
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
+            from kiro.debug_logger import debug_logger
+            debug_logger.debug_dir = debug_dir
+
+            _log_model_source_snapshot(
+                account_id="account-1",
+                source="list_available_models",
+                models_data=models_data,
+                raw_payload=raw_payload,
+                endpoint="https://q.example.com/ListAvailableModels",
+                status_code=200,
+            )
+
+        records = [
+            json.loads(line)
+            for line in (debug_dir / "model_source_snapshots.jsonl").read_text(
+                encoding="utf-8"
+            ).splitlines()
+        ]
+        assert records == [
+            {
+                "event": "model_source_snapshot",
+                "account_id": "account-1",
+                "source": "list_available_models",
+                "model_count": 2,
+                "model_ids": ["claude-sonnet-4.5", "claude-opus-4.8"],
+                "raw_payload": raw_payload,
+                "endpoint": "https://q.example.com/ListAvailableModels",
+                "status_code": 200,
+            }
+        ]
 
 
 class TestAccountDataclass:
@@ -820,6 +889,163 @@ class TestAccountManagerInitializeAccount:
         print(f"Initialization success: {success}")
         assert success is True  # Should succeed with fallback
         assert manager._accounts[account_id].model_cache is not None
+
+    @pytest.mark.asyncio
+    async def test_initialize_runtime_sqlite_account_uses_kiro_cli_models(self, tmp_path, temp_sqlite_db):
+        """
+        Test runtime sqlite account initialization with kiro-cli model discovery.
+
+        What it does: Initializes a sqlite account and uses kiro-cli model JSON.
+        Purpose: Ensure runtime accounts use entitlement-aware model lists.
+        """
+        print("\n=== Test: initialize runtime sqlite account with kiro-cli models ===")
+
+        # Arrange
+        creds_file = tmp_path / "credentials.json"
+        creds_file.write_text(json.dumps([
+            {"type": "sqlite", "path": temp_sqlite_db, "enabled": True}
+        ]))
+
+        manager = AccountManager(
+            credentials_file=str(creds_file),
+            state_file=str(tmp_path / "state.json")
+        )
+        await manager.load_credentials()
+        account_id = str(Path(temp_sqlite_db).resolve())
+
+        cli_model_list = KiroCliModelList(
+            models=[
+                {
+                    "modelId": "auto",
+                    "modelName": "auto",
+                    "description": "Auto",
+                    "tokenLimits": {"maxInputTokens": 1000000},
+                    "_source": "kiro_cli",
+                },
+                {
+                    "modelId": "claude-opus-4.8",
+                    "modelName": "claude-opus-4.8",
+                    "description": "Experimental preview",
+                    "tokenLimits": {"maxInputTokens": 1000000},
+                    "_source": "kiro_cli",
+                },
+            ],
+            default_model="claude-opus-4.8",
+            raw_payload={"models": [{"model_id": "claude-opus-4.8"}]},
+        )
+
+        with patch(
+            "kiro.account_manager.fetch_kiro_cli_models",
+            AsyncMock(return_value=cli_model_list),
+        ) as mock_fetch:
+            # Act
+            success = await manager._initialize_account(account_id)
+
+        # Assert
+        assert success is True
+        mock_fetch.assert_awaited_once()
+        account = manager._accounts[account_id]
+        assert account.credential_type == "sqlite"
+        assert account.model_cache is not None
+        assert account.model_cache.get_max_input_tokens("claude-opus-4.8") == 1000000
+        assert "claude-opus-4.8" in account.model_resolver.get_available_models()
+        assert "claude-opus-4.8" in manager._model_to_accounts
+
+    @pytest.mark.asyncio
+    async def test_initialize_runtime_sqlite_account_falls_back_when_kiro_cli_fails(self, tmp_path, temp_sqlite_db):
+        """
+        Test runtime sqlite account initialization when kiro-cli model discovery fails.
+
+        What it does: Simulates a kiro-cli failure and initializes with fallback models.
+        Purpose: Keep gateway startup resilient when kiro-cli is unavailable.
+        """
+        print("\n=== Test: initialize runtime sqlite account with kiro-cli failure ===")
+
+        # Arrange
+        creds_file = tmp_path / "credentials.json"
+        creds_file.write_text(json.dumps([
+            {"type": "sqlite", "path": temp_sqlite_db, "enabled": True}
+        ]))
+
+        manager = AccountManager(
+            credentials_file=str(creds_file),
+            state_file=str(tmp_path / "state.json")
+        )
+        await manager.load_credentials()
+        account_id = str(Path(temp_sqlite_db).resolve())
+
+        with patch(
+            "kiro.account_manager.fetch_kiro_cli_models",
+            AsyncMock(side_effect=KiroCliModelListError("not logged in")),
+        ) as mock_fetch:
+            # Act
+            success = await manager._initialize_account(account_id)
+
+        # Assert
+        assert success is True
+        mock_fetch.assert_awaited_once()
+        account = manager._accounts[account_id]
+        assert account.model_cache is not None
+        assert "claude-opus-4.7" in account.model_resolver.get_available_models()
+        assert "claude-opus-4.8" not in account.model_resolver.get_available_models()
+
+    @pytest.mark.asyncio
+    async def test_refresh_runtime_sqlite_account_uses_kiro_cli_models(self, tmp_path):
+        """
+        Test runtime sqlite account model refresh with kiro-cli model discovery.
+
+        What it does: Refreshes an initialized runtime account from kiro-cli output.
+        Purpose: Ensure TTL refresh can discover newly available runtime models.
+        """
+        print("\n=== Test: refresh runtime sqlite account with kiro-cli models ===")
+
+        # Arrange
+        manager = AccountManager(
+            credentials_file=str(tmp_path / "credentials.json"),
+            state_file=str(tmp_path / "state.json")
+        )
+        account_id = "sqlite-account"
+
+        model_cache = ModelInfoCache()
+        await model_cache.update([{"modelId": "auto"}])
+        model_resolver = ModelResolver(
+            cache=model_cache,
+            hidden_models={},
+            aliases={},
+            hidden_from_list=[],
+        )
+        auth_manager = Mock()
+        auth_manager.api_host = "https://runtime.us-east-1.kiro.dev"
+
+        manager._accounts[account_id] = Account(
+            id=account_id,
+            auth_manager=auth_manager,
+            credential_type="sqlite",
+            model_cache=model_cache,
+            model_resolver=model_resolver,
+            models_cached_at=time.time() - 999999,
+        )
+
+        cli_model_list = KiroCliModelList(
+            models=[
+                {"modelId": "auto", "tokenLimits": {"maxInputTokens": 1000000}},
+                {"modelId": "claude-opus-4.8", "tokenLimits": {"maxInputTokens": 1000000}},
+            ],
+            default_model="auto",
+            raw_payload={"models": [{"model_id": "claude-opus-4.8"}]},
+        )
+
+        with patch(
+            "kiro.account_manager.fetch_kiro_cli_models",
+            AsyncMock(return_value=cli_model_list),
+        ) as mock_fetch:
+            # Act
+            await manager._refresh_account_models(account_id)
+
+        # Assert
+        mock_fetch.assert_awaited_once()
+        assert manager._accounts[account_id].model_cache.is_valid_model("claude-opus-4.8")
+        assert "claude-opus-4.8" in manager._model_to_accounts
 
 
 class TestAccountManagerGetNextAccount:

--- a/tests/unit/test_cli_models.py
+++ b/tests/unit/test_cli_models.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+
+"""
+Unit tests for kiro/cli_models.py.
+
+Tests the Kiro CLI model list provider that parses
+`kiro-cli chat --list-models --format json` output.
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from kiro.cli_models import (
+    KiroCliModelListError,
+    fetch_kiro_cli_models,
+    parse_kiro_cli_models_json,
+)
+
+
+def _cli_payload() -> dict:
+    """
+    Build a representative kiro-cli model list payload.
+
+    Returns:
+        JSON-compatible payload matching kiro-cli output.
+    """
+    return {
+        "models": [
+            {
+                "model_name": "auto",
+                "description": "Models chosen by task",
+                "model_id": "auto",
+                "context_window_tokens": 1000000,
+                "rate_multiplier": 1.0,
+                "rate_unit": "Credit",
+            },
+            {
+                "model_name": "claude-opus-4.8",
+                "description": "Experimental preview",
+                "model_id": "claude-opus-4.8",
+                "context_window_tokens": 1000000,
+                "rate_multiplier": 2.2,
+                "rate_unit": "Credit",
+            },
+        ],
+        "default_model": "claude-opus-4.8",
+    }
+
+
+class FakeProcess:
+    """
+    Fake asyncio subprocess process.
+
+    Args:
+        stdout: Bytes returned from stdout.
+        stderr: Bytes returned from stderr.
+        returncode: Process return code.
+    """
+
+    def __init__(self, stdout: bytes, stderr: bytes = b"", returncode: int = 0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+        self.killed = False
+        self.wait = AsyncMock(return_value=None)
+
+    async def communicate(self):
+        """
+        Return fake subprocess output.
+
+        Returns:
+            Tuple of stdout and stderr bytes.
+        """
+        return self.stdout, self.stderr
+
+    def kill(self) -> None:
+        """Mark the fake process as killed."""
+        self.killed = True
+
+
+class HangingProcess(FakeProcess):
+    """Fake process whose communicate call never completes quickly."""
+
+    async def communicate(self):
+        """
+        Sleep long enough for asyncio.wait_for to time out.
+
+        Returns:
+            Tuple of stdout and stderr bytes.
+        """
+        await asyncio.sleep(60)
+        return self.stdout, self.stderr
+
+
+class TestParseKiroCliModelsJson:
+    """Tests for parse_kiro_cli_models_json()."""
+
+    def test_parses_valid_json_payload(self):
+        """
+        What it does: Parses valid kiro-cli JSON output.
+        Purpose: Convert CLI schema to ModelInfoCache schema.
+        """
+        result = parse_kiro_cli_models_json(json.dumps(_cli_payload()))
+
+        assert result.default_model == "claude-opus-4.8"
+        assert result.raw_payload == _cli_payload()
+        assert [model["modelId"] for model in result.models] == [
+            "auto",
+            "claude-opus-4.8",
+        ]
+        assert result.models[1]["modelName"] == "claude-opus-4.8"
+        assert result.models[1]["description"] == "Experimental preview"
+        assert result.models[1]["tokenLimits"]["maxInputTokens"] == 1000000
+        assert result.models[1]["rateMultiplier"] == 2.2
+        assert result.models[1]["rateUnit"] == "Credit"
+        assert result.models[1]["_is_default"] is True
+        assert result.models[1]["_source"] == "kiro_cli"
+
+    def test_skips_malformed_model_entries(self):
+        """
+        What it does: Skips non-dict and missing-id model entries.
+        Purpose: Handle partial CLI schema changes without failing all models.
+        """
+        payload = {
+            "models": [
+                "not-a-dict",
+                {"model_name": "missing-id"},
+                {"model_id": ""},
+                {"model_id": "claude-sonnet-4.6"},
+            ]
+        }
+
+        result = parse_kiro_cli_models_json(json.dumps(payload))
+
+        assert len(result.models) == 1
+        assert result.models[0]["modelId"] == "claude-sonnet-4.6"
+        assert result.models[0]["modelName"] == "claude-sonnet-4.6"
+
+    def test_uses_default_token_limit_for_invalid_context_window(self):
+        """
+        What it does: Falls back when context_window_tokens is invalid.
+        Purpose: Prevent malformed CLI metadata from breaking token accounting.
+        """
+        payload = {"models": [{"model_id": "claude-opus-4.8", "context_window_tokens": -1}]}
+
+        result = parse_kiro_cli_models_json(json.dumps(payload))
+
+        assert result.models[0]["tokenLimits"]["maxInputTokens"] == 200000
+
+    def test_invalid_json_raises_error(self):
+        """
+        What it does: Parses invalid JSON output.
+        Purpose: Surface CLI output format problems clearly.
+        """
+        with pytest.raises(KiroCliModelListError, match="invalid JSON"):
+            parse_kiro_cli_models_json("not json")
+
+    def test_non_object_json_raises_error(self):
+        """
+        What it does: Parses a JSON array instead of object.
+        Purpose: Reject unexpected top-level schema.
+        """
+        with pytest.raises(KiroCliModelListError, match="JSON object"):
+            parse_kiro_cli_models_json("[]")
+
+    def test_missing_models_array_raises_error(self):
+        """
+        What it does: Parses a payload without models array.
+        Purpose: Reject incomplete CLI output.
+        """
+        with pytest.raises(KiroCliModelListError, match="models array"):
+            parse_kiro_cli_models_json("{}")
+
+    def test_no_usable_models_raises_error(self):
+        """
+        What it does: Parses a payload where every model entry is invalid.
+        Purpose: Avoid replacing cache with an empty CLI result.
+        """
+        with pytest.raises(KiroCliModelListError, match="no usable models"):
+            parse_kiro_cli_models_json(json.dumps({"models": [{"model_id": ""}]}))
+
+
+class TestFetchKiroCliModels:
+    """Tests for fetch_kiro_cli_models()."""
+
+    @pytest.mark.asyncio
+    async def test_fetches_models_from_cli_json_output(self):
+        """
+        What it does: Runs the kiro-cli command and parses stdout.
+        Purpose: Verify subprocess invocation uses JSON format.
+        """
+        process = FakeProcess(json.dumps(_cli_payload()).encode("utf-8"))
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)) as create_process:
+            result = await fetch_kiro_cli_models(command="kiro-cli", timeout_seconds=5)
+
+        create_process.assert_awaited_once_with(
+            "kiro-cli",
+            "chat",
+            "--list-models",
+            "--format",
+            "json",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        assert [model["modelId"] for model in result.models] == ["auto", "claude-opus-4.8"]
+
+    @pytest.mark.asyncio
+    async def test_empty_command_raises_error(self):
+        """
+        What it does: Calls fetch with an empty command.
+        Purpose: Reject invalid configuration before subprocess execution.
+        """
+        with pytest.raises(KiroCliModelListError, match="command is empty"):
+            await fetch_kiro_cli_models(command="")
+
+    @pytest.mark.asyncio
+    async def test_command_not_found_raises_error(self):
+        """
+        What it does: Simulates missing kiro-cli executable.
+        Purpose: Fall back cleanly when CLI is unavailable.
+        """
+        with patch(
+            "asyncio.create_subprocess_exec",
+            AsyncMock(side_effect=FileNotFoundError("missing")),
+        ):
+            with pytest.raises(KiroCliModelListError, match="command not found"):
+                await fetch_kiro_cli_models(command="missing-cli")
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_raises_error_with_stderr(self):
+        """
+        What it does: Simulates kiro-cli returning a non-zero exit code.
+        Purpose: Preserve actionable CLI failure details.
+        """
+        process = FakeProcess(b"", b"not logged in", returncode=2)
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)):
+            with pytest.raises(KiroCliModelListError, match="not logged in"):
+                await fetch_kiro_cli_models(command="kiro-cli")
+
+    @pytest.mark.asyncio
+    async def test_timeout_kills_process_and_raises_error(self):
+        """
+        What it does: Simulates kiro-cli hanging.
+        Purpose: Ensure account initialization cannot block indefinitely.
+        """
+        process = HangingProcess(b"")
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)):
+            with pytest.raises(KiroCliModelListError, match="timed out"):
+                await fetch_kiro_cli_models(command="kiro-cli", timeout_seconds=0.01)
+
+        assert process.killed is True
+        process.wait.assert_awaited_once()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -514,6 +514,46 @@ class TestKiroCliDbFileConfig:
             assert str(path) == config_module.KIRO_CLI_DB_FILE
 
 
+class TestKiroCliModelListConfig:
+    """Tests for Kiro CLI model list discovery configuration."""
+
+    def test_kiro_cli_model_list_defaults(self, monkeypatch):
+        """
+        What it does: Verifies default Kiro CLI model discovery settings.
+        Purpose: Ensure sqlite runtime accounts use CLI discovery by default.
+        """
+        import importlib
+        import kiro.config as config_module
+
+        monkeypatch.delenv("KIRO_CLI_LIST_MODELS_ENABLED", raising=False)
+        monkeypatch.delenv("KIRO_CLI_LIST_MODELS_COMMAND", raising=False)
+        monkeypatch.delenv("KIRO_CLI_LIST_MODELS_TIMEOUT_SECONDS", raising=False)
+
+        importlib.reload(config_module)
+
+        assert config_module.KIRO_CLI_LIST_MODELS_ENABLED is True
+        assert config_module.KIRO_CLI_LIST_MODELS_COMMAND == "kiro-cli"
+        assert config_module.KIRO_CLI_LIST_MODELS_TIMEOUT_SECONDS == 10.0
+
+    def test_kiro_cli_model_list_env_overrides(self, monkeypatch):
+        """
+        What it does: Verifies environment overrides for Kiro CLI discovery.
+        Purpose: Let users disable CLI discovery or point to a custom executable.
+        """
+        import importlib
+        import kiro.config as config_module
+
+        monkeypatch.setenv("KIRO_CLI_LIST_MODELS_ENABLED", "false")
+        monkeypatch.setenv("KIRO_CLI_LIST_MODELS_COMMAND", "C:\\tools\\kiro-cli.exe")
+        monkeypatch.setenv("KIRO_CLI_LIST_MODELS_TIMEOUT_SECONDS", "3.5")
+
+        importlib.reload(config_module)
+
+        assert config_module.KIRO_CLI_LIST_MODELS_ENABLED is False
+        assert config_module.KIRO_CLI_LIST_MODELS_COMMAND == "C:\\tools\\kiro-cli.exe"
+        assert config_module.KIRO_CLI_LIST_MODELS_TIMEOUT_SECONDS == 3.5
+
+
 class TestFallbackModelsConfig:
     """Tests for FALLBACK_MODELS configuration."""
     

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -1941,7 +1941,7 @@ class TestAnthropicToKiroIntegration:
 
     def test_native_thinking_forwarded_for_newer_model(self):
         """
-        What it does: Verifies newer models forward raw thinking/output_config into userInputMessage
+        What it does: Verifies newer models forward thinking/output_config as additionalModelRequestFields
         Purpose: Adaptive-thinking generation should pass native params, NOT fake-reasoning tags
         """
         request = AnthropicMessagesRequest(
@@ -1958,9 +1958,13 @@ class TestAnthropicToKiroIntegration:
 
         user_input = payload["conversationState"]["currentMessage"]["userInputMessage"]
 
-        # Native params forwarded verbatim
-        assert user_input["thinking"] == {"type": "adaptive"}
-        assert user_input["output_config"] == {"effort": "high"}
+        # Native params use the command-level Kiro Runtime shape.
+        assert payload["additionalModelRequestFields"] == {
+            "thinking": {"type": "adaptive", "display": "summarized"},
+            "output_config": {"effort": "high"},
+        }
+        assert "thinking" not in user_input
+        assert "output_config" not in user_input
 
         # No fake-reasoning tags injected
         assert "<thinking_mode>" not in user_input["content"]
@@ -1988,6 +1992,7 @@ class TestAnthropicToKiroIntegration:
         # No native params on legacy path
         assert "thinking" not in user_input
         assert "output_config" not in user_input
+        assert "additionalModelRequestFields" not in payload
 
         # Fake-reasoning tags present
         assert "<max_thinking_length>6000</max_thinking_length>" in user_input["content"]
@@ -2010,7 +2015,10 @@ class TestAnthropicToKiroIntegration:
 
         user_input = payload["conversationState"]["currentMessage"]["userInputMessage"]
 
-        assert user_input["thinking"] == {"type": "adaptive"}
+        assert payload["additionalModelRequestFields"] == {
+            "thinking": {"type": "adaptive", "display": "summarized"},
+        }
+        assert "thinking" not in user_input
         assert "output_config" not in user_input
         assert "<thinking_mode>" not in user_input["content"]
 

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -1852,7 +1852,61 @@ class TestExtractThinkingConfigFromAnthropic:
         print(f"Comparing: enabled={config.enabled}, budget_tokens={config.budget_tokens}")
         assert config.enabled is True
         assert config.budget_tokens is None
-    
+
+    def test_thinking_adaptive_no_effort(self):
+        """
+        What it does: Verifies adaptive thinking reaching the legacy path is enabled with default budget
+        Purpose: If {"type": "adaptive"} hits this legacy helper, treat as enabled w/ default budget
+        """
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4-8",
+            messages=[AnthropicMessage(role="user", content="test")],
+            max_tokens=1024,
+            thinking={"type": "adaptive"},
+        )
+
+        config = extract_thinking_config_from_anthropic(request)
+
+        assert config.enabled is True
+        assert config.budget_tokens is None
+
+    def test_effort_does_not_affect_legacy_budget(self):
+        """
+        What it does: Verifies output_config.effort is ignored by the legacy budget helper
+        Purpose: effort is only forwarded natively for newer models; legacy path ignores it
+        """
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-4.5",
+            messages=[AnthropicMessage(role="user", content="test")],
+            max_tokens=1024,
+            thinking={"type": "enabled", "budget_tokens": 8000},
+            output_config={"effort": "low"},
+        )
+
+        config = extract_thinking_config_from_anthropic(request)
+
+        assert config.enabled is True
+        # budget_tokens wins; effort is not consulted on the legacy path
+        assert config.budget_tokens == 8000
+
+    def test_disabled_ignores_effort(self):
+        """
+        What it does: Verifies thinking.type="disabled" stays disabled even with effort set
+        Purpose: Explicit disable must win
+        """
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4-8",
+            messages=[AnthropicMessage(role="user", content="test")],
+            max_tokens=1024,
+            thinking={"type": "disabled"},
+            output_config={"effort": "high"},
+        )
+
+        config = extract_thinking_config_from_anthropic(request)
+
+        assert config.enabled is False
+        assert config.budget_tokens is None
+
 
 
 class TestAnthropicToKiroIntegration:
@@ -1884,3 +1938,100 @@ class TestAnthropicToKiroIntegration:
         print(f"Checking for <max_thinking_length>6000</max_thinking_length>...")
         assert "<max_thinking_length>6000</max_thinking_length>" in content
         assert "<thinking_mode>enabled</thinking_mode>" in content
+
+    def test_native_thinking_forwarded_for_newer_model(self):
+        """
+        What it does: Verifies newer models forward raw thinking/output_config into userInputMessage
+        Purpose: Adaptive-thinking generation should pass native params, NOT fake-reasoning tags
+        """
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4-8",
+            messages=[AnthropicMessage(role="user", content="Test message")],
+            max_tokens=1024,
+            thinking={"type": "adaptive"},
+            output_config={"effort": "high"},
+        )
+
+        with patch("kiro.converters_anthropic.get_model_id_for_kiro", return_value="claude-opus-4.8"):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+                payload = anthropic_to_kiro(request, "test-conv-123", "arn:aws:test")
+
+        user_input = payload["conversationState"]["currentMessage"]["userInputMessage"]
+
+        # Native params forwarded verbatim
+        assert user_input["thinking"] == {"type": "adaptive"}
+        assert user_input["output_config"] == {"effort": "high"}
+
+        # No fake-reasoning tags injected
+        assert "<thinking_mode>" not in user_input["content"]
+        assert "<max_thinking_length>" not in user_input["content"]
+
+    def test_legacy_model_uses_fake_reasoning_not_native(self):
+        """
+        What it does: Verifies older models still use fake-reasoning tags and do NOT forward native params
+        Purpose: Legacy generation must keep the budget_tokens path
+        """
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-4.5",
+            messages=[AnthropicMessage(role="user", content="Test message")],
+            max_tokens=1024,
+            thinking={"type": "enabled", "budget_tokens": 6000},
+        )
+
+        with patch("kiro.converters_anthropic.get_model_id_for_kiro", return_value="claude-sonnet-4.5"):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+                with patch("kiro.converters_core.FAKE_REASONING_BUDGET_CAP", 10000):
+                    payload = anthropic_to_kiro(request, "test-conv-123", "arn:aws:test")
+
+        user_input = payload["conversationState"]["currentMessage"]["userInputMessage"]
+
+        # No native params on legacy path
+        assert "thinking" not in user_input
+        assert "output_config" not in user_input
+
+        # Fake-reasoning tags present
+        assert "<max_thinking_length>6000</max_thinking_length>" in user_input["content"]
+
+    def test_native_thinking_only_no_output_config(self):
+        """
+        What it does: Verifies adaptive thinking without output_config still forwards thinking
+        Purpose: output_config is optional; thinking alone should pass through
+        """
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-4-6",
+            messages=[AnthropicMessage(role="user", content="Test message")],
+            max_tokens=1024,
+            thinking={"type": "adaptive"},
+        )
+
+        with patch("kiro.converters_anthropic.get_model_id_for_kiro", return_value="claude-sonnet-4.6"):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", True):
+                payload = anthropic_to_kiro(request, "test-conv-123", "arn:aws:test")
+
+        user_input = payload["conversationState"]["currentMessage"]["userInputMessage"]
+
+        assert user_input["thinking"] == {"type": "adaptive"}
+        assert "output_config" not in user_input
+        assert "<thinking_mode>" not in user_input["content"]
+
+
+class TestModelSupportsNativeThinking:
+    """Tests for the model generation detection used to branch thinking handling."""
+
+    def test_newer_models_supported(self):
+        from kiro.model_resolver import model_supports_native_thinking
+        for m in [
+            "claude-opus-4-6", "claude-opus-4.6", "claude-opus-4-7", "claude-opus-4-8",
+            "claude-sonnet-4-6", "claude-sonnet-4.6",
+            "claude-fable-5", "claude-mythos-5", "claude-mythos-preview",
+        ]:
+            assert model_supports_native_thinking(m) is True, m
+
+    def test_older_models_not_supported(self):
+        from kiro.model_resolver import model_supports_native_thinking
+        for m in [
+            "claude-opus-4-5", "claude-opus-4.5", "claude-sonnet-4-5", "claude-sonnet-4.5",
+            "claude-sonnet-4", "claude-haiku-4-5", "claude-3-7-sonnet", "claude-3.7-sonnet",
+            "", "gpt-4",
+        ]:
+            assert model_supports_native_thinking(m) is False, m

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -1960,7 +1960,7 @@ class TestAnthropicToKiroIntegration:
 
         # Native params use the command-level Kiro Runtime shape.
         assert payload["additionalModelRequestFields"] == {
-            "thinking": {"type": "adaptive", "display": "summarized"},
+            "thinking": {"type": "adaptive"},
             "output_config": {"effort": "high"},
         }
         assert "thinking" not in user_input
@@ -2016,7 +2016,7 @@ class TestAnthropicToKiroIntegration:
         user_input = payload["conversationState"]["currentMessage"]["userInputMessage"]
 
         assert payload["additionalModelRequestFields"] == {
-            "thinking": {"type": "adaptive", "display": "summarized"},
+            "thinking": {"type": "adaptive"},
         }
         assert "thinking" not in user_input
         assert "output_config" not in user_input

--- a/tests/unit/test_converters_core.py
+++ b/tests/unit/test_converters_core.py
@@ -6479,7 +6479,7 @@ class TestBuildKiroPayloadWithThinkingConfig:
         user_input = payload["conversationState"]["currentMessage"]["userInputMessage"]
 
         assert payload["additionalModelRequestFields"] == {
-            "thinking": {"type": "adaptive", "display": "summarized"},
+            "thinking": {"type": "adaptive"},
             "output_config": {"effort": "high"},
         }
         assert "thinking" not in user_input
@@ -6487,10 +6487,10 @@ class TestBuildKiroPayloadWithThinkingConfig:
         assert "<thinking_mode>" not in user_input["content"]
         assert "<max_thinking_length>" not in user_input["content"]
 
-    def test_native_thinking_without_output_config_defaults_display(self):
+    def test_native_thinking_without_output_config_preserves_omitted_display(self):
         """
-        What it does: Verifies adaptive native thinking defaults display without output_config.
-        Purpose: Match Kiro CLI's summarized adaptive-thinking default.
+        What it does: Verifies adaptive native thinking preserves omitted display.
+        Purpose: Avoid deciding user-visible thinking display when the client omits it.
         """
         messages = [UnifiedMessage(role="user", content="Test message")]
 
@@ -6509,7 +6509,7 @@ class TestBuildKiroPayloadWithThinkingConfig:
         user_input = payload["conversationState"]["currentMessage"]["userInputMessage"]
 
         assert payload["additionalModelRequestFields"] == {
-            "thinking": {"type": "adaptive", "display": "summarized"},
+            "thinking": {"type": "adaptive"},
         }
         assert "thinking" not in user_input
         assert "output_config" not in user_input

--- a/tests/unit/test_converters_core.py
+++ b/tests/unit/test_converters_core.py
@@ -6455,3 +6455,85 @@ class TestBuildKiroPayloadWithThinkingConfig:
         print(f"Checking for <max_thinking_length>7000</max_thinking_length> in content...")
         assert "<max_thinking_length>7000</max_thinking_length>" in content
         assert "<thinking_mode>enabled</thinking_mode>" in content
+
+    def test_native_fields_use_additional_model_request_fields(self):
+        """
+        What it does: Verifies native thinking fields are sent at the Kiro command level.
+        Purpose: Match Kiro CLI's additionalModelRequestFields shape.
+        """
+        messages = [UnifiedMessage(role="user", content="Test message")]
+
+        result = build_kiro_payload(
+            messages=messages,
+            system_prompt="",
+            model_id="claude-opus-4.8",
+            tools=None,
+            conversation_id="test-conv-123",
+            profile_arn="arn:aws:test",
+            thinking_config=ThinkingConfig(enabled=True, budget_tokens=7000),
+            native_thinking={"type": "adaptive"},
+            native_output_config={"effort": "high"},
+        )
+
+        payload = result.payload
+        user_input = payload["conversationState"]["currentMessage"]["userInputMessage"]
+
+        assert payload["additionalModelRequestFields"] == {
+            "thinking": {"type": "adaptive", "display": "summarized"},
+            "output_config": {"effort": "high"},
+        }
+        assert "thinking" not in user_input
+        assert "output_config" not in user_input
+        assert "<thinking_mode>" not in user_input["content"]
+        assert "<max_thinking_length>" not in user_input["content"]
+
+    def test_native_thinking_without_output_config_defaults_display(self):
+        """
+        What it does: Verifies adaptive native thinking defaults display without output_config.
+        Purpose: Match Kiro CLI's summarized adaptive-thinking default.
+        """
+        messages = [UnifiedMessage(role="user", content="Test message")]
+
+        result = build_kiro_payload(
+            messages=messages,
+            system_prompt="",
+            model_id="claude-sonnet-4.6",
+            tools=None,
+            conversation_id="test-conv-123",
+            profile_arn="arn:aws:test",
+            thinking_config=ThinkingConfig(enabled=True),
+            native_thinking={"type": "adaptive"},
+        )
+
+        payload = result.payload
+        user_input = payload["conversationState"]["currentMessage"]["userInputMessage"]
+
+        assert payload["additionalModelRequestFields"] == {
+            "thinking": {"type": "adaptive", "display": "summarized"},
+        }
+        assert "thinking" not in user_input
+        assert "output_config" not in user_input
+
+    def test_native_thinking_preserves_explicit_display(self):
+        """
+        What it does: Verifies an explicit adaptive display value is not overwritten.
+        Purpose: Allow clients to switch display between summarized and omitted.
+        """
+        messages = [UnifiedMessage(role="user", content="Test message")]
+
+        result = build_kiro_payload(
+            messages=messages,
+            system_prompt="",
+            model_id="claude-sonnet-4.6",
+            tools=None,
+            conversation_id="test-conv-123",
+            profile_arn="arn:aws:test",
+            thinking_config=ThinkingConfig(enabled=True),
+            native_thinking={"type": "adaptive", "display": "omitted"},
+        )
+
+        payload = result.payload
+
+        assert payload["additionalModelRequestFields"] == {
+            "thinking": {"type": "adaptive", "display": "omitted"},
+        }

--- a/tests/unit/test_debug_logger.py
+++ b/tests/unit/test_debug_logger.py
@@ -161,6 +161,53 @@ class TestDebugLoggerModeAll:
             content = file_path.read_bytes()
             assert content == b'chunk1chunk2'
 
+    def test_append_jsonl_artifact_writes_record(self, tmp_path):
+        """
+        What it does: Verifies diagnostic JSONL artifacts are written in all mode.
+        Purpose: Ensure source-data collection can persist structured snapshots.
+        """
+        debug_dir = tmp_path / "debug_logs"
+        debug_dir.mkdir()
+
+        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+            from kiro.debug_logger import DebugLogger
+            logger = DebugLogger.__new__(DebugLogger)
+            logger._initialized = False
+            logger.__init__()
+            logger.debug_dir = debug_dir
+
+            logger.append_jsonl_artifact(
+                "model_source_snapshots.jsonl",
+                {"event": "model_source_snapshot", "model_ids": ["claude-opus-4.8"]},
+            )
+
+            file_path = debug_dir / "model_source_snapshots.jsonl"
+            assert file_path.exists()
+            records = [json.loads(line) for line in file_path.read_text(encoding="utf-8").splitlines()]
+            assert records == [
+                {"event": "model_source_snapshot", "model_ids": ["claude-opus-4.8"]}
+            ]
+
+    def test_append_jsonl_artifact_rejects_nested_file_name(self, tmp_path):
+        """
+        What it does: Verifies artifact file names cannot escape the debug directory.
+        Purpose: Keep diagnostic logging scoped to DEBUG_DIR.
+        """
+        debug_dir = tmp_path / "debug_logs"
+        debug_dir.mkdir()
+
+        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+            from kiro.debug_logger import DebugLogger
+            logger = DebugLogger.__new__(DebugLogger)
+            logger._initialized = False
+            logger.__init__()
+            logger.debug_dir = debug_dir
+
+            logger.append_jsonl_artifact("../outside.jsonl", {"event": "bad"})
+
+            assert not (tmp_path / "outside.jsonl").exists()
+            assert not (debug_dir / "outside.jsonl").exists()
+
 
 class TestDebugLoggerModeErrors:
     """Тесты для режима DEBUG_MODE=errors."""
@@ -189,6 +236,27 @@ class TestDebugLoggerModeErrors:
             
             print(f"Проверяем, что данные в буфере...")
             assert logger._request_body_buffer == test_data
+
+    def test_append_jsonl_artifact_does_not_write_success_artifacts(self, tmp_path):
+        """
+        What it does: Verifies JSONL artifacts are not written immediately in errors mode.
+        Purpose: Preserve existing DEBUG_MODE=errors flush-on-error semantics.
+        """
+        debug_dir = tmp_path / "debug_logs"
+
+        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+            from kiro.debug_logger import DebugLogger
+            logger = DebugLogger.__new__(DebugLogger)
+            logger._initialized = False
+            logger.__init__()
+            logger.debug_dir = debug_dir
+
+            logger.append_jsonl_artifact(
+                "model_source_snapshots.jsonl",
+                {"event": "model_source_snapshot"},
+            )
+
+            assert not (debug_dir / "model_source_snapshots.jsonl").exists()
     
     def test_flush_on_error_writes_buffers(self, tmp_path):
         """

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -38,6 +38,7 @@ from kiro.models_anthropic import (
     # Request models
     SystemContentBlock,
     AnthropicMessagesRequest,
+    AnthropicCountTokensRequest,
     # Response models
     AnthropicUsage,
     AnthropicMessagesResponse,
@@ -620,6 +621,101 @@ class TestAnthropicMessagesRequestWithImages:
         assert request.messages[2].content == "Can you describe it in more detail?"
         
         print("Multi-turn conversation with images validated successfully!")
+
+
+# ==================================================================================================
+# Tests for AnthropicMessagesRequest System Message Compatibility
+# ==================================================================================================
+
+class TestAnthropicMessagesRequestSystemMessageCompatibility:
+    """Tests for compatibility with non-standard system messages."""
+
+    def test_hoists_system_message_into_top_level_system(self):
+        """
+        What it does: Verifies role="system" messages are moved to top-level system.
+        Purpose: Ensure Claude Code compatible payloads do not fail request validation.
+        """
+        print("Setup: Creating request with top-level system and message-level system...")
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4-8",
+            max_tokens=1024,
+            system=[
+                {
+                    "type": "text",
+                    "text": "Top-level system.",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {"role": "system", "content": "Compatibility system."},
+                {"role": "assistant", "content": "Hi"},
+            ],
+        )
+
+        print(f"Result messages: {request.messages}")
+        print(f"Result system: {request.system}")
+        assert [message.role for message in request.messages] == ["user", "assistant"]
+        assert request.system is not None
+        assert len(request.system) == 2
+        assert request.system[0].text == "Top-level system."
+        assert request.system[0].cache_control == {"type": "ephemeral"}
+        assert request.system[1].text == "Compatibility system."
+
+    def test_preserves_system_message_content_blocks(self):
+        """
+        What it does: Verifies system content blocks are preserved when hoisted.
+        Purpose: Ensure prompt caching metadata survives compatibility normalization.
+        """
+        print("Setup: Creating request with system message content blocks...")
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4-8",
+            max_tokens=1024,
+            system="Existing system.",
+            messages=[
+                {
+                    "role": "system",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Cached compatibility system.",
+                            "cache_control": {"type": "ephemeral"},
+                        }
+                    ],
+                },
+                {"role": "user", "content": "Hello"},
+            ],
+        )
+
+        print(f"Result messages: {request.messages}")
+        print(f"Result system: {request.system}")
+        assert [message.role for message in request.messages] == ["user"]
+        assert request.system is not None
+        assert len(request.system) == 2
+        assert request.system[0].text == "Existing system."
+        assert request.system[1].text == "Cached compatibility system."
+        assert request.system[1].cache_control == {"type": "ephemeral"}
+
+    def test_count_tokens_request_hoists_system_message(self):
+        """
+        What it does: Verifies count-tokens requests normalize system messages too.
+        Purpose: Ensure Anthropic request compatibility is consistent across endpoints.
+        """
+        print("Setup: Creating count-tokens request with message-level system...")
+        request = AnthropicCountTokensRequest(
+            model="claude-opus-4-8",
+            messages=[
+                {"role": "system", "content": "Count tokens system."},
+                {"role": "user", "content": "Hello"},
+            ],
+        )
+
+        print(f"Result messages: {request.messages}")
+        print(f"Result system: {request.system}")
+        assert [message.role for message in request.messages] == ["user"]
+        assert request.system is not None
+        assert len(request.system) == 1
+        assert request.system[0].text == "Count tokens system."
 
 
 # ==================================================================================================

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -5,7 +5,9 @@ Unit tests for AwsEventStreamParser and auxiliary parsing functions.
 Tests the parsing logic for AWS SSE stream from Kiro API.
 """
 
+import json
 import pytest
+from unittest.mock import patch
 
 from kiro.parsers import (
     AwsEventStreamParser,
@@ -429,6 +431,39 @@ class TestAwsEventStreamParserFeed:
         assert len(events) == 1
         assert events[0]["type"] == "content"
         assert events[0]["data"] == "Hello World"
+
+    def test_logs_runtime_model_id_summary_without_changing_event(self, aws_event_parser, tmp_path):
+        """
+        What it does: Verifies content events with modelId write a debug summary.
+        Goal: Preserve raw-source diagnostics without changing parser output.
+        """
+        debug_dir = tmp_path / "debug_logs"
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
+            from kiro.debug_logger import debug_logger
+            debug_logger.debug_dir = debug_dir
+
+            events = aws_event_parser.feed(
+                b'{"content":"Hello World","modelId":"claude-opus-4.8"}'
+            )
+
+        assert events == [{"type": "content", "data": "Hello World"}]
+
+        file_path = debug_dir / "runtime_content_events.jsonl"
+        assert file_path.exists()
+        records = [
+            json.loads(line)
+            for line in file_path.read_text(encoding="utf-8").splitlines()
+        ]
+        assert records == [
+            {
+                "event": "runtime_content",
+                "model_id": "claude-opus-4.8",
+                "keys": ["content", "modelId"],
+                "content_length": 11,
+                "followup_prompt": False,
+            }
+        ]
     
     def test_parses_multiple_content_events(self, aws_event_parser):
         """

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -447,6 +447,36 @@ class TestMessagesSystemPrompt:
         # Should pass validation
         assert response.status_code != 422
 
+    def test_accepts_system_message_compatibility_format(self, test_client, valid_proxy_api_key):
+        """
+        What it does: Verifies message-level system prompts pass request validation.
+        Purpose: Ensure Claude Code compatible payloads do not fail with 422 errors.
+        """
+        print("Action: POST /v1/messages with message-level system prompt...")
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-opus-4-8",
+                "max_tokens": 1024,
+                "system": [
+                    {
+                        "type": "text",
+                        "text": "Top-level system.",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+                "messages": [
+                    {"role": "user", "content": "Hello"},
+                    {"role": "system", "content": "Compatibility system."},
+                ],
+            },
+        )
+
+        print(f"Status: {response.status_code}")
+        # Should pass body validation even if later request handling cannot reach Kiro in tests.
+        assert response.status_code != 422
+
 
 # =============================================================================
 # Tests for /v1/messages content blocks
@@ -2280,6 +2310,39 @@ class TestCountTokensEndpoint:
         assert data["input_tokens"] > 0
         
         print(f"✅ System blocks counted: {data['input_tokens']} tokens")
+
+    def test_count_tokens_with_system_message_compatibility_format(self, test_client, valid_proxy_api_key):
+        """
+        What it does: Tests token counting with message-level system prompts.
+        Purpose: Ensure compatibility system messages are hoisted before validation.
+        """
+        print("Setup: Creating request with message-level system prompt...")
+        request_data = {
+            "model": "claude-opus-4-8",
+            "messages": [
+                {"role": "system", "content": "Compatibility system."},
+                {"role": "user", "content": "Hello"},
+            ],
+        }
+
+        print("Action: POST /v1/messages/count_tokens...")
+        response = test_client.post(
+            "/v1/messages/count_tokens",
+            headers={"x-api-key": valid_proxy_api_key},
+            json=request_data,
+        )
+
+        print(f"Status: {response.status_code}")
+        print(f"Response: {response.json()}")
+
+        print("Checking: HTTP 200...")
+        assert response.status_code == 200
+
+        print("Checking: Response structure...")
+        data = response.json()
+        assert "input_tokens" in data
+        assert isinstance(data["input_tokens"], int)
+        assert data["input_tokens"] > 0
     
     def test_count_tokens_empty_messages(self, test_client, valid_proxy_api_key):
         """

--- a/tests/unit/test_routes_openai.py
+++ b/tests/unit/test_routes_openai.py
@@ -380,6 +380,40 @@ class TestModelsEndpoint:
         for model in response.json()["data"]:
             assert model["owned_by"] == "anthropic"
 
+    def test_models_writes_debug_snapshot_in_all_mode(self, test_client, valid_proxy_api_key, tmp_path):
+        """
+        What it does: Verifies /v1/models writes a debug snapshot in all mode.
+        Purpose: Preserve the exact model list returned by the endpoint for diagnosis.
+        """
+        debug_dir = tmp_path / "debug_logs"
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
+            from kiro.debug_logger import debug_logger
+            debug_logger.debug_dir = debug_dir
+
+            response = test_client.get(
+                "/v1/models",
+                headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
+            )
+
+        assert response.status_code == 200
+        response_model_ids = [model["id"] for model in response.json()["data"]]
+
+        records = [
+            json.loads(line)
+            for line in (debug_dir / "models_endpoint_snapshots.jsonl").read_text(
+                encoding="utf-8"
+            ).splitlines()
+        ]
+        assert records == [
+            {
+                "event": "v1_models_response",
+                "source": "legacy",
+                "model_count": len(response_model_ids),
+                "model_ids": response_model_ids,
+            }
+        ]
+
 
 # =============================================================================
 # Tests for chat completions endpoint (/v1/chat/completions)


### PR DESCRIPTION
## Summary

This PR fixes several compatibility gaps that show up with newer Kiro / Claude Code clients and newer Claude model metadata.

- Add Kiro CLI SQLite model discovery so dynamically advertised models such as Claude Opus 4.8 can be resolved instead of relying only on static gateway metadata.
- Accept Anthropic `messages[]` entries with `role: "system"` by hoisting them into the top-level `system` prompt, preserving cache-control text blocks when present.
- Forward native adaptive thinking fields through Kiro Runtime's command-level `additionalModelRequestFields`, matching Kiro CLI's `GenerateAssistantResponseCommand` location while preserving client-supplied `thinking` fields.
- Preserve explicit adaptive thinking `display` values such as `summarized` or `omitted`, and leave `display` omitted when the client omits it.
- Add focused tests covering model discovery, system-message compatibility, native adaptive thinking forwarding, and debug/parser support.

## Related issues

This should partially or fully address the following open issues:

- Fixes #208
- Fixes #211
- Fixes #190
- Fixes #219
- Fixes #226

## Root cause

Newer clients and Kiro CLI behavior differ from the previous gateway assumptions in three places:

1. Model availability can come from Kiro CLI's local model cache/database, so hidden/newer models may not appear in static gateway mappings.
2. Some clients inline `role: "system"` inside the Anthropic `messages` array, which the strict request model rejected before conversion.
3. Kiro CLI sends adaptive thinking effort metadata as top-level `additionalModelRequestFields`, not inside `conversationState.currentMessage.userInputMessage`.

## Validation

Validated locally with:

```text
pytest tests/unit/test_config.py tests/unit/test_models_anthropic.py tests/unit/test_converters_anthropic.py -v
226 passed

pytest tests/unit/test_converters_core.py tests/unit/test_converters_anthropic.py -v
341 passed
```

Additional focused tests were added across the touched modules for the new behavior.