### PR TITLE
fix(models): resolve ToolReferenceContentBlock forward reference causing 422 on tool_result validation

### DIFF
--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -568,3 +568,10 @@ class AnthropicErrorResponse(BaseModel):
 
     type: Literal["error"] = "error"
     error: AnthropicErrorDetail
+
+
+# Rebuild models that use forward references in Union types.
+# ToolResultContentBlock.content references "ToolReferenceContentBlock" as a string —
+# Pydantic v2 needs an explicit rebuild to resolve it after all classes are defined.
+ToolResultContentBlock.model_rebuild()
+AnthropicMessage.model_rebuild()


### PR DESCRIPTION
## Summary

- Fix Pydantic v2 forward reference resolution for `ToolReferenceContentBlock`, which caused 422 validation errors when Claude Code sends `tool_reference` blocks inside `tool_result` content

## Problem

Claude Code v2.1+ uses the ToolSearch deferred tool mechanism, which places `tool_reference` content blocks inside `tool_result` messages:

```json
{
  "type": "tool_result",
  "tool_use_id": "tooluse_xxx",
  "content": [
    {"type": "tool_reference", "tool_name": "mcp__codebase-memory-mcp__index_repository"}
  ]
}
```
ToolResultContentBlock.content is typed as:
content: Optional[Union[str, List[Union["TextContentBlock", "ImageContentBlock", "ToolReferenceContentBlock"]]]]

However, Pydantic v2 never resolved the "ToolReferenceContentBlock" forward reference string into the actual class. At validation time, the Union only recognized TextContentBlock and ImageContentBlock, rejecting tool_reference blocks with a 422 error.

Solution

Added model_rebuild() calls at the end of models_anthropic.py after all classes are defined:

ToolResultContentBlock.model_rebuild()
AnthropicMessage.model_rebuild()

This forces Pydantic v2 to resolve all forward reference strings in Union type annotations, allowing tool_reference blocks to pass validation correctly.

Test plan

- [x] Validated payload containing tool_reference inside tool_result now parses successfully
- [x] Existing test suite passes (235 passed)