### PR TITLE
fix(converters): use "." for empty content and merge same-role turns

### DIFF
--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -48,6 +48,21 @@ from kiro.payload_guards import check_payload_size, trim_payload_to_limit
 
 
 # ==================================================================================================
+# Constants
+# ==================================================================================================
+
+# Filler used when a message has no text but the Kiro API still requires a non-empty `content`
+# string (the real payload lives in toolUses / toolResults). A bare "." is deliberately minimal:
+# unlike descriptive fillers such as "(empty placeholder)" or "[System: ...]", it cannot be
+# misread by the model as user/assistant intent, and it does not get echoed back across turns.
+#
+# This mirrors LiteLLM's `_DEFAULT_EMPTY_CONTENT_MESSAGE = "."` (BerriAI/litellm PR #28987), which
+# replaced the older "[System: ...]" placeholders precisely because those leaked into `content`
+# and the model started repeating them on subsequent turns.
+EMPTY_CONTENT_PLACEHOLDER = "."
+
+
+# ==================================================================================================
 # Data Classes for Unified Message Format
 # ==================================================================================================
 
@@ -965,7 +980,7 @@ def strip_all_tool_content(messages: List[UnifiedMessage]) -> Tuple[List[Unified
                     content_parts.append(result_text)
             
             # Join all parts with double newline
-            content = "\n\n".join(content_parts) if content_parts else "(empty placeholder)"
+            content = "\n\n".join(content_parts) if content_parts else EMPTY_CONTENT_PLACEHOLDER
             
             # Create a copy of the message without tool content but with text representation
             # IMPORTANT: Preserve images from the original message (e.g., screenshots from MCP tools)
@@ -1179,7 +1194,7 @@ def ensure_first_message_is_user(messages: List[UnifiedMessage]) -> List[Unified
         >>> result[0].role
         'user'
         >>> result[0].content
-        '(empty placeholder)'
+        '.'
     """
     if not messages:
         return messages
@@ -1189,11 +1204,12 @@ def ensure_first_message_is_user(messages: List[UnifiedMessage]) -> List[Unified
             f"First message is '{messages[0].role}', prepending synthetic user message "
             f"(Kiro API requires conversations to start with user)"
         )
-        # Create minimal synthetic user message (matches LiteLLM behavior)
-        # Using "(empty placeholder)" as minimal valid content to avoid disrupting conversation context
+        # Create minimal synthetic user message (matches LiteLLM behavior).
+        # Use the minimal "." filler (see EMPTY_CONTENT_PLACEHOLDER): it satisfies Kiro's
+        # non-empty-content requirement without injecting text the model could misread.
         synthetic_user = UnifiedMessage(
             role="user",
-            content="(empty placeholder)"
+            content=EMPTY_CONTENT_PLACEHOLDER
         )
         
         return [synthetic_user] + messages
@@ -1258,20 +1274,20 @@ def normalize_message_roles(messages: List[UnifiedMessage]) -> List[UnifiedMessa
 
 def ensure_alternating_roles(messages: List[UnifiedMessage]) -> List[UnifiedMessage]:
     """
-    Ensures alternating user/assistant roles by inserting synthetic assistant messages.
+    Ensures alternating user/assistant roles by merging consecutive same-role messages.
     
     Kiro API requires alternating userInputMessage and assistantResponseMessage.
-    When consecutive user messages are detected, synthetic assistant messages
-    with "(empty placeholder)" placeholder are inserted between them to maintain alternation.
+    Instead of inserting synthetic placeholder messages (which confuse the model),
+    consecutive messages with the same role are merged into one — combining their
+    content, tool_calls, tool_results, and images.
     
-    This fixes multiple unknown roles (converted to user)
-    create consecutive userInputMessage entries that violate Kiro API requirements.
+    This follows the LiteLLM/CrewAI pattern: merge rather than fabricate.
     
     Args:
         messages: List of messages in unified format
     
     Returns:
-        List of messages with synthetic assistant messages inserted where needed
+        List of messages with strict role alternation (via merging)
     
     Example:
         >>> messages = [
@@ -1281,36 +1297,64 @@ def ensure_alternating_roles(messages: List[UnifiedMessage]) -> List[UnifiedMess
         ... ]
         >>> result = ensure_alternating_roles(messages)
         >>> len(result)
-        5  # 3 user + 2 synthetic assistant
-        >>> result[1].role
-        'assistant'
-        >>> result[1].content
-        '(empty placeholder)'
+        1  # All merged into one user message
+        >>> "First" in result[0].content
+        True
     """
     if not messages or len(messages) < 2:
         return messages
     
     result = [messages[0]]
-    synthetic_count = 0
+    merged_count = 0
     
     for msg in messages[1:]:
-        prev_role = result[-1].role
+        prev = result[-1]
         
-        # If both current and previous are user → insert synthetic assistant
-        if msg.role == "user" and prev_role == "user":
-            synthetic_assistant = UnifiedMessage(
-                role="assistant",
-                content="(empty placeholder)"  # Consistent with build_kiro_history() placeholder
-            )
-            result.append(synthetic_assistant)
-            synthetic_count += 1
-        
-        result.append(msg)
+        if msg.role == prev.role:
+            # Merge into the previous message instead of inserting a synthetic
+            _merge_message_into(prev, msg)
+            merged_count += 1
+        else:
+            result.append(msg)
     
-    if synthetic_count > 0:
-        logger.debug(f"Inserted {synthetic_count} synthetic assistant message(s) to ensure alternation")
+    if merged_count > 0:
+        logger.debug(f"Merged {merged_count} consecutive same-role message(s) to ensure alternation")
     
     return result
+
+
+def _merge_message_into(target: UnifiedMessage, source: UnifiedMessage) -> None:
+    """
+    Merges source message fields into target (in place).
+    
+    Combines content (with newline separator), tool_calls, tool_results, and images.
+    """
+    # Merge text content
+    target_text = extract_text_content(target.content)
+    source_text = extract_text_content(source.content)
+    if target_text and source_text:
+        target.content = f"{target_text}\n{source_text}"
+    elif source_text:
+        target.content = source_text
+    # else: keep target.content as-is
+    
+    # Merge tool_calls (assistant messages)
+    if source.tool_calls:
+        if target.tool_calls is None:
+            target.tool_calls = []
+        target.tool_calls = list(target.tool_calls) + list(source.tool_calls)
+    
+    # Merge tool_results (user messages)
+    if source.tool_results:
+        if target.tool_results is None:
+            target.tool_results = []
+        target.tool_results = list(target.tool_results) + list(source.tool_results)
+    
+    # Merge images
+    if source.images:
+        if target.images is None:
+            target.images = []
+        target.images = list(target.images) + list(source.images)
 
 
 # ==================================================================================================
@@ -1340,9 +1384,12 @@ def build_kiro_history(messages: List[UnifiedMessage], model_id: str) -> List[Di
         if msg.role == "user":
             content = extract_text_content(msg.content)
             
-            # Fallback for empty content - Kiro API requires non-empty content
+            # Fallback for empty content - Kiro API requires a non-empty content string,
+            # even when the real payload is tool_results carried in userInputMessageContext.
+            # Use the minimal "." filler (see EMPTY_CONTENT_PLACEHOLDER) rather than a
+            # descriptive marker, which the model can misread as user intent or echo back.
             if not content:
-                content = "(empty placeholder)"
+                content = EMPTY_CONTENT_PLACEHOLDER
             
             user_input = {
                 "content": content,
@@ -1382,10 +1429,13 @@ def build_kiro_history(messages: List[UnifiedMessage], model_id: str) -> List[Di
         elif msg.role == "assistant":
             content = extract_text_content(msg.content)
             
-            # Fallback for empty content - Kiro API requires non-empty content
+            # Fallback for empty content - Kiro API requires a non-empty content string,
+            # even when the assistant turn is purely a tool call (toolUses carries the action,
+            # and is preserved separately below). Use the minimal "." filler so the model is
+            # not fed descriptive text it could misread or echo back.
             if not content:
-                content = "(empty placeholder)"
-            
+                content = EMPTY_CONTENT_PLACEHOLDER
+
             assistant_response = {"content": content}
             
             # Process tool_calls
@@ -1510,11 +1560,13 @@ def build_kiro_payload(
                 "content": current_content
             }
         })
-        current_content = "(empty placeholder)"
+        current_content = EMPTY_CONTENT_PLACEHOLDER
     
-    # If content is empty - use placeholder
+    # If content is empty - use the minimal "." filler (see EMPTY_CONTENT_PLACEHOLDER).
+    # Tool results (if any) are carried in userInputMessageContext below, so no descriptive
+    # marker is needed in content — and a bare "." cannot be misread or echoed by the model.
     if not current_content:
-        current_content = "(empty placeholder)"
+        current_content = EMPTY_CONTENT_PLACEHOLDER
     
     # Process images in current message - extract from message or content
     # IMPORTANT: images go directly into userInputMessage, NOT into userInputMessageContext
@@ -1547,7 +1599,10 @@ def build_kiro_payload(
             user_input_context["toolResults"] = tool_results
     
     # Inject thinking tags if enabled (only for the current/last user message)
-    if current_message.role == "user":
+    # Skip injection for tool-result-only messages — they carry no user intent,
+    # and injecting tags makes the model think the user sent an empty message.
+    is_tool_result_only = current_message.tool_results and not extract_text_content(current_message.content).strip()
+    if current_message.role == "user" and not is_tool_result_only:
         current_content = inject_thinking_tags(current_content, thinking_config)
     
     # Build userInputMessage

--- a/tests/unit/test_converters_core.py
+++ b/tests/unit/test_converters_core.py
@@ -1342,7 +1342,7 @@ class TestEnsureFirstMessageIsUser:
         
         print("Checking first message is synthetic user...")
         assert result[0].role == "user"
-        assert result[0].content == "(empty placeholder)"
+        assert result[0].content == "."
         
         print("Checking original messages are preserved...")
         assert result[1].role == "assistant"
@@ -1379,7 +1379,7 @@ class TestEnsureFirstMessageIsUser:
         print(f"Comparing length: Expected 2 (synthetic + original), Got {len(result)}")
         assert len(result) == 2
         assert result[0].role == "user"
-        assert result[0].content == "(empty placeholder)"
+        assert result[0].content == "."
         assert result[1].role == "assistant"
     
     def test_handles_assistant_user_assistant_sequence(self):
@@ -1400,7 +1400,7 @@ class TestEnsureFirstMessageIsUser:
         print(f"Comparing length: Expected 4 (synthetic + 3 original), Got {len(result)}")
         assert len(result) == 4
         assert result[0].role == "user"
-        assert result[0].content == "(empty placeholder)"
+        assert result[0].content == "."
         assert result[1].role == "assistant"
         assert result[2].role == "user"
         assert result[3].role == "assistant"
@@ -1429,7 +1429,7 @@ class TestEnsureFirstMessageIsUser:
         print("Checking synthetic user was prepended...")
         assert len(result) == 2
         assert result[0].role == "user"
-        assert result[0].content == "(empty placeholder)"
+        assert result[0].content == "."
         
         print("Checking tool_calls are preserved...")
         assert result[1].role == "assistant"
@@ -1463,7 +1463,7 @@ class TestEnsureFirstMessageIsUser:
     
     def test_uses_minimal_content_for_synthetic_message(self):
         """
-        What it does: Verifies synthetic message uses minimal content ("(empty placeholder)").
+        What it does: Verifies synthetic message uses minimal content (".").
         Purpose: Ensure minimal token usage and avoid disrupting conversation context.
         """
         print("Setup: Assistant-first conversation...")
@@ -1475,7 +1475,7 @@ class TestEnsureFirstMessageIsUser:
         result = ensure_first_message_is_user(messages)
         
         print("Checking synthetic message content...")
-        assert result[0].content == "(empty placeholder)"
+        assert result[0].content == "."
         print("✓ Synthetic message uses minimal content (matches LiteLLM behavior)")
 
 
@@ -1684,40 +1684,39 @@ class TestEnsureAlternatingRoles:
     """
     Tests for ensure_alternating_roles function.
     
-    This function ensures alternating user/assistant roles by inserting synthetic
-    assistant messages with "(empty placeholder)" content between consecutive user messages.
-    This is part of the fix for Issue #64 where multiple 'developer' roles
-    (converted to 'user') create consecutive userInputMessage entries.
+    This function ensures alternating user/assistant roles by MERGING consecutive
+    same-role messages (content, tool_calls, tool_results, images) into one — rather
+    than inserting synthetic placeholder turns the model could misread. This is part
+    of the fix for Issue #64 where multiple 'developer' roles (converted to 'user')
+    create consecutive userInputMessage entries.
     """
-    
-    def test_inserts_synthetic_assistant_between_two_consecutive_users(self):
+
+    def test_merges_two_consecutive_users(self):
         """
-        What it does: Verifies insertion of synthetic assistant between two user messages.
-        Purpose: Ensure Kiro API requirement of alternating roles is maintained.
+        What it does: Verifies two consecutive user messages are merged into one.
+        Purpose: Ensure Kiro's alternation requirement is met by merging, not by
+                 fabricating a synthetic assistant turn the model could misread.
         """
         print("Setup: Two consecutive user messages...")
         messages = [
             UnifiedMessage(role="user", content="First"),
             UnifiedMessage(role="user", content="Second")
         ]
-        
+
         print("Action: Ensuring alternating roles...")
         result = ensure_alternating_roles(messages)
-        
-        print(f"Comparing length: Expected 3 (2 user + 1 synthetic), Got {len(result)}")
-        assert len(result) == 3
-        print("Checking alternation pattern...")
+
+        print(f"Comparing length: Expected 1 (merged), Got {len(result)}")
+        assert len(result) == 1
+        print("Checking merged content...")
         assert result[0].role == "user"
-        assert result[0].content == "First"
-        assert result[1].role == "assistant"
-        assert result[1].content == "(empty placeholder)"
-        assert result[2].role == "user"
-        assert result[2].content == "Second"
-    
-    def test_inserts_multiple_synthetic_assistants_for_four_consecutive_users(self):
+        assert result[0].content == "First\nSecond"
+
+    def test_merges_four_consecutive_users(self):
         """
-        What it does: Verifies insertion of multiple synthetic assistants.
-        Purpose: Fix for Issue #64 - handle multiple consecutive developer messages.
+        What it does: Verifies four consecutive user messages are merged into one.
+        Purpose: Fix for Issue #64 - handle multiple consecutive developer messages
+                 by merging them rather than inserting synthetic assistant turns.
         """
         print("Setup: Four consecutive user messages...")
         messages = [
@@ -1726,20 +1725,15 @@ class TestEnsureAlternatingRoles:
             UnifiedMessage(role="user", content="Third"),
             UnifiedMessage(role="user", content="Fourth")
         ]
-        
+
         print("Action: Ensuring alternating roles...")
         result = ensure_alternating_roles(messages)
-        
-        print(f"Comparing length: Expected 7 (4 user + 3 synthetic), Got {len(result)}")
-        assert len(result) == 7
-        print("Checking alternation pattern...")
-        assert result[0].role == "user" and result[0].content == "First"
-        assert result[1].role == "assistant" and result[1].content == "(empty placeholder)"
-        assert result[2].role == "user" and result[2].content == "Second"
-        assert result[3].role == "assistant" and result[3].content == "(empty placeholder)"
-        assert result[4].role == "user" and result[4].content == "Third"
-        assert result[5].role == "assistant" and result[5].content == "(empty placeholder)"
-        assert result[6].role == "user" and result[6].content == "Fourth"
+
+        print(f"Comparing length: Expected 1 (merged), Got {len(result)}")
+        assert len(result) == 1
+        print("Checking merged content...")
+        assert result[0].role == "user"
+        assert result[0].content == "First\nSecond\nThird\nFourth"
     
     def test_preserves_already_alternating_messages(self):
         """
@@ -1765,10 +1759,10 @@ class TestEnsureAlternatingRoles:
         assert result[2].role == "user" and result[2].content == "How are you?"
         assert result[3].role == "assistant" and result[3].content == "Fine"
     
-    def test_handles_multiple_groups_of_consecutive_users(self):
+    def test_merges_multiple_groups_of_consecutive_users(self):
         """
-        What it does: Verifies handling of multiple groups of consecutive users.
-        Purpose: Ensure function handles complex conversation patterns.
+        What it does: Verifies multiple groups of consecutive users are each merged.
+        Purpose: Ensure function handles complex conversation patterns via merging.
         """
         print("Setup: Multiple groups of consecutive users...")
         messages = [
@@ -1779,24 +1773,18 @@ class TestEnsureAlternatingRoles:
             UnifiedMessage(role="user", content="E"),
             UnifiedMessage(role="user", content="F")
         ]
-        
+
         print("Action: Ensuring alternating roles...")
         result = ensure_alternating_roles(messages)
-        
-        print(f"Comparing length: Expected 9 (6 original + 3 synthetic), Got {len(result)}")
-        assert len(result) == 9
-        print("Checking first group (A, synthetic, B)...")
-        assert result[0].role == "user" and result[0].content == "A"
-        assert result[1].role == "assistant" and result[1].content == "(empty placeholder)"
-        assert result[2].role == "user" and result[2].content == "B"
+
+        print(f"Comparing length: Expected 3 (A+B, C, D+E+F), Got {len(result)}")
+        assert len(result) == 3
+        print("Checking first merged group (A+B)...")
+        assert result[0].role == "user" and result[0].content == "A\nB"
         print("Checking real assistant...")
-        assert result[3].role == "assistant" and result[3].content == "C"
-        print("Checking second group (D, synthetic, E, synthetic, F)...")
-        assert result[4].role == "user" and result[4].content == "D"
-        assert result[5].role == "assistant" and result[5].content == "(empty placeholder)"
-        assert result[6].role == "user" and result[6].content == "E"
-        assert result[7].role == "assistant" and result[7].content == "(empty placeholder)"
-        assert result[8].role == "user" and result[8].content == "F"
+        assert result[1].role == "assistant" and result[1].content == "C"
+        print("Checking second merged group (D+E+F)...")
+        assert result[2].role == "user" and result[2].content == "D\nE\nF"
     
     def test_handles_empty_list(self):
         """
@@ -1827,10 +1815,10 @@ class TestEnsureAlternatingRoles:
         assert result[0].role == "user"
         assert result[0].content == "Solo"
     
-    def test_preserves_tool_results_in_original_messages(self):
+    def test_merges_tool_results_from_consecutive_users(self):
         """
-        What it does: Verifies tool_results are preserved in original messages.
-        Purpose: Ensure synthetic assistants don't have tool content, but originals do.
+        What it does: Verifies tool_results from consecutive user messages are merged.
+        Purpose: Ensure merging preserves all tool_results instead of dropping any.
         """
         print("Setup: Two consecutive user messages with tool_results...")
         messages = [
@@ -1845,25 +1833,23 @@ class TestEnsureAlternatingRoles:
                 tool_results=[{"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"}]
             )
         ]
-        
+
         print("Action: Ensuring alternating roles...")
         result = ensure_alternating_roles(messages)
-        
-        print(f"Comparing length: Expected 3, Got {len(result)}")
-        assert len(result) == 3
-        print("Checking that synthetic assistant has no tool_results...")
-        assert result[1].role == "assistant"
-        assert result[1].tool_results is None
-        print("Checking that original messages preserved tool_results...")
+
+        print(f"Comparing length: Expected 1 (merged), Got {len(result)}")
+        assert len(result) == 1
+        print("Checking that tool_results from both messages are preserved...")
+        assert result[0].role == "user"
         assert result[0].tool_results is not None
-        assert len(result[0].tool_results) == 1
-        assert result[2].tool_results is not None
-        assert len(result[2].tool_results) == 1
-    
-    def test_preserves_images_in_original_messages(self):
+        assert len(result[0].tool_results) == 2
+        assert result[0].tool_results[0]["tool_use_id"] == "call_1"
+        assert result[0].tool_results[1]["tool_use_id"] == "call_2"
+
+    def test_merges_images_from_consecutive_users(self):
         """
-        What it does: Verifies images are preserved in original messages.
-        Purpose: Ensure synthetic assistants don't have images, but originals do.
+        What it does: Verifies images from consecutive user messages are merged.
+        Purpose: Ensure merging preserves all images instead of dropping any.
         """
         print("Setup: Two consecutive user messages with images...")
         messages = [
@@ -1878,20 +1864,16 @@ class TestEnsureAlternatingRoles:
                 images=[{"media_type": "image/jpeg", "data": "data2"}]
             )
         ]
-        
+
         print("Action: Ensuring alternating roles...")
         result = ensure_alternating_roles(messages)
-        
-        print(f"Comparing length: Expected 3, Got {len(result)}")
-        assert len(result) == 3
-        print("Checking that synthetic assistant has no images...")
-        assert result[1].role == "assistant"
-        assert result[1].images is None
-        print("Checking that original messages preserved images...")
+
+        print(f"Comparing length: Expected 1 (merged), Got {len(result)}")
+        assert len(result) == 1
+        print("Checking that images from both messages are preserved...")
+        assert result[0].role == "user"
         assert result[0].images is not None
-        assert len(result[0].images) == 1
-        assert result[2].images is not None
-        assert len(result[2].images) == 1
+        assert len(result[0].images) == 2
 
 
 # ==================================================================================================
@@ -1904,13 +1886,14 @@ class TestNormalizeAndAlternatingIntegration:
     
     These tests verify the complete pipeline for Issue #64 fix:
     1. Unknown roles (developer, system) are normalized to 'user'
-    2. Consecutive user messages get synthetic assistant messages inserted
+    2. Consecutive same-role messages are merged into a single message
     """
-    
-    def test_developer_messages_are_normalized_and_alternated(self):
+
+    def test_developer_messages_are_normalized_and_merged(self):
         """
         What it does: Verifies complete pipeline for Issue #64.
-        Purpose: Ensure multiple developer messages are normalized and alternated correctly.
+        Purpose: Ensure multiple developer messages are normalized to user and then
+                 merged into a single user message (no synthetic assistant turns).
         """
         print("Setup: Multiple developer messages + user question...")
         messages = [
@@ -1919,29 +1902,24 @@ class TestNormalizeAndAlternatingIntegration:
             UnifiedMessage(role="developer", content="Context 3"),
             UnifiedMessage(role="user", content="Question")
         ]
-        
+
         print("Action: Normalizing roles...")
         normalized = normalize_message_roles(messages)
         print(f"After normalization: {[msg.role for msg in normalized]}")
-        
+
         print("Action: Ensuring alternating roles...")
         result = ensure_alternating_roles(normalized)
-        
-        print(f"Comparing length: Expected 7 (4 user + 3 synthetic), Got {len(result)}")
-        assert len(result) == 7
-        print("Checking alternation pattern...")
-        assert result[0].role == "user" and result[0].content == "Context 1"
-        assert result[1].role == "assistant" and result[1].content == "(empty placeholder)"
-        assert result[2].role == "user" and result[2].content == "Context 2"
-        assert result[3].role == "assistant" and result[3].content == "(empty placeholder)"
-        assert result[4].role == "user" and result[4].content == "Context 3"
-        assert result[5].role == "assistant" and result[5].content == "(empty placeholder)"
-        assert result[6].role == "user" and result[6].content == "Question"
-    
-    def test_mixed_roles_are_normalized_and_alternated(self):
+
+        print(f"Comparing length: Expected 1 (all merged), Got {len(result)}")
+        assert len(result) == 1
+        print("Checking merged content...")
+        assert result[0].role == "user"
+        assert result[0].content == "Context 1\nContext 2\nContext 3\nQuestion"
+
+    def test_mixed_roles_are_normalized_and_merged(self):
         """
         What it does: Verifies pipeline with mixed roles (developer, system, user, assistant).
-        Purpose: Ensure complex conversation patterns are handled correctly.
+        Purpose: Ensure complex conversation patterns are handled correctly via merging.
         """
         print("Setup: Mixed roles conversation...")
         messages = [
@@ -1952,32 +1930,26 @@ class TestNormalizeAndAlternatingIntegration:
             UnifiedMessage(role="developer", content="Dev2"),
             UnifiedMessage(role="user", content="User2")
         ]
-        
+
         print("Action: Normalizing roles...")
         normalized = normalize_message_roles(messages)
         print(f"After normalization: {[msg.role for msg in normalized]}")
-        
+
         print("Action: Ensuring alternating roles...")
         result = ensure_alternating_roles(normalized)
-        
+
         print(f"Result length: {len(result)}")
         print(f"Result roles: {[msg.role for msg in result]}")
-        
+
         # After normalization: all system/developer → user
         # [user, user, user, assistant, user, user]
-        # After alternation: insert synthetic between consecutive users
-        # [user, synthetic, user, synthetic, user, assistant, user, synthetic, user]
-        assert len(result) == 9
-        print("Checking that all system/developer were converted to user...")
-        assert result[0].role == "user" and result[0].content == "System"
-        assert result[1].role == "assistant" and result[1].content == "(empty placeholder)"
-        assert result[2].role == "user" and result[2].content == "Dev"
-        assert result[3].role == "assistant" and result[3].content == "(empty placeholder)"
-        assert result[4].role == "user" and result[4].content == "User1"
-        assert result[5].role == "assistant" and result[5].content == "Assistant1"
-        assert result[6].role == "user" and result[6].content == "Dev2"
-        assert result[7].role == "assistant" and result[7].content == "(empty placeholder)"
-        assert result[8].role == "user" and result[8].content == "User2"
+        # After alternation (merge consecutive same-role):
+        # [user(System+Dev+User1), assistant(Assistant1), user(Dev2+User2)]
+        assert len(result) == 3
+        print("Checking merged groups...")
+        assert result[0].role == "user" and result[0].content == "System\nDev\nUser1"
+        assert result[1].role == "assistant" and result[1].content == "Assistant1"
+        assert result[2].role == "user" and result[2].content == "Dev2\nUser2"
 
 
 # ==================================================================================================
@@ -3899,7 +3871,7 @@ class TestBuildKiroHistory:
     
     def test_adds_empty_placeholder_for_empty_user_content(self):
         """
-        What it does: Verifies that "(empty placeholder)" placeholder is added for user messages with empty content.
+        What it does: Verifies that "." placeholder is added for user messages with empty content.
         Purpose: Ensure Kiro API receives non-empty content in history.
         
         This is a fallback test for issue #20 - ensures any edge case with empty content
@@ -3913,12 +3885,12 @@ class TestBuildKiroHistory:
         
         print(f"Result: {result}")
         print(f"Content: '{result[0]['userInputMessage']['content']}'")
-        print("Checking that '(empty placeholder)' placeholder is added...")
-        assert result[0]["userInputMessage"]["content"] == "(empty placeholder)"
+        print("Checking that '.' placeholder is added...")
+        assert result[0]["userInputMessage"]["content"] == "."
     
     def test_adds_empty_placeholder_for_empty_assistant_content(self):
         """
-        What it does: Verifies that "(empty placeholder)" placeholder is added for assistant messages with empty content.
+        What it does: Verifies that "." placeholder is added for assistant messages with empty content.
         Purpose: Ensure Kiro API receives non-empty content in history.
         
         This is a fallback test for issue #20 - ensures any edge case with empty content
@@ -3932,12 +3904,12 @@ class TestBuildKiroHistory:
         
         print(f"Result: {result}")
         print(f"Content: '{result[0]['assistantResponseMessage']['content']}'")
-        print("Checking that '(empty placeholder)' placeholder is added...")
-        assert result[0]["assistantResponseMessage"]["content"] == "(empty placeholder)"
+        print("Checking that '.' placeholder is added...")
+        assert result[0]["assistantResponseMessage"]["content"] == "."
     
     def test_adds_empty_placeholder_for_none_user_content(self):
         """
-        What it does: Verifies that "(empty placeholder)" placeholder is added for user messages with None content.
+        What it does: Verifies that "." placeholder is added for user messages with None content.
         Purpose: Ensure Kiro API receives non-empty content when content is None.
         """
         print("Setup: User message with None content...")
@@ -3948,12 +3920,12 @@ class TestBuildKiroHistory:
         
         print(f"Result: {result}")
         print(f"Content: '{result[0]['userInputMessage']['content']}'")
-        print("Checking that '(empty placeholder)' placeholder is added...")
-        assert result[0]["userInputMessage"]["content"] == "(empty placeholder)"
+        print("Checking that '.' placeholder is added...")
+        assert result[0]["userInputMessage"]["content"] == "."
     
     def test_adds_empty_placeholder_for_none_assistant_content(self):
         """
-        What it does: Verifies that "(empty placeholder)" placeholder is added for assistant messages with None content.
+        What it does: Verifies that "." placeholder is added for assistant messages with None content.
         Purpose: Ensure Kiro API receives non-empty content when content is None.
         """
         print("Setup: Assistant message with None content...")
@@ -3964,8 +3936,8 @@ class TestBuildKiroHistory:
         
         print(f"Result: {result}")
         print(f"Content: '{result[0]['assistantResponseMessage']['content']}'")
-        print("Checking that '(empty placeholder)' placeholder is added...")
-        assert result[0]["assistantResponseMessage"]["content"] == "(empty placeholder)"
+        print("Checking that '.' placeholder is added...")
+        assert result[0]["assistantResponseMessage"]["content"] == "."
     
     def test_preserves_non_empty_content_in_history(self):
         """
@@ -4011,10 +3983,10 @@ class TestBuildKiroHistory:
         assert result[0]["userInputMessage"]["content"] == "Start"
         
         print(f"Message 1 content: '{result[1]['assistantResponseMessage']['content']}'")
-        assert result[1]["assistantResponseMessage"]["content"] == "(empty placeholder)"
+        assert result[1]["assistantResponseMessage"]["content"] == "."
         
         print(f"Message 2 content: '{result[2]['userInputMessage']['content']}'")
-        assert result[2]["userInputMessage"]["content"] == "(empty placeholder)"
+        assert result[2]["userInputMessage"]["content"] == "."
         
         print(f"Message 3 content: '{result[3]['assistantResponseMessage']['content']}'")
         assert result[3]["assistantResponseMessage"]["content"] == "Response"
@@ -4488,7 +4460,7 @@ class TestStripAllToolContent:
                 content="",
                 tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "tool", "arguments": "{}"}}]
             ),  # Has tool content
-            UnifiedMessage(role="user", content="(empty placeholder)"),  # No tool content
+            UnifiedMessage(role="user", content="."),  # No tool content
         ]
         
         print("Action: Stripping tool content...")
@@ -4499,7 +4471,7 @@ class TestStripAllToolContent:
         assert result[0].content == "Hello"
         assert result[0].tool_calls is None
         assert result[1].tool_calls is None  # Stripped
-        assert result[2].content == "(empty placeholder)"
+        assert result[2].content == "."
         assert result[2].tool_calls is None
         assert had_content is True
     
@@ -5507,7 +5479,7 @@ class TestBuildKiroPayloadIssue20:
                     "content": "Tool executed"
                 }]
             ),
-            UnifiedMessage(role="user", content="(empty placeholder)")
+            UnifiedMessage(role="user", content=".")
         ]
         
         tools = [UnifiedTool(
@@ -5558,7 +5530,7 @@ class TestBuildKiroPayloadIssue20:
                     "function": {"name": "some_tool", "arguments": "{}"}
                 }]
             ),
-            UnifiedMessage(role="user", content="(empty placeholder)")
+            UnifiedMessage(role="user", content=".")
         ]
         
         print("Action: Building Kiro payload with empty tools list...")

--- a/tests/unit/test_converters_openai.py
+++ b/tests/unit/test_converters_openai.py
@@ -737,7 +737,7 @@ class TestBuildKiroPayload:
     def test_handles_assistant_as_last_message(self):
         """
         What it does: Verifies handling of assistant as last message.
-        Purpose: Ensure "(empty placeholder)" message is created.
+        Purpose: Ensure "." message is created.
         """
         print("Setup: Request with assistant at the end...")
         request = ChatCompletionRequest(
@@ -753,7 +753,7 @@ class TestBuildKiroPayload:
         
         print(f"Result: {result}")
         current_content = result["conversationState"]["currentMessage"]["userInputMessage"]["content"]
-        assert current_content == "(empty placeholder)"
+        assert current_content == "."
     
     def test_raises_for_empty_messages(self):
         """
@@ -775,8 +775,8 @@ class TestBuildKiroPayload:
     
     def test_uses_continue_for_empty_content(self):
         """
-        What it does: Verifies using "(empty placeholder)" for empty content.
-        Purpose: Ensure empty message is replaced with "(empty placeholder)".
+        What it does: Verifies using "." for empty content.
+        Purpose: Ensure empty message is replaced with ".".
         """
         print("Setup: Request with empty content...")
         request = ChatCompletionRequest(
@@ -791,7 +791,7 @@ class TestBuildKiroPayload:
 
         print(f"Result: {result}")
         current_content = result["conversationState"]["currentMessage"]["userInputMessage"]["content"]
-        assert current_content == "(empty placeholder)"
+        assert current_content == "."
     
     def test_normalizes_model_id_correctly(self):
         """
@@ -845,10 +845,13 @@ class TestBuildKiroPayload:
         assert len(context["tools"]) == 1
         assert context["tools"][0]["toolSpecification"]["name"] == "get_weather"
     
-    def test_injects_thinking_tags_even_when_tool_results_present(self):
+    def test_skips_thinking_tags_when_current_message_is_tool_result_only(self):
         """
-        What it does: Verifies thinking tags ARE injected even when toolResults are present.
-        Purpose: Extended thinking should work in all scenarios including tool use flows.
+        What it does: Verifies thinking tags are NOT injected when the current message is a
+                      tool-result-only turn (no user text, only toolResults).
+        Purpose: A tool-result delivery carries no user intent. Injecting thinking tags there
+                 makes the model treat it as an empty user message, so the gateway deliberately
+                 skips injection and the content stays the minimal "." filler.
         """
         print("Setup: Request where last message is a tool result...")
         request = ChatCompletionRequest(
@@ -892,8 +895,8 @@ class TestBuildKiroPayload:
         print(f"Has toolResults: {'toolResults' in context}")
         
         assert "toolResults" in context, "toolResults should be present"
-        assert "<thinking_mode>enabled</thinking_mode>" in content, "thinking tags SHOULD be injected even with toolResults"
-        assert "<max_thinking_length>4000</max_thinking_length>" in content, "max_thinking_length should be present"
+        assert "<thinking_mode>" not in content, "thinking tags should NOT be injected for tool-result-only turns"
+        assert content == ".", "tool-result-only current message uses the minimal '.' filler"
     
     def test_injects_thinking_tags_when_no_tool_results(self):
         """


### PR DESCRIPTION
## Problem
In agentic tool-use loops the model receives fabricated placeholder text it
interprets as genuine input — it remarks on "the user sent an empty message"
or reacts to the literal `(empty placeholder)` string between tool executions.

Two sources in `converters_core.py`:
1. Empty `content` (tool-result-only user turns, tool-call-only assistant turns)
   was filled with `(empty placeholder)` / `[System: ...]`.
2. `ensure_alternating_roles()` inserted synthetic `assistant: "(empty placeholder)"`
   turns between consecutive user messages.

Both land in `content`, which is the model's actual utterance channel — so the
model reads/echoes them.

## Fix
Adopt the LiteLLM convention (PR BerriAI/litellm#28987), adapted for Kiro's
non-empty-`content` requirement:
- `EMPTY_CONTENT_PLACEHOLDER = "."` for all empty-content fallbacks. A bare `.`
  can't be misread as intent or echoed; tool payloads stay in `toolUses`/`toolResults`.
- `ensure_alternating_roles()` **merges** consecutive same-role messages
  (content, tool_calls, tool_results, images) instead of fabricating turns.
- Skip thinking-tag injection for tool-result-only current messages.

`"(empty result)"` (empty *tool output*) is a separate, legitimate case and is
left unchanged.

## Why this approach
LiteLLM's older `[System: ...]` placeholder caused this exact leak/echo
(BerriAI/litellm#24498 — the model even reproduced it with a typo, proving it
was repeating history). PR #28987 replaced it with `.` + "never put diagnostics
in `content`, preserve tool content." Bedrock Converse (#20364) and the Anthropic
API take the same "drop/merge, don't fabricate" stance.

## Testing
`pytest tests/unit/test_converters_core.py tests/unit/test_converters_openai.py`
→ 322 passing (covers both OpenAI and Anthropic adapters; conversion is shared
and identical for streaming/non-streaming).