### PR TITLE
fix(models): accept non-standard roles in AnthropicMessage so normalization can run

### DIFF
--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -183,11 +183,15 @@ class AnthropicMessage(BaseModel):
     Message in Anthropic format.
 
     Attributes:
-        role: Message role (user or assistant)
+        role: Message role. Normally "user" or "assistant", but some clients
+            (e.g. Claude Code) occasionally send other values such as "system"
+            for injected context. These are accepted here and coerced to "user"
+            downstream by normalize_message_roles() in converters_core.py,
+            instead of rejecting the whole request with a 422.
         content: Message content (string or list of content blocks)
     """
 
-    role: Literal["user", "assistant"]
+    role: str
     content: Union[str, List[ContentBlock]]
 
     model_config = {"extra": "allow"}

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -1499,6 +1499,54 @@ class TestAnthropicToKiro:
         print(f"Current content: {current_content}")
         assert "You are a helpful assistant." in current_content
 
+    def test_inline_system_role_message_is_normalized(self):
+        """
+        What it does: Verifies a request with an inline system-role message
+        converts end-to-end without errors and the message is normalized.
+        Purpose: End-to-end coverage for Issue #190 / #226 - newer Claude Code
+        clients inline role="system" hook context in the messages array.
+        The pipeline (normalize_message_roles) must coerce it to "user" so the
+        Kiro API only ever sees user/assistant history entries.
+        """
+        print("Setup: Request with inline system-role message...")
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-4-5",
+            max_tokens=1024,
+            messages=[
+                AnthropicMessage(role="user", content="Hello!"),
+                AnthropicMessage(role="assistant", content="Hi!"),
+                AnthropicMessage(role="system", content="Injected hook context"),
+                AnthropicMessage(role="user", content="Continue please"),
+            ],
+        )
+
+        print("Action: Converting to Kiro payload...")
+        with patch(
+            "kiro.converters_anthropic.get_model_id_for_kiro",
+            return_value="claude-sonnet-4.5",
+        ):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
+                result = anthropic_to_kiro(request, "conv-123", "arn:aws:test")
+
+        print(f"Result: {result}")
+        history = result["conversationState"].get("history", [])
+
+        print("Checking history only contains user/assistant entries...")
+        for entry in history:
+            assert (
+                "userInputMessage" in entry or "assistantResponseMessage" in entry
+            ), f"Unexpected history entry keys: {list(entry.keys())}"
+
+        print("Checking system-role content survived as a user message...")
+        history_user_contents = [
+            entry["userInputMessage"]["content"]
+            for entry in history
+            if "userInputMessage" in entry
+        ]
+        assert any(
+            "Injected hook context" in content for content in history_user_contents
+        ), "System-role message content was lost during normalization"
+
     def test_includes_tools(self):
         """
         What it does: Verifies that tools are included in payload.

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -623,6 +623,101 @@ class TestAnthropicMessagesRequestWithImages:
 
 
 # ==================================================================================================
