### PR TITLE
fix: accept system role in AnthropicMessage

### DIFF
--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -187,7 +187,7 @@ class AnthropicMessage(BaseModel):
         content: Message content (string or list of content blocks)
     """
 
-    role: Literal["user", "assistant"]
+    role: str  # accepts any role; normalize_message_roles() handles non-user/assistant values
     content: Union[str, List[ContentBlock]]
 
     model_config = {"extra": "allow"}


### PR DESCRIPTION
## Summary

- `AnthropicMessage.role` was `Literal["user", "assistant"]`, causing FastAPI/Pydantic to return **422** before the request reached the normalization pipeline
- Claude Code v2.1.181+ (opus-4-8 model) injects `system`-role messages inside the `messages` array for injected context (`system-reminder` blocks)
- `normalize_message_roles()` in `converters_core.py` already converts unknown roles to `"user"` — it just never got the chance to run

## Fix

Change `role: Literal["user", "assistant"]` → `role: str` on `AnthropicMessage` so validation passes and the existing normalization logic handles it.

## Test plan

- [ ] Send a request with `{"role": "system", ...}` in `messages` — should return a response, not 422
- [ ] Existing user/assistant messages unaffected
- [ ] `normalize_message_roles()` converts `system` → `user` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)