### PR TITLE
fix(config): add claude-opus-4.8 to FALLBACK_MODELS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ state.json
 .vscode/
 .idea/
 .shard/
+.DS_Store
+
+# Python venv
+.venv/
+venv/
 
 # Python
 __pycache__/

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -282,6 +282,7 @@ FALLBACK_MODELS: List[Dict[str, str]] = [
     {"modelId": "claude-opus-4.5"},
     {"modelId": "claude-opus-4.6"},
     {"modelId": "claude-opus-4.7"},
+    {"modelId": "claude-opus-4.8"},
     {"modelId": "deepseek-3.2"},
     {"modelId": "glm-5"},
     {"modelId": "minimax-m2.1"},
@@ -578,4 +579,3 @@ def get_kiro_api_host(region: str) -> str:
 def get_kiro_q_host(region: str) -> str:
     """Return Q API host for the specified region."""
     return KIRO_Q_HOST_TEMPLATE.format(region=region)
-


### PR DESCRIPTION
## What

- Adds `claude-opus-4.8` to `FALLBACK_MODELS` so the fallback list stays
  in sync with the model catalog (4.5/4.6/4.7 are already present).
- Adds `.venv/` and `.DS_Store` to `.gitignore` — these are dev-machine
  artifacts that show up in `git status` and add noise.

## Why

- claude-opus-4.8 should match the same upstream flag pattern as the
  rest of the catalog.
- `.gitignore` was missing the two most common Python-on-macOS
  artifacts.

## Test

- `python -c "from kiro.config import FALLBACK_MODELS; print(any(m['modelId']=='claude-opus-4.8' for m in FALLBACK_MODELS))"`
  → `True`
- `git status` no longer reports `.venv/` or `.DS_Store` as untracked.

Co-authored-by: Cursor <cursoragent@cursor.com>

Made with [Cursor](https://cursor.com)