+# Tests for AnthropicMessage role acceptance
+# ==================================================================================================
+
+class TestAnthropicMessageRoleAcceptance:
+    """
+    Tests for AnthropicMessage role field accepting non-standard roles.
+
+    These tests verify the fix for Issue #190 / #226 - 422 Validation Error
+    when newer Claude Code clients inline role="system" messages in the
+    messages array (e.g. SessionStart hook context).
+
+    Before the fix, role was Literal["user", "assistant"], so Pydantic
+    rejected the request before normalize_message_roles() in
+    converters_core.py had a chance to coerce unknown roles to "user".
+    This mirrors the OpenAI path, where ChatMessage.role is already str.
+    """
+
+    def test_accepts_user_role(self):
+        """
+        What it does: Verifies AnthropicMessage still accepts role="user".
+        Purpose: Regression guard for the standard role.
+        """
+        print("Setup: Creating AnthropicMessage with role='user'...")
+        message = AnthropicMessage(role="user", content="Hello!")
+
+        print(f"Comparing role: Expected 'user', Got '{message.role}'")
+        assert message.role == "user"
+
+    def test_accepts_assistant_role(self):
+        """
+        What it does: Verifies AnthropicMessage still accepts role="assistant".
+        Purpose: Regression guard for the standard role.
+        """
+        print("Setup: Creating AnthropicMessage with role='assistant'...")
+        message = AnthropicMessage(role="assistant", content="Hi there!")
+
+        print(f"Comparing role: Expected 'assistant', Got '{message.role}'")
+        assert message.role == "assistant"
+
+    def test_accepts_system_role(self):
+        """
+        What it does: Verifies AnthropicMessage accepts role="system".
+        Purpose: This is the PRIMARY test for Issue #190 / #226 fix.
+
+        Before the fix, this raised a ValidationError:
+        "Input should be 'user' or 'assistant'".
+        """
+        print("Setup: Creating AnthropicMessage with role='system'...")
+        message = AnthropicMessage(
+            role="system",
+            content="<system-reminder>Injected hook context</system-reminder>"
+        )
+
+        print(f"Comparing role: Expected 'system', Got '{message.role}'")
+        assert message.role == "system"
+
+    def test_accepts_unknown_role(self):
+        """
+        What it does: Verifies AnthropicMessage accepts arbitrary roles
+        (e.g. "developer"), matching the OpenAI path where role is str.
+        Purpose: Handle the entire class of unknown-role issues, not just
+        "system" - normalize_message_roles() coerces them all downstream.
+        """
+        print("Setup: Creating AnthropicMessage with role='developer'...")
+        message = AnthropicMessage(role="developer", content="Context")
+
+        print(f"Comparing role: Expected 'developer', Got '{message.role}'")
+        assert message.role == "developer"
+
+    def test_request_with_inline_system_message_validates(self):
+        """
+        What it does: Verifies a full AnthropicMessagesRequest containing an
+        inline system-role message validates without a 422.
+        Purpose: Reproduces the exact Claude Code request shape from
+        Issue #190 / #226 (system message mid-conversation).
+        """
+        print("Setup: Request with inline system-role message...")
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-4-5",
+            max_tokens=1024,
+            system="You are a helpful assistant.",
+            messages=[
+                AnthropicMessage(role="user", content="Hello!"),
+                AnthropicMessage(role="assistant", content="Hi!"),
+                AnthropicMessage(role="system", content="Hook context update"),
+                AnthropicMessage(role="user", content="Continue please"),
+            ]
+        )
+
+        print(f"Result messages count: {len(request.messages)}")
+        assert len(request.messages) == 4
+        assert request.messages[2].role == "system"
+
+
+# ==================================================================================================
 # Tests for TextContentBlock
 # ==================================================================================================
 

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -337,26 +337,62 @@ class TestMessagesValidation:
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
     
-    def test_validates_invalid_role(self, test_client, valid_proxy_api_key):
+    def test_accepts_non_standard_role(self, test_client, valid_proxy_api_key):
         """
-        What it does: Verifies invalid message role is rejected.
-        Purpose: Anthropic model strictly validates role (only 'user' or 'assistant').
+        What it does: Verifies non-standard message roles pass validation.
+        Purpose: Fix for Issue #190 / #226 - unknown roles must NOT be
+        rejected with 422; normalize_message_roles() in converters_core.py
+        coerces them to 'user' downstream, matching the OpenAI path where
+        role is already str.
+
+        Note: This inverts the previous behavior (strict Literal validation),
+        which rejected requests before the gateway's own normalization logic
+        could run.
         """
-        print("Action: POST /v1/messages with invalid role...")
+        print("Action: POST /v1/messages with non-standard role...")
         response = test_client.post(
             "/v1/messages",
             headers={"x-api-key": valid_proxy_api_key},
             json={
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
-                "messages": [{"role": "invalid_role", "content": "Hello"}]
+                "messages": [{"role": "developer", "content": "Hello"}]
             }
         )
-        
+
         print(f"Status: {response.status_code}")
-        # Anthropic model strictly validates role - only 'user' or 'assistant' allowed
-        assert response.status_code == 422
-    
+        # Should pass validation (not 422) - normalized to 'user' downstream
+        assert response.status_code != 422
+
+    def test_accepts_inline_system_role_message(self, test_client, valid_proxy_api_key):
+        """
+        What it does: Verifies inline system-role messages pass validation.
+        Purpose: This is the PRIMARY route-level test for Issue #190 / #226.
+        Newer Claude Code clients inline role="system" hook context in the
+        messages array; before the fix this returned:
+        422 "Input should be 'user' or 'assistant'".
+        """
+        print("Action: POST /v1/messages with inline system-role message...")
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-4-5",
+                "max_tokens": 1024,
+                "system": "You are a helpful assistant.",
+                "messages": [
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi!"},
+                    {"role": "system", "content": "Injected hook context"},
+                    {"role": "user", "content": "Continue please"}
+                ]
+            }
+        )
+
+        print(f"Status: {response.status_code}")
+        # Should pass validation (not 422)
+        assert response.status_code != 422
+
     def test_accepts_valid_request_format(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies valid request format passes validation.


### PR DESCRIPTION
## What

Widens `AnthropicMessage.role` from `Literal["user", "assistant"]` to `str` in `kiro/models_anthropic.py`, so requests containing inline non-standard roles (e.g. `role: "system"` sent by newer Claude Code clients for SessionStart hook context) are accepted and handled by the gateway's existing normalization pipeline instead of being rejected with:

```
422 {"detail":[{"type":"literal_error","loc":["body","messages",N,"role"],"msg":"Input should be 'user' or 'assistant'", ...}]}
```

Fixes #190
Fixes #226

## Why this approach

- **The handling logic already exists** — `normalize_message_roles()` in `converters_core.py` (added for issue #64) coerces any non-user/assistant role to `user` before `ensure_alternating_roles()`. The strict `Literal` on the Anthropic model rejects the request *before* that logic can run. This PR removes the gate rather than adding a new mechanism, handling the entire class of unknown-role issues ("system", "developer", future roles), not just one value.
- **Consistency across both APIs** (per CONTRIBUTING.md): the OpenAI path already does exactly this — `ChatMessage.role` is `str` (`kiro/models_openai.py:78`), and `tests/unit/test_routes_openai.py::test_validates_invalid_role` already asserts unknown roles pass validation. This brings the Anthropic path into parity. Streaming and non-streaming share the same request model, so both modes are covered by one change.
- **Field-tested**: we've been running this exact patch locally in front of Claude Code (Sonnet 5 / Opus 4.8) since it started sending inline `system` messages; the 422s disappeared and conversations flow normally.

## Behavior change (intentional)

`tests/unit/test_routes_anthropic.py::TestMessagesValidation::test_validates_invalid_role` previously asserted unknown role → 422. That assertion enforced the bug, so it is replaced by `test_accepts_non_standard_role` (mirroring the existing OpenAI-side test of the same name and expectation).

## Test coverage

- `tests/unit/test_models_anthropic.py` — new `TestAnthropicMessageRoleAcceptance` (5 tests): user/assistant regression guards, `system` role (primary repro), arbitrary unknown role, and a full `AnthropicMessagesRequest` with an inline system message mid-conversation (exact Claude Code shape).
- `tests/unit/test_converters_anthropic.py` — new end-to-end test `test_inline_system_role_message_is_normalized`: converts a request with an inline system message via `anthropic_to_kiro()` and asserts the Kiro history contains only `userInputMessage`/`assistantResponseMessage` entries and the system content survives as a user message.
- `tests/unit/test_routes_anthropic.py` — route-level tests: `test_accepts_non_standard_role` and `test_accepts_inline_system_role_message` (no 422 at `/v1/messages`).

`pytest -q`: **1698 passed** (full unit + integration suite).

## Related PRs

I'm aware several open PRs address the same 422 (#191, #195, #197, #199, #205, #206, #207, #210, #234...). This one aims to be the minimal, test-covered variant that reuses the gateway's existing normalization rather than introducing new hoisting/merging logic — and it updates the route test that previously locked in the strict behavior. The merge-into-system approach discussed in #190 (comment by @W0n9) is a reasonable semantic refinement that could layer on top of this change later; happy to close this in favor of whichever direction the maintainer prefers.