### PR TITLE
fix(anthropic): normalize embedded system messages

### DIFF
--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -294,6 +294,67 @@ class SystemContentBlock(BaseModel):
 SystemPrompt = Union[str, List[SystemContentBlock], List[Dict[str, Any]]]
 
 
+def _promote_embedded_system_messages(data: Any) -> Any:
+    """Move Claude Code's embedded system messages to the system prompt.
+
+    Claude Code may insert runtime reminders into the ``messages`` array with
+    role ``system``. The Anthropic API only permits ``user`` and ``assistant``
+    there, so merge valid embedded system content into the top-level ``system``
+    field before normal request validation. Invalid content is deliberately
+    left untouched so Pydantic reports it instead of silently discarding it.
+
+    Args:
+        data: Raw request data supplied to the Pydantic model.
+
+    Returns:
+        Normalized request data, or the original value when normalization does
+        not apply.
+    """
+    if not isinstance(data, dict):
+        return data
+
+    messages = data.get("messages")
+    if not isinstance(messages, list):
+        return data
+
+    conversation_messages = []
+    embedded_system_blocks = []
+    promoted_message = False
+
+    for message in messages:
+        if not isinstance(message, dict) or message.get("role") != "system":
+            conversation_messages.append(message)
+            continue
+
+        content = message.get("content")
+        if isinstance(content, str):
+            embedded_system_blocks.append({"type": "text", "text": content})
+            promoted_message = True
+        elif isinstance(content, list):
+            embedded_system_blocks.extend(content)
+            promoted_message = True
+        else:
+            conversation_messages.append(message)
+
+    if not promoted_message:
+        return data
+
+    existing_system = data.get("system")
+    if existing_system is None:
+        system_blocks = []
+    elif isinstance(existing_system, str):
+        system_blocks = [{"type": "text", "text": existing_system}]
+    elif isinstance(existing_system, list):
+        system_blocks = list(existing_system)
+    else:
+        return data
+
+    normalized = dict(data)
+    normalized["messages"] = conversation_messages
+    normalized["system"] = system_blocks + embedded_system_blocks
+    return normalized
+
+
 class AnthropicMessagesRequest(BaseModel):
     """
     Request to Anthropic Messages API (/v1/messages).
@@ -337,6 +398,12 @@ class AnthropicMessagesRequest(BaseModel):
     stop_sequences: Optional[List[str]] = None
     metadata: Optional[Dict[str, Any]] = None
 
+    @model_validator(mode="before")
+    @classmethod
+    def promote_embedded_system_messages(cls, data: Any) -> Any:
+        """Normalize Claude Code runtime reminders before validation."""
+        return _promote_embedded_system_messages(data)
+
     model_config = {"extra": "allow"}
 
 
@@ -360,6 +427,12 @@ class AnthropicCountTokensRequest(BaseModel):
     # Optional parameters - only those that affect token count
     system: Optional[SystemPrompt] = None
     tools: Optional[List[AnthropicTool]] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def promote_embedded_system_messages(cls, data: Any) -> Any:
+        """Normalize Claude Code runtime reminders before validation."""
+        return _promote_embedded_system_messages(data)
     
     model_config = {"extra": "allow"}
 

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -38,6 +38,7 @@ from kiro.models_anthropic import (
     # Request models
     SystemContentBlock,
     AnthropicMessagesRequest,
+    AnthropicCountTokensRequest,
     # Response models
     AnthropicUsage,
     AnthropicMessagesResponse,
@@ -527,6 +528,151 @@ class TestAnthropicMessageWithImages:
 # ==================================================================================================
 # Tests for AnthropicMessagesRequest with Image Content
 # ==================================================================================================
+
+class TestEmbeddedSystemMessageNormalization:
+    """Tests for clients that place system instructions in messages[]."""
+
+    def test_promotes_string_content_after_existing_string_system(self):
+        """
+        What it does: Promotes an embedded string system message after a top-level string.
+        Purpose: Preserve both instruction sources in deterministic order.
+        """
+        print("Action: Validating request with string system sources...")
+        request = AnthropicMessagesRequest.model_validate({
+            "model": "claude-sonnet-5",
+            "max_tokens": 1024,
+            "system": "base system",
+            "messages": [
+                {"role": "user", "content": "ping"},
+                {"role": "system", "content": "runtime system"},
+            ],
+        })
+
+        print("Verifying system ordering and conversation roles...")
+        assert [message.role for message in request.messages] == ["user"]
+        assert [block.text for block in request.system] == ["base system", "runtime system"]
+
+    def test_promotes_multiple_block_messages_and_preserves_cache_control(self):
+        """
+        What it does: Promotes multiple embedded block-list system messages.
+        Purpose: Preserve ordering, extra fields, and prompt-cache metadata.
+        """
+        print("Action: Validating multiple embedded system messages...")
+        request = AnthropicMessagesRequest.model_validate({
+            "model": "claude-sonnet-5",
+            "max_tokens": 1024,
+            "system": [{"type": "text", "text": "base system"}],
+            "messages": [
+                {"role": "user", "content": "first"},
+                {
+                    "role": "system",
+                    "content": [{
+                        "type": "text",
+                        "text": "runtime one",
+                        "cache_control": {"type": "ephemeral"},
+                    }],
+                },
+                {"role": "assistant", "content": "second"},
+                {"role": "system", "content": [{"type": "text", "text": "runtime two"}]},
+            ],
+        })
+
+        system_blocks = [block.model_dump() for block in request.system]
+        print("Verifying promoted content and cache metadata...")
+        assert [message.role for message in request.messages] == ["user", "assistant"]
+        assert [block["text"] for block in system_blocks] == [
+            "base system",
+            "runtime one",
+            "runtime two",
+        ]
+        assert system_blocks[1]["cache_control"] == {"type": "ephemeral"}
+
+    def test_removes_empty_embedded_system_block_list(self):
+        """
+        What it does: Removes an embedded system message with an empty block list.
+        Purpose: Avoid leaving a role that fails conversation-role validation.
+        """
+        print("Action: Validating an empty embedded system block list...")
+        request = AnthropicMessagesRequest.model_validate({
+            "model": "claude-sonnet-5",
+            "max_tokens": 1024,
+            "messages": [
+                {"role": "user", "content": "ping"},
+                {"role": "system", "content": []},
+            ],
+        })
+
+        print("Verifying empty system message is removed without inventing content...")
+        assert [message.role for message in request.messages] == ["user"]
+        assert request.system == []
+
+    def test_rejects_embedded_system_message_with_invalid_content(self):
+        """
+        What it does: Rejects embedded system content that is neither text nor blocks.
+        Purpose: Prevent compatibility normalization from silently dropping invalid content.
+        """
+        print("Action: Validating invalid embedded system content...")
+        with pytest.raises(ValidationError):
+            AnthropicMessagesRequest.model_validate({
+                "model": "claude-sonnet-5",
+                "max_tokens": 1024,
+                "messages": [
+                    {"role": "user", "content": "ping"},
+                    {"role": "system", "content": 42},
+                ],
+            })
+
+    def test_rejects_request_when_normalization_leaves_no_conversation_messages(self):
+        """
+        What it does: Rejects a request containing only embedded system messages.
+        Purpose: Preserve the API requirement for at least one conversation message.
+        """
+        print("Action: Validating a system-only messages list...")
+        with pytest.raises(ValidationError) as exc_info:
+            AnthropicMessagesRequest.model_validate({
+                "model": "claude-sonnet-5",
+                "max_tokens": 1024,
+                "messages": [{"role": "system", "content": "runtime system"}],
+            })
+
+        print("Verifying messages min-length validation still applies...")
+        assert "messages" in str(exc_info.value)
+
+    def test_leaves_standard_request_unchanged(self):
+        """
+        What it does: Validates a standard Anthropic request without embedded systems.
+        Purpose: Prevent normalization from changing compliant requests.
+        """
+        print("Action: Validating a standard request...")
+        request = AnthropicMessagesRequest.model_validate({
+            "model": "claude-sonnet-5",
+            "max_tokens": 1024,
+            "system": "base system",
+            "messages": [{"role": "user", "content": "ping"}],
+        })
+
+        print("Verifying standard field representations are unchanged...")
+        assert request.system == "base system"
+        assert [message.role for message in request.messages] == ["user"]
+
+    def test_count_tokens_request_promotes_embedded_system_message(self):
+        """
+        What it does: Normalizes embedded system content for token-count requests.
+        Purpose: Keep /v1/messages and /v1/messages/count_tokens compatible.
+        """
+        print("Action: Validating token-count request with embedded system content...")
+        request = AnthropicCountTokensRequest.model_validate({
+            "model": "claude-sonnet-5",
+            "messages": [
+                {"role": "user", "content": "ping"},
+                {"role": "system", "content": "runtime system"},
+            ],
+        })
+
+        print("Verifying token-count request normalization...")
+        assert [message.role for message in request.messages] == ["user"]
+        assert [block.text for block in request.system] == ["runtime system"]
+
 
 class TestAnthropicMessagesRequestWithImages:
     """Tests for full AnthropicMessagesRequest with image content."""

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -384,6 +384,38 @@ class TestMessagesValidation:
 
 class TestMessagesSystemPrompt:
     """Tests for system prompt handling on /v1/messages endpoint."""
+
+    def test_accepts_embedded_system_message_from_claude_code(
+        self, test_client, valid_proxy_api_key
+    ):
+        """
+        What it does: Accepts Claude Code runtime instructions in messages[].
+        Purpose: Prevent request validation from returning HTTP 422 before conversion.
+        """
+        print("Action: POST /v1/messages with an embedded system message...")
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-5",
+                "max_tokens": 1024,
+                "system": [{"type": "text", "text": "base system"}],
+                "messages": [
+                    {"role": "user", "content": "ping"},
+                    {
+                        "role": "system",
+                        "content": [{
+                            "type": "text",
+                            "text": "runtime system",
+                            "cache_control": {"type": "ephemeral"},
+                        }],
+                    },
+                ],
+            },
+        )
+
+        print(f"Status: {response.status_code}")
+        assert response.status_code == 200
     
     def test_accepts_system_as_separate_field(self, test_client, valid_proxy_api_key):
         """


### PR DESCRIPTION
## Summary

- normalize Claude Code runtime `system` entries embedded in `messages[]`
- preserve their content and cache-control metadata in the top-level `system` prompt
- apply the same normalization to message generation and token-count requests
- add model and route regression coverage

## Testing

- `pytest -q` (`1699 passed`)

Closes #255
