### PR TITLE
feat(converters): extract and merge inline system messages from Anthropic format

### DIFF
--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -257,11 +257,12 @@ def extract_tool_uses_from_anthropic_content(content: Any) -> List[Dict[str, Any
 
 def convert_anthropic_messages(
     messages: List[AnthropicMessage],
-) -> List[UnifiedMessage]:
+) -> tuple:
     """
     Converts Anthropic messages to unified format.
 
     Handles:
+    - System messages (extracted as inline system prompt, non-standard but sent by Claude Code)
     - Text content (string or list of text blocks)
     - Tool use blocks (assistant messages)
     - Tool result blocks (user messages)
@@ -270,10 +271,13 @@ def convert_anthropic_messages(
         messages: List of Anthropic messages
 
     Returns:
-        List of messages in unified format
+        Tuple of (inline_system_prompt, unified_messages):
+        - inline_system_prompt: Text from any system-role messages found inline
+        - unified_messages: List of messages in unified format (excluding system messages)
     """
 
     unified_messages = []
+    inline_system_parts = []
     total_tool_calls = 0
     total_tool_results = 0
     total_images = 0
@@ -281,6 +285,13 @@ def convert_anthropic_messages(
     for msg in messages:
         role = msg.role
         content = msg.content
+
+        # Handle system messages inline (non-standard, sent by Claude Code)
+        if role == "system":
+            text_content = convert_anthropic_content_to_text(content)
+            if text_content:
+                inline_system_parts.append(text_content)
+            continue
 
         # Extract text content
         text_content = convert_anthropic_content_to_text(content)
@@ -333,7 +344,14 @@ def convert_anthropic_messages(
             f"{total_tool_calls} tool_calls, {total_tool_results} tool_results, {total_images} images"
         )
 
-    return unified_messages
+    inline_system_prompt = "\n".join(inline_system_parts).strip()
+    if inline_system_prompt:
+        logger.debug(
+            f"Extracted {len(inline_system_parts)} inline system message(s) "
+            f"({len(inline_system_prompt)} chars) from Anthropic messages array"
+        )
+
+    return inline_system_prompt, unified_messages
 
 
 def convert_anthropic_tools(
@@ -451,7 +469,8 @@ def anthropic_to_kiro(
         ValueError: If there are no messages to send
     """
     # Convert messages to unified format
-    unified_messages = convert_anthropic_messages(request.messages)
+    # Also extracts any inline system messages (non-standard, sent by Claude Code)
+    inline_system_prompt, unified_messages = convert_anthropic_messages(request.messages)
 
     # Convert tools to unified format
     unified_tools = convert_anthropic_tools(request.tools)
@@ -459,6 +478,13 @@ def anthropic_to_kiro(
     # System prompt is already separate in Anthropic format!
     # It can be a string or list of content blocks (for prompt caching)
     system_prompt = extract_system_prompt(request.system)
+
+    # Merge inline system messages (from messages array) with the explicit system field
+    if inline_system_prompt:
+        if system_prompt:
+            system_prompt = system_prompt + "\n\n" + inline_system_prompt
+        else:
+            system_prompt = inline_system_prompt
 
     # Get model ID for Kiro API (normalizes + resolves hidden models)
     # Pass-through principle: we normalize and send to Kiro, Kiro decides if valid

--- a/kiro/model_resolver.py
+++ b/kiro/model_resolver.py
@@ -194,9 +194,10 @@ def get_model_id_for_kiro(model_name: str, hidden_models: Dict[str, str]) -> str
     Get the model ID to send to Kiro API.
     
     This is a simple helper for converters that don't have access to the full
-    ModelResolver. It normalizes the name and checks hidden models.
+    ModelResolver. It resolves aliases, normalizes the name, and checks hidden models.
     
     For hidden models (like claude-3.7-sonnet), returns the internal Kiro ID.
+    For aliased models (like claude-sonnet-5), resolves the alias first.
     For regular models, returns the normalized name.
     
     Args:
@@ -214,7 +215,14 @@ def get_model_id_for_kiro(model_name: str, hidden_models: Dict[str, str]) -> str
         >>> get_model_id_for_kiro("claude-3-7-sonnet", {"claude-3.7-sonnet": "CLAUDE_3_7_SONNET_20250219_V1_0"})
         'CLAUDE_3_7_SONNET_20250219_V1_0'
     """
-    normalized = normalize_model_name(model_name)
+    from kiro.config import MODEL_ALIASES
+    
+    # Layer 0: Resolve alias (if exists)
+    resolved = MODEL_ALIASES.get(model_name, model_name)
+    if resolved != model_name:
+        logger.debug(f"Alias resolved in get_model_id_for_kiro: '{model_name}' → '{resolved}'")
+    
+    normalized = normalize_model_name(resolved)
     internal = hidden_models.get(normalized, normalized)
     return to_runtime_model_id(internal)
 

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -183,11 +183,13 @@ class AnthropicMessage(BaseModel):
     Message in Anthropic format.
 
     Attributes:
-        role: Message role (user or assistant)
+        role: Message role (user, assistant, or system).
+              System messages are non-standard but sent by some clients (e.g., Claude Code).
+              They are extracted and merged into the system prompt during conversion.
         content: Message content (string or list of content blocks)
     """
 
-    role: Literal["user", "assistant"]
+    role: Literal["user", "assistant", "system"]
     content: Union[str, List[ContentBlock]]
 
     model_config = {"extra": "allow"}

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -955,7 +955,7 @@ class TestConvertAnthropicMessages:
         messages = [AnthropicMessage(role="user", content="Hello!")]
 
         print("Action: Converting messages...")
-        result = convert_anthropic_messages(messages)
+        _, result = convert_anthropic_messages(messages)
 
         print(f"Result: {result}")
         assert len(result) == 1
@@ -973,7 +973,7 @@ class TestConvertAnthropicMessages:
         messages = [AnthropicMessage(role="assistant", content="Hi there!")]
 
         print("Action: Converting messages...")
-        result = convert_anthropic_messages(messages)
+        _, result = convert_anthropic_messages(messages)
 
         print(f"Result: {result}")
         assert len(result) == 1
@@ -997,7 +997,7 @@ class TestConvertAnthropicMessages:
         ]
 
         print("Action: Converting messages...")
-        result = convert_anthropic_messages(messages)
+        _, result = convert_anthropic_messages(messages)
 
         print(f"Result: {result}")
         assert len(result) == 1
@@ -1025,7 +1025,7 @@ class TestConvertAnthropicMessages:
         ]
 
         print("Action: Converting messages...")
-        result = convert_anthropic_messages(messages)
+        _, result = convert_anthropic_messages(messages)
 
         print(f"Result: {result}")
         assert len(result) == 1
@@ -1055,7 +1055,7 @@ class TestConvertAnthropicMessages:
         ]
 
         print("Action: Converting messages...")
-        result = convert_anthropic_messages(messages)
+        _, result = convert_anthropic_messages(messages)
 
         print(f"Result: {result}")
         assert len(result) == 1
@@ -1077,7 +1077,7 @@ class TestConvertAnthropicMessages:
         ]
 
         print("Action: Converting messages...")
-        result = convert_anthropic_messages(messages)
+        _, result = convert_anthropic_messages(messages)
 
         print(f"Result: {result}")
         assert len(result) == 3
@@ -1094,7 +1094,7 @@ class TestConvertAnthropicMessages:
         messages = []
 
         print("Action: Converting messages...")
-        result = convert_anthropic_messages(messages)
+        _, result = convert_anthropic_messages(messages)
 
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
@@ -1132,7 +1132,7 @@ class TestConvertAnthropicMessages:
         ]
 
         print("Action: Converting messages...")
-        result = convert_anthropic_messages(messages)
+        _, result = convert_anthropic_messages(messages)
 
         print(f"Result: {result}")
         print(f"Images: {result[0].images}")
@@ -1185,7 +1185,7 @@ class TestConvertAnthropicMessages:
         ]
 
         print("Action: Converting messages...")
-        result = convert_anthropic_messages(messages)
+        _, result = convert_anthropic_messages(messages)
 
         print(f"Result: {result}")
 
@@ -1240,7 +1240,7 @@ class TestConvertAnthropicMessages:
         ]
 
         print("Action: Converting messages...")
-        result = convert_anthropic_messages(messages)
+        _, result = convert_anthropic_messages(messages)
 
         print(
             f"Result images count: {len(result[0].images) if result[0].images else 0}"
@@ -1295,7 +1295,7 @@ class TestConvertAnthropicMessages:
 
         print("Action: Converting messages with logging enabled...")
         with caplog.at_level(logging.DEBUG):
-            result = convert_anthropic_messages(messages)
+            _, result = convert_anthropic_messages(messages)
 
         print(f"Log records: {[r.message for r in caplog.records]}")
 


### PR DESCRIPTION
- Add support for system-role messages in Anthropic message arrays (non-standard but sent by Claude Code)
- Update convert_anthropic_messages() to return tuple of (inline_system_prompt, unified_messages)
- Extract system messages from message array and merge into explicit system prompt during conversion
- Update AnthropicMessage model to accept "system" role in addition to "user" and "assistant"
- Add alias resolution layer in get_model_id_for_kiro() to normalize model names before hidden model lookup
- Update convert_anthropic_tools() call site to unpack new tuple return value
- Update all test cases to handle new tuple return format from convert_anthropic_messages()
- Add debug logging for extracted inline system messages and resolved model aliases