### PR TITLE
fix(anthropic): continue after emulated web search

### DIFF
--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -30,6 +30,7 @@ from loguru import logger
 
 from kiro.config import HIDDEN_MODELS
 from kiro.model_resolver import get_model_id_for_kiro
+from kiro.mcp_tools import generate_search_summary
 from kiro.models_anthropic import (
     AnthropicMessagesRequest,
     AnthropicMessage,
@@ -162,6 +163,84 @@ def extract_tool_results_from_anthropic_content(content: Any) -> List[Dict[str, 
     return tool_results
 
 
+def extract_server_web_search_results_from_anthropic_content(
+    content: Any,
+) -> List[Dict[str, Any]]:
+    """Convert Anthropic server WebSearch result blocks to unified tool results."""
+    if not isinstance(content, list):
+        return []
+
+    search_queries: Dict[str, str] = {}
+    for block in content:
+        if isinstance(block, dict):
+            block_type = block.get("type")
+            tool_id = block.get("id")
+            tool_name = block.get("name")
+            tool_input = block.get("input", {})
+        else:
+            block_type = getattr(block, "type", None)
+            tool_id = getattr(block, "id", None)
+            tool_name = getattr(block, "name", None)
+            tool_input = getattr(block, "input", {})
+
+        if (
+            block_type == "server_tool_use"
+            and tool_name == "web_search"
+            and tool_id
+        ):
+            search_queries[tool_id] = (
+                tool_input.get("query", "") if isinstance(tool_input, dict) else ""
+            )
+
+    tool_results = []
+    for block in content:
+        if isinstance(block, dict):
+            block_type = block.get("type")
+            tool_use_id = block.get("tool_use_id")
+            result_content = block.get("content")
+        else:
+            block_type = getattr(block, "type", None)
+            tool_use_id = getattr(block, "tool_use_id", None)
+            result_content = getattr(block, "content", None)
+
+        if block_type != "web_search_tool_result" or not tool_use_id:
+            continue
+
+        if isinstance(result_content, list):
+            search_results = []
+            for item in result_content:
+                if isinstance(item, dict):
+                    search_results.append({
+                        "title": item.get("title", ""),
+                        "url": item.get("url", ""),
+                        "snippet": item.get("encrypted_content", ""),
+                    })
+                else:
+                    search_results.append({
+                        "title": getattr(item, "title", ""),
+                        "url": getattr(item, "url", ""),
+                        "snippet": getattr(item, "encrypted_content", ""),
+                    })
+            result_text = generate_search_summary(
+                search_queries.get(tool_use_id, ""),
+                {"results": search_results},
+            )
+        else:
+            if isinstance(result_content, dict):
+                error_code = result_content.get("error_code", "unknown")
+            else:
+                error_code = getattr(result_content, "error_code", "unknown")
+            result_text = f"Web search failed: {error_code}"
+
+        tool_results.append({
+            "type": "tool_result",
+            "tool_use_id": tool_use_id,
+            "content": result_text,
+        })
+
+    return tool_results
+
+
 def extract_images_from_tool_results(content: Any) -> List[Dict[str, Any]]:
     """
     Extracts images from tool_result content blocks.
@@ -238,7 +317,11 @@ def extract_tool_uses_from_anthropic_content(content: Any) -> List[Dict[str, Any
             tool_name = getattr(block, "name", None)
             tool_input = getattr(block, "input", {})
 
-        if block_type == "tool_use" and tool_id and tool_name:
+        if (
+            block_type in {"tool_use", "server_tool_use"}
+            and tool_id
+            and tool_name
+        ):
             tool_calls.append(
                 {
                     "id": tool_id,
@@ -277,6 +360,7 @@ def convert_anthropic_messages(
     total_tool_calls = 0
     total_tool_results = 0
     total_images = 0
+    pending_server_tool_results: List[Dict[str, Any]] = []
 
     for msg in messages:
         role = msg.role
@@ -295,10 +379,18 @@ def convert_anthropic_messages(
             tool_calls = extract_tool_uses_from_anthropic_content(content)
             if tool_calls:
                 total_tool_calls += len(tool_calls)
+            server_tool_results = (
+                extract_server_web_search_results_from_anthropic_content(content)
+            )
+            if server_tool_results:
+                pending_server_tool_results.extend(server_tool_results)
 
         elif role == "user":
             # User messages may contain tool_result blocks and images
             tool_results = extract_tool_results_from_anthropic_content(content)
+            if pending_server_tool_results:
+                tool_results = pending_server_tool_results + tool_results
+                pending_server_tool_results = []
             if tool_results:
                 total_tool_results += len(tool_results)
 
@@ -325,6 +417,14 @@ def convert_anthropic_messages(
             images=images if images else None,
         )
         unified_messages.append(unified_msg)
+
+    if pending_server_tool_results:
+        unified_messages.append(UnifiedMessage(
+            role="user",
+            content="",
+            tool_results=pending_server_tool_results,
+        ))
+        total_tool_results += len(pending_server_tool_results)
 
     # Log summary if any tool content or images were found
     if total_tool_calls > 0 or total_tool_results > 0 or total_images > 0:

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -162,6 +162,48 @@ class ImageContentBlock(BaseModel):
     source: Union[Base64ImageSource, URLImageSource]
 
 
+class ServerToolUseContentBlock(BaseModel):
+    """Anthropic server-executed tool call returned in assistant history."""
+
+    type: Literal["server_tool_use"] = "server_tool_use"
+    id: str
+    name: str
+    input: Dict[str, Any]
+
+    model_config = {"extra": "allow"}
+
+
+class WebSearchResultBlock(BaseModel):
+    """One result nested inside an Anthropic web-search tool result."""
+
+    type: Literal["web_search_result"] = "web_search_result"
+    title: str
+    url: str
+    encrypted_content: str
+    page_age: Optional[str] = None
+
+    model_config = {"extra": "allow"}
+
+
+class WebSearchToolResultErrorContentBlock(BaseModel):
+    """Error returned by Anthropic-compatible server-side web search."""
+
+    type: Literal["web_search_tool_result_error"] = "web_search_tool_result_error"
+    error_code: str
+
+    model_config = {"extra": "allow"}
+
+
+class WebSearchToolResultContentBlock(BaseModel):
+    """Completed Anthropic web-search result returned in assistant history."""
+
+    type: Literal["web_search_tool_result"] = "web_search_tool_result"
+    tool_use_id: str
+    content: Union[List[WebSearchResultBlock], WebSearchToolResultErrorContentBlock]
+
+    model_config = {"extra": "allow"}
+
+
 # Union type for all content blocks (including images and thinking)
 ContentBlock = Union[
     TextContentBlock,
@@ -170,6 +212,8 @@ ContentBlock = Union[
     ToolUseContentBlock,
     ToolResultContentBlock,
     ToolReferenceContentBlock,
+    ServerToolUseContentBlock,
+    WebSearchToolResultContentBlock,
 ]
 
 

--- a/kiro/routes_anthropic.py
+++ b/kiro/routes_anthropic.py
@@ -26,7 +26,7 @@ Reference: https://docs.anthropic.com/en/api/messages
 """
 
 import json
-from typing import Optional
+from typing import List, Optional
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, Security, Header
@@ -41,6 +41,7 @@ from kiro.models_anthropic import (
     AnthropicMessagesResponse,
     AnthropicErrorResponse,
     AnthropicErrorDetail,
+    AnthropicMessage,
 )
 from kiro.auth import KiroAuthManager, AuthType
 from kiro.cache import ModelInfoCache
@@ -49,12 +50,14 @@ from kiro.streaming_anthropic import (
     stream_kiro_to_anthropic,
     collect_anthropic_response,
     stream_with_first_token_retry_anthropic,
+    WebSearchContinuation,
+    WebSearchContinuationItem,
 )
 from kiro.http_client import KiroHttpClient
 from kiro.utils import generate_conversation_id
 from kiro.tokenizer import estimate_request_tokens
 from kiro.config import WEB_SEARCH_ENABLED
-from kiro.mcp_tools import handle_native_web_search
+from kiro.mcp_tools import generate_search_summary, handle_native_web_search
 
 # Import debug_logger
 try:
@@ -68,6 +71,76 @@ except ImportError:
 anthropic_api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
 # Also support Authorization: Bearer for compatibility
 auth_header = APIKeyHeader(name="Authorization", auto_error=False)
+
+
+def _create_web_search_continuation(
+    request_data: AnthropicMessagesRequest,
+    http_client: KiroHttpClient,
+    url: str,
+    conversation_id: str,
+    profile_arn: str,
+) -> WebSearchContinuation:
+    """Create a stateful callback that feeds server search results back to Kiro."""
+    history = [message.model_copy(deep=True) for message in request_data.messages]
+
+    async def continue_after_web_search(
+        assistant_text: str,
+        searches: List[WebSearchContinuationItem],
+        allow_more_search: bool,
+    ) -> httpx.Response:
+        assistant_content = []
+        if assistant_text:
+            assistant_content.append({"type": "text", "text": assistant_text})
+        assistant_content.extend(
+            {
+                "type": "tool_use",
+                "id": search["tool_use_id"],
+                "name": "web_search",
+                "input": {"query": search["query"]},
+            }
+            for search in searches
+        )
+        result_content = [
+            {
+                "type": "tool_result",
+                "tool_use_id": search["tool_use_id"],
+                "content": generate_search_summary(search["query"], search["results"]),
+            }
+            for search in searches
+        ]
+
+        history.extend([
+            AnthropicMessage.model_validate({
+                "role": "assistant",
+                "content": assistant_content,
+            }),
+            AnthropicMessage.model_validate({
+                "role": "user",
+                "content": result_content,
+            }),
+        ])
+
+        continuation_request = request_data.model_copy(deep=True)
+        continuation_request.messages = list(history)
+        if not allow_more_search and continuation_request.tools:
+            continuation_request.tools = [
+                tool for tool in continuation_request.tools
+                if tool.name != "web_search"
+            ]
+
+        payload = anthropic_to_kiro(
+            continuation_request,
+            conversation_id,
+            profile_arn,
+        )
+        return await http_client.request_with_retry(
+            "POST",
+            url,
+            payload,
+            stream=True,
+        )
+
+    return continue_after_web_search
 
 
 async def verify_anthropic_api_key(
@@ -423,6 +496,14 @@ async def messages(
                 system_for_tokenizer = [b.model_dump() if hasattr(b, "model_dump") else b for b in request_data.system]
             else:
                 system_for_tokenizer = request_data.system
+
+            web_search_continuation = _create_web_search_continuation(
+                request_data=request_data,
+                http_client=http_client,
+                url=url,
+                conversation_id=conversation_id,
+                profile_arn=profile_arn_for_payload,
+            )
             
             try:
                 # Make request to Kiro API
@@ -457,6 +538,7 @@ async def messages(
                                     request_messages=messages_for_tokenizer,
                                     request_tools=tools_for_tokenizer,
                                     request_system=system_for_tokenizer,
+                                    web_search_continuation=web_search_continuation,
                                 ):
                                     yield chunk
                             except GeneratorExit:
@@ -738,6 +820,14 @@ async def messages(
         system_for_tokenizer = [b.model_dump() if hasattr(b, "model_dump") else b for b in request_data.system]
     else:
         system_for_tokenizer = request_data.system
+
+    web_search_continuation = _create_web_search_continuation(
+        request_data=request_data,
+        http_client=http_client,
+        url=url,
+        conversation_id=conversation_id,
+        profile_arn=profile_arn_for_payload,
+    )
     
     try:
         # Make request to Kiro API (for both streaming and non-streaming modes)
@@ -815,6 +905,7 @@ async def messages(
                         request_messages=messages_for_tokenizer,
                         request_tools=tools_for_tokenizer,
                         request_system=system_for_tokenizer,
+                        web_search_continuation=web_search_continuation,
                     ):
                         yield chunk
                 except GeneratorExit:

--- a/kiro/streaming_anthropic.py
+++ b/kiro/streaming_anthropic.py
@@ -34,7 +34,17 @@ Reference: https://docs.anthropic.com/en/api/messages-streaming
 import json
 import time
 import uuid
-from typing import TYPE_CHECKING, AsyncGenerator, Dict, List, Optional, Any
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncGenerator,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    TypedDict,
+)
 
 import httpx
 from loguru import logger
@@ -54,6 +64,20 @@ from kiro.config import FIRST_TOKEN_TIMEOUT, FIRST_TOKEN_MAX_RETRIES, FAKE_REASO
 if TYPE_CHECKING:
     from kiro.auth import KiroAuthManager
     from kiro.cache import ModelInfoCache
+
+
+class WebSearchContinuationItem(TypedDict):
+    """One completed web search passed back to Kiro for continuation."""
+
+    tool_use_id: str
+    query: str
+    results: Dict[str, Any]
+
+
+WebSearchContinuation = Callable[
+    [str, List[WebSearchContinuationItem], bool],
+    Awaitable[httpx.Response],
+]
 
 # Import debug_logger for logging
 try:
@@ -135,7 +159,9 @@ async def stream_kiro_to_anthropic(
     request_messages: Optional[list] = None,
     request_tools: Optional[list] = None,
     request_system: Optional[Any] = None,
-    conversation_id: Optional[str] = None
+    conversation_id: Optional[str] = None,
+    web_search_continuation: Optional[WebSearchContinuation] = None,
+    max_web_search_rounds: int = 5,
 ) -> AsyncGenerator[str, None]:
     """
     Generator for converting Kiro stream to Anthropic SSE format.
@@ -153,6 +179,8 @@ async def stream_kiro_to_anthropic(
         request_tools: Original request tools (for token counting)
         request_system: Original system prompt (for token counting)
         conversation_id: Stable conversation ID for truncation recovery (optional)
+        web_search_continuation: Callback that sends completed search results back to Kiro
+        max_web_search_rounds: Maximum internal search continuation rounds
     
     Yields:
         Strings in Anthropic SSE format
@@ -200,6 +228,7 @@ async def stream_kiro_to_anthropic(
     
     # Track truncated tool calls for recovery
     truncated_tools: List[Dict[str, Any]] = []
+    pending_searches: List[WebSearchContinuationItem] = []
     
     try:
         # Send message_start event
@@ -439,30 +468,11 @@ async def stream_kiro_to_anthropic(
                         })
                         current_block_index += 1
                         
-                        # Event: content_block_start (text)
-                        yield format_sse_event("content_block_start", {
-                            "type": "content_block_start",
-                            "index": current_block_index,
-                            "content_block": {"type": "text", "text": ""}
+                        pending_searches.append({
+                            "tool_use_id": tool_id,
+                            "query": query,
+                            "results": results,
                         })
-                        
-                        # Events: content_block_delta (text_delta) - stream summary
-                        summary = generate_search_summary(query, results)
-                        chunk_size = 100
-                        for i in range(0, len(summary), chunk_size):
-                            chunk = summary[i:i + chunk_size]
-                            yield format_sse_event("content_block_delta", {
-                                "type": "content_block_delta",
-                                "index": current_block_index,
-                                "delta": {"type": "text_delta", "text": chunk}
-                            })
-                        
-                        # Event: content_block_stop (text)
-                        yield format_sse_event("content_block_stop", {
-                            "type": "content_block_stop",
-                            "index": current_block_index
-                        })
-                        current_block_index += 1
                         
                         # Skip normal tool_use processing
                         continue
@@ -522,6 +532,286 @@ async def stream_kiro_to_anthropic(
                 context_usage_percentage = event.context_usage_percentage
             elif event.type == "usage" and event.usage:
                 upstream_cache_usage.update(_extract_cache_usage_fields(event.usage))
+
+        if pending_searches and not tool_blocks:
+            from kiro.mcp_tools import call_kiro_mcp_api, generate_search_summary
+
+            searches_for_continuation = pending_searches
+            assistant_text_for_continuation = full_content
+            search_round = 0
+            search_round_limit = max(1, max_web_search_rounds)
+
+            while searches_for_continuation and not tool_blocks:
+                continuation_failed = web_search_continuation is None
+                continuation_response: Optional[httpx.Response] = None
+
+                if web_search_continuation is not None:
+                    try:
+                        search_round += 1
+                        continuation_response = await web_search_continuation(
+                            assistant_text_for_continuation,
+                            searches_for_continuation,
+                            search_round < search_round_limit,
+                        )
+                        if continuation_response.status_code != 200:
+                            raise RuntimeError(
+                                f"Web search continuation returned HTTP "
+                                f"{continuation_response.status_code}"
+                            )
+
+                        continuation_result = await collect_stream_to_result(
+                            continuation_response
+                        )
+                        continuation_failed = False
+                        context_usage_percentage = (
+                            continuation_result.context_usage_percentage
+                        )
+                        upstream_cache_usage.update(
+                            _extract_cache_usage_fields(continuation_result.usage)
+                        )
+
+                        continuation_thinking = (
+                            continuation_result.thinking_content or ""
+                        )
+                        continuation_text = continuation_result.content or ""
+                        full_thinking_content += continuation_thinking
+                        full_content += continuation_text
+
+                        if (
+                            continuation_thinking
+                            and FAKE_REASONING_HANDLING == "as_reasoning_content"
+                        ):
+                            thinking_block_index = current_block_index
+                            yield format_sse_event("content_block_start", {
+                                "type": "content_block_start",
+                                "index": thinking_block_index,
+                                "content_block": {
+                                    "type": "thinking",
+                                    "thinking": "",
+                                    "signature": thinking_signature,
+                                },
+                            })
+                            yield format_sse_event("content_block_delta", {
+                                "type": "content_block_delta",
+                                "index": thinking_block_index,
+                                "delta": {
+                                    "type": "thinking_delta",
+                                    "thinking": continuation_thinking,
+                                },
+                            })
+                            thinking_block_started = True
+                        elif (
+                            continuation_thinking
+                            and FAKE_REASONING_HANDLING == "include_as_text"
+                        ):
+                            continuation_text = continuation_thinking + continuation_text
+
+                        if continuation_text:
+                            if thinking_block_started and thinking_block_index is not None:
+                                yield format_sse_event("content_block_stop", {
+                                    "type": "content_block_stop",
+                                    "index": thinking_block_index,
+                                })
+                                thinking_block_started = False
+                                current_block_index += 1
+
+                            text_block_index = current_block_index
+                            yield format_sse_event("content_block_start", {
+                                "type": "content_block_start",
+                                "index": text_block_index,
+                                "content_block": {"type": "text", "text": ""},
+                            })
+                            yield format_sse_event("content_block_delta", {
+                                "type": "content_block_delta",
+                                "index": text_block_index,
+                                "delta": {
+                                    "type": "text_delta",
+                                    "text": continuation_text,
+                                },
+                            })
+                            text_block_started = True
+
+                        next_searches: List[WebSearchContinuationItem] = []
+                        for tool_call in continuation_result.tool_calls:
+                            if text_block_started and text_block_index is not None:
+                                yield format_sse_event("content_block_stop", {
+                                    "type": "content_block_stop",
+                                    "index": text_block_index,
+                                })
+                                text_block_started = False
+                                current_block_index += 1
+                            if thinking_block_started and thinking_block_index is not None:
+                                yield format_sse_event("content_block_stop", {
+                                    "type": "content_block_stop",
+                                    "index": thinking_block_index,
+                                })
+                                thinking_block_started = False
+                                current_block_index += 1
+
+                            continuation_tool_id = (
+                                tool_call.get("id")
+                                or f"toolu_{uuid.uuid4().hex[:24]}"
+                            )
+                            continuation_tool_name = (
+                                tool_call.get("function", {}).get("name", "")
+                                or tool_call.get("name", "")
+                            )
+                            continuation_tool_input = (
+                                tool_call.get("function", {}).get("arguments", {})
+                                or tool_call.get("input", {})
+                            )
+                            if isinstance(continuation_tool_input, str):
+                                try:
+                                    continuation_tool_input = json.loads(
+                                        continuation_tool_input
+                                    )
+                                except json.JSONDecodeError:
+                                    continuation_tool_input = {}
+
+                            if (
+                                continuation_tool_name == "web_search"
+                                and search_round < search_round_limit
+                            ):
+                                query = continuation_tool_input.get("query", "")
+                                if query:
+                                    mcp_tool_use_id, results = await call_kiro_mcp_api(
+                                        query, auth_manager
+                                    )
+                                    if results is not None:
+                                        yield format_sse_event("content_block_start", {
+                                            "type": "content_block_start",
+                                            "index": current_block_index,
+                                            "content_block": {
+                                                "id": mcp_tool_use_id,
+                                                "type": "server_tool_use",
+                                                "name": "web_search",
+                                                "input": {},
+                                            },
+                                        })
+                                        yield format_sse_event("content_block_delta", {
+                                            "type": "content_block_delta",
+                                            "index": current_block_index,
+                                            "delta": {
+                                                "type": "input_json_delta",
+                                                "partial_json": json.dumps({"query": query}),
+                                            },
+                                        })
+                                        yield format_sse_event("content_block_stop", {
+                                            "type": "content_block_stop",
+                                            "index": current_block_index,
+                                        })
+                                        current_block_index += 1
+
+                                        search_content = [
+                                            {
+                                                "type": "web_search_result",
+                                                "title": result.get("title", ""),
+                                                "url": result.get("url", ""),
+                                                "encrypted_content": result.get("snippet", ""),
+                                                "page_age": None,
+                                            }
+                                            for result in results.get("results", [])
+                                        ]
+                                        yield format_sse_event("content_block_start", {
+                                            "type": "content_block_start",
+                                            "index": current_block_index,
+                                            "content_block": {
+                                                "type": "web_search_tool_result",
+                                                "tool_use_id": mcp_tool_use_id,
+                                                "content": search_content,
+                                            },
+                                        })
+                                        yield format_sse_event("content_block_stop", {
+                                            "type": "content_block_stop",
+                                            "index": current_block_index,
+                                        })
+                                        current_block_index += 1
+                                        next_searches.append({
+                                            "tool_use_id": continuation_tool_id,
+                                            "query": query,
+                                            "results": results,
+                                        })
+                                        continue
+
+                            if (
+                                continuation_tool_name == "web_search"
+                                and search_round >= search_round_limit
+                            ):
+                                logger.warning(
+                                    "Web search round limit reached; ignoring additional "
+                                    "model search request"
+                                )
+                                continue
+
+                            yield format_sse_event("content_block_start", {
+                                "type": "content_block_start",
+                                "index": current_block_index,
+                                "content_block": {
+                                    "type": "tool_use",
+                                    "id": continuation_tool_id,
+                                    "name": continuation_tool_name,
+                                    "input": {},
+                                },
+                            })
+                            yield format_sse_event("content_block_delta", {
+                                "type": "content_block_delta",
+                                "index": current_block_index,
+                                "delta": {
+                                    "type": "input_json_delta",
+                                    "partial_json": json.dumps(
+                                        continuation_tool_input,
+                                        ensure_ascii=False,
+                                    ),
+                                },
+                            })
+                            yield format_sse_event("content_block_stop", {
+                                "type": "content_block_stop",
+                                "index": current_block_index,
+                            })
+                            tool_blocks.append({
+                                "id": continuation_tool_id,
+                                "name": continuation_tool_name,
+                                "input": continuation_tool_input,
+                            })
+                            current_block_index += 1
+
+                        assistant_text_for_continuation = continuation_text
+                        searches_for_continuation = next_searches
+                    except Exception as continuation_error:
+                        continuation_failed = True
+                        logger.error(
+                            f"Web search model continuation failed: {continuation_error}"
+                        )
+                    finally:
+                        if continuation_response is not None:
+                            try:
+                                await continuation_response.aclose()
+                            except Exception as close_error:
+                                logger.debug(
+                                    "Error closing web search continuation response: "
+                                    f"{close_error}"
+                                )
+
+                if continuation_failed:
+                    for search in searches_for_continuation:
+                        summary = generate_search_summary(
+                            search["query"], search["results"]
+                        )
+                        full_content += summary
+                        if not text_block_started:
+                            text_block_index = current_block_index
+                            yield format_sse_event("content_block_start", {
+                                "type": "content_block_start",
+                                "index": text_block_index,
+                                "content_block": {"type": "text", "text": ""},
+                            })
+                            text_block_started = True
+                        yield format_sse_event("content_block_delta", {
+                            "type": "content_block_delta",
+                            "index": text_block_index,
+                            "delta": {"type": "text_delta", "text": summary},
+                        })
+                    break
         
         # Track completion signals for truncation detection
         stream_completed_normally = context_usage_percentage is not None
@@ -873,7 +1163,8 @@ async def stream_with_first_token_retry_anthropic(
     first_token_timeout: float = FIRST_TOKEN_TIMEOUT,
     request_messages: Optional[list] = None,
     request_tools: Optional[list] = None,
-    request_system: Optional[Any] = None
+    request_system: Optional[Any] = None,
+    web_search_continuation: Optional[WebSearchContinuation] = None,
 ) -> AsyncGenerator[str, None]:
     """
     Streaming with automatic retry on first token timeout for Anthropic API.
@@ -896,6 +1187,7 @@ async def stream_with_first_token_retry_anthropic(
         request_messages: Original request messages (for fallback token counting)
         request_tools: Original request tools (for fallback token counting)
         request_system: Original system prompt (for fallback token counting)
+        web_search_continuation: Callback for model continuation after web search
     
     Yields:
         Strings in Anthropic SSE format
@@ -934,6 +1226,7 @@ async def stream_with_first_token_retry_anthropic(
             request_messages=request_messages,
             request_tools=request_tools,
             request_system=request_system,
+            web_search_continuation=web_search_continuation,
         ):
             yield chunk
     

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -1064,6 +1064,60 @@ class TestConvertAnthropicMessages:
         assert len(result[0].tool_results) == 1
         assert result[0].tool_results[0]["tool_use_id"] == "call_123"
 
+    def test_preserves_server_search_result_with_mixed_client_tool_history(self):
+        """Server search results join the following user tool results for Kiro history."""
+        messages = [
+            AnthropicMessage.model_validate({
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "server_tool_use",
+                        "id": "srvtoolu_search",
+                        "name": "web_search",
+                        "input": {"query": "synthetic query"},
+                    },
+                    {
+                        "type": "web_search_tool_result",
+                        "tool_use_id": "srvtoolu_search",
+                        "content": [{
+                            "type": "web_search_result",
+                            "title": "Synthetic result",
+                            "url": "https://example.com/result",
+                            "encrypted_content": "Synthetic result text.",
+                            "page_age": None,
+                        }],
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_client",
+                        "name": "read_file",
+                        "input": {"path": "example.txt"},
+                    },
+                ],
+            }),
+            AnthropicMessage.model_validate({
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_client",
+                    "content": "Synthetic file content.",
+                }],
+            }),
+        ]
+
+        result = convert_anthropic_messages(messages)
+
+        assert [call["function"]["name"] for call in result[0].tool_calls] == [
+            "web_search",
+            "read_file",
+        ]
+        assert [item["tool_use_id"] for item in result[1].tool_results] == [
+            "srvtoolu_search",
+            "toolu_client",
+        ]
+        assert "synthetic query" in result[1].tool_results[0]["content"]
+        assert "Synthetic result text." in result[1].tool_results[0]["content"]
+
     def test_converts_full_conversation(self):
         """
         What it does: Verifies conversion of full conversation.
@@ -1636,6 +1690,88 @@ class TestAnthropicToKiro:
         tool_results = context.get("toolResults", [])
         print(f"Tool results: {tool_results}")
         assert len(tool_results) == 1
+
+    def test_builds_mixed_server_search_and_client_tool_history(self):
+        """Kiro receives both the completed server search and client tool result."""
+        request = AnthropicMessagesRequest.model_validate({
+            "model": "claude-sonnet-5",
+            "max_tokens": 1024,
+            "messages": [
+                {"role": "user", "content": "Complete a synthetic task."},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "server_tool_use",
+                            "id": "srvtoolu_search",
+                            "name": "web_search",
+                            "input": {"query": "synthetic query"},
+                        },
+                        {
+                            "type": "web_search_tool_result",
+                            "tool_use_id": "srvtoolu_search",
+                            "content": [{
+                                "type": "web_search_result",
+                                "title": "Synthetic result",
+                                "url": "https://example.com/result",
+                                "encrypted_content": "Synthetic result text.",
+                                "page_age": None,
+                            }],
+                        },
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_client",
+                            "name": "read_file",
+                            "input": {"path": "example.txt"},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [{
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_client",
+                        "content": "Synthetic file content.",
+                    }],
+                },
+            ],
+            "tools": [
+                {
+                    "name": "web_search",
+                    "description": "Search the web.",
+                    "input_schema": {"type": "object", "properties": {}},
+                },
+                {
+                    "name": "read_file",
+                    "description": "Read a file.",
+                    "input_schema": {"type": "object", "properties": {}},
+                },
+            ],
+        })
+
+        with (
+            patch(
+                "kiro.converters_anthropic.get_model_id_for_kiro",
+                return_value="claude-sonnet-5",
+            ),
+            patch("kiro.converters_core.FAKE_REASONING_ENABLED", False),
+        ):
+            result = anthropic_to_kiro(request, "conv-123", "arn:aws:test")
+
+        assistant = result["conversationState"]["history"][1][
+            "assistantResponseMessage"
+        ]
+        current_user = result["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]
+        assert [item["name"] for item in assistant["toolUses"]] == [
+            "web_search",
+            "read_file",
+        ]
+        assert [
+            item["toolUseId"]
+            for item in current_user["userInputMessageContext"]["toolResults"]
+        ] == ["srvtoolu_search", "toolu_client"]
 
     def test_raises_for_empty_messages(self):
         """

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -528,6 +528,95 @@ class TestAnthropicMessageWithImages:
 # Tests for AnthropicMessagesRequest with Image Content
 # ==================================================================================================
 
+class TestWebSearchHistoryContentBlocks:
+    """Tests for Anthropic server-side web search blocks replayed in history."""
+
+    def test_accepts_completed_web_search_history(self):
+        """
+        What it does: Validates a completed server-side web search assistant turn.
+        Purpose: Allow Claude Code to send gateway search output back on the next request.
+        """
+        print("Action: Validating synthetic web search history...")
+        request = AnthropicMessagesRequest.model_validate({
+            "model": "claude-sonnet-5",
+            "max_tokens": 1024,
+            "messages": [
+                {"role": "user", "content": "search for an example"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "server_tool_use",
+                            "id": "srvtoolu_test",
+                            "name": "web_search",
+                            "input": {"query": "example query"},
+                        },
+                        {
+                            "type": "web_search_tool_result",
+                            "tool_use_id": "srvtoolu_test",
+                            "content": [
+                                {
+                                    "type": "web_search_result",
+                                    "title": "Example",
+                                    "url": "https://example.com",
+                                    "encrypted_content": "Synthetic result text",
+                                    "page_age": None,
+                                }
+                            ],
+                        },
+                        {"type": "text", "text": "Synthetic search summary"},
+                    ],
+                },
+                {"role": "user", "content": "continue"},
+            ],
+        })
+
+        search_call, search_result, summary = request.messages[1].content
+        print("Verifying typed blocks preserve server search metadata...")
+        assert search_call.type == "server_tool_use"
+        assert search_call.id == "srvtoolu_test"
+        assert search_call.input == {"query": "example query"}
+        assert search_result.type == "web_search_tool_result"
+        assert search_result.tool_use_id == "srvtoolu_test"
+        assert search_result.content[0].type == "web_search_result"
+        assert search_result.content[0].url == "https://example.com"
+        assert search_result.content[0].encrypted_content == "Synthetic result text"
+        assert summary.text == "Synthetic search summary"
+
+    def test_accepts_web_search_error_history(self):
+        """
+        What it does: Validates an error result from server-side web search.
+        Purpose: Keep a failed search in history without causing an unrelated HTTP 422.
+        """
+        print("Action: Validating synthetic web search error history...")
+        request = AnthropicMessagesRequest.model_validate({
+            "model": "claude-sonnet-5",
+            "max_tokens": 1024,
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "web_search_tool_result",
+                            "tool_use_id": "srvtoolu_test",
+                            "content": {
+                                "type": "web_search_tool_result_error",
+                                "error_code": "unavailable",
+                            },
+                        }
+                    ],
+                },
+                {"role": "user", "content": "continue"},
+            ],
+        })
+
+        error_result = request.messages[0].content[0]
+        print("Verifying typed error content is preserved...")
+        assert error_result.type == "web_search_tool_result"
+        assert error_result.content.type == "web_search_tool_result_error"
+        assert error_result.content.error_code == "unavailable"
+
+
 class TestAnthropicMessagesRequestWithImages:
     """Tests for full AnthropicMessagesRequest with image content."""
     

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -454,6 +454,58 @@ class TestMessagesSystemPrompt:
 
 class TestMessagesContentBlocks:
     """Tests for content block handling on /v1/messages endpoint."""
+
+    def test_accepts_web_search_history_from_claude_code(
+        self, test_client, valid_proxy_api_key
+    ):
+        """
+        What it does: Replays a completed server-side web search in conversation history.
+        Purpose: Prevent the request after a successful search from failing with HTTP 422.
+        """
+        print("Action: POST /v1/messages with synthetic web search history...")
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-5",
+                "max_tokens": 1024,
+                "messages": [
+                    {"role": "user", "content": "search for an example"},
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "server_tool_use",
+                                "id": "srvtoolu_test",
+                                "name": "web_search",
+                                "input": {"query": "example query"},
+                            },
+                            {
+                                "type": "web_search_tool_result",
+                                "tool_use_id": "srvtoolu_test",
+                                "content": [
+                                    {
+                                        "type": "web_search_result",
+                                        "title": "Example",
+                                        "url": "https://example.com",
+                                        "encrypted_content": "Synthetic result text",
+                                        "page_age": None,
+                                    }
+                                ],
+                            },
+                            {
+                                "type": "text",
+                                "text": "<web_search>Synthetic search summary</web_search>",
+                            },
+                        ],
+                    },
+                    {"role": "user", "content": "continue"},
+                ],
+            },
+        )
+
+        print(f"Status: {response.status_code}")
+        assert response.status_code == 200
     
     def test_accepts_string_content(self, test_client, valid_proxy_api_key):
         """
@@ -1600,6 +1652,102 @@ class TestContentTruncationRecovery:
 # ==================================================================================================
 # Tests for WebSearch Support
 # ==================================================================================================
+
+class TestWebSearchContinuationRequest:
+    """Tests for the internal model request after a server-side web search."""
+
+    @pytest.mark.asyncio
+    async def test_builds_tool_history_and_removes_web_search_at_round_limit(self):
+        """Search results are fed back with the original tool ID and client tools remain."""
+        from kiro.models_anthropic import AnthropicMessagesRequest
+        from kiro.routes_anthropic import _create_web_search_continuation
+
+        request_data = AnthropicMessagesRequest.model_validate({
+            "model": "claude-sonnet-5",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Find a synthetic example."}],
+            "tools": [
+                {
+                    "name": "web_search",
+                    "description": "Search the web.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                    },
+                },
+                {
+                    "name": "read_file",
+                    "description": "Read a local file.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}},
+                    },
+                },
+            ],
+        })
+        response = Mock(status_code=200)
+        http_client = Mock()
+        http_client.request_with_retry = AsyncMock(return_value=response)
+
+        with patch(
+            "kiro.routes_anthropic.anthropic_to_kiro",
+            return_value={"synthetic": "payload"},
+        ) as converter:
+            continuation = _create_web_search_continuation(
+                request_data=request_data,
+                http_client=http_client,
+                url="https://example.invalid/generateAssistantResponse",
+                conversation_id="conv_synthetic",
+                profile_arn="synthetic-profile",
+            )
+            actual = await continuation(
+                "Searching now.",
+                [{
+                    "tool_use_id": "toolu_synthetic_search",
+                    "query": "synthetic query",
+                    "results": {
+                        "results": [{
+                            "title": "Synthetic result",
+                            "url": "https://example.com/result",
+                            "snippet": "Synthetic result text.",
+                        }],
+                    },
+                }],
+                False,
+            )
+
+        assert actual is response
+        continuation_request = converter.call_args.args[0]
+        assistant_message = continuation_request.messages[-2]
+        result_message = continuation_request.messages[-1]
+
+        assert assistant_message.role == "assistant"
+        assert assistant_message.content[0].type == "text"
+        assert assistant_message.content[0].text == "Searching now."
+        assert assistant_message.content[1].type == "tool_use"
+        assert assistant_message.content[1].id == "toolu_synthetic_search"
+        assert assistant_message.content[1].name == "web_search"
+        assert assistant_message.content[1].input == {"query": "synthetic query"}
+
+        assert result_message.role == "user"
+        assert result_message.content[0].type == "tool_result"
+        assert result_message.content[0].tool_use_id == "toolu_synthetic_search"
+        assert "Synthetic result" in result_message.content[0].content
+        assert "https://example.com/result" in result_message.content[0].content
+
+        assert [tool.name for tool in continuation_request.tools] == ["read_file"]
+        converter.assert_called_once_with(
+            continuation_request,
+            "conv_synthetic",
+            "synthetic-profile",
+        )
+        http_client.request_with_retry.assert_awaited_once_with(
+            "POST",
+            "https://example.invalid/generateAssistantResponse",
+            {"synthetic": "payload"},
+            stream=True,
+        )
+
 
 class TestWebSearchAutoInjection:
     """Tests for WebSearch auto-injection (Path B - MCP Tool Emulation)."""

--- a/tests/unit/test_streaming_anthropic.py
+++ b/tests/unit/test_streaming_anthropic.py
@@ -859,6 +859,315 @@ class TestCollectAnthropicResponse:
 
 
 # ==================================================================================================
+# Tests for native-style WebSearch continuation
+# ==================================================================================================
+
+class TestStreamingAnthropicWebSearchContinuation:
+    """Tests for continuing Kiro generation after an intercepted web search."""
+
+    @pytest.mark.asyncio
+    async def test_streams_model_answer_after_server_search_blocks(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        """
+        What it does: Continues the same SSE message with a second Kiro response.
+        Purpose: Match Anthropic server-tool UX instead of returning a raw result dump.
+        """
+        continuation_response = AsyncMock()
+        continuation_response.status_code = 200
+        continuation_response.aclose = AsyncMock()
+
+        async def mock_parse_kiro_stream(response, *args, **kwargs):
+            if response is mock_response:
+                yield KiroEvent(
+                    type="tool_use",
+                    tool_use={
+                        "id": "toolu_kiro_search",
+                        "function": {
+                            "name": "web_search",
+                            "arguments": {"query": "example query"},
+                        },
+                    },
+                )
+                yield KiroEvent(type="context_usage", context_usage_percentage=1.0)
+            else:
+                assert response is continuation_response
+                yield KiroEvent(type="content", content="Natural synthesized answer")
+                yield KiroEvent(type="context_usage", context_usage_percentage=2.0)
+
+        results = {
+            "results": [{
+                "title": "Example",
+                "url": "https://example.com",
+                "snippet": "Synthetic result text",
+            }],
+            "totalResults": 1,
+        }
+        continuation = AsyncMock(return_value=continuation_response)
+        continuation_result = StreamResult(
+            content="Natural synthesized answer",
+            thinking_content="",
+            tool_calls=[],
+            usage=None,
+            context_usage_percentage=2.0,
+        )
+        events = []
+
+        with (
+            patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream),
+            patch(
+                "kiro.streaming_anthropic.collect_stream_to_result",
+                AsyncMock(return_value=continuation_result),
+            ),
+            patch("kiro.mcp_tools.call_kiro_mcp_api", AsyncMock(
+                return_value=("srvtoolu_test", results)
+            )),
+            patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]),
+        ):
+            async for event in stream_kiro_to_anthropic(
+                mock_response,
+                "claude-sonnet-5",
+                mock_model_cache,
+                mock_auth_manager,
+                web_search_continuation=continuation,
+            ):
+                events.append(event)
+
+        joined_events = "".join(events)
+        print("Verifying native server-tool blocks and synthesized answer...")
+        continuation.assert_awaited_once()
+        assistant_text, searches, allow_more_search = continuation.await_args.args
+        assert assistant_text == ""
+        assert searches == [{
+            "tool_use_id": "toolu_kiro_search",
+            "query": "example query",
+            "results": results,
+        }]
+        assert allow_more_search is True
+        assert "server_tool_use" in joined_events
+        assert "web_search_tool_result" in joined_events
+        assert "Natural synthesized answer" in joined_events
+        assert "<web_search>" not in joined_events
+        assert joined_events.count("event: message_start") == 1
+        assert joined_events.count("event: message_stop") == 1
+        assert '"stop_reason": "end_turn"' in joined_events
+
+    @pytest.mark.asyncio
+    async def test_allows_at_most_five_internal_search_rounds(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        """Repeated searches continue internally and disable search on round five."""
+        continuation_responses = []
+        for _ in range(5):
+            response = AsyncMock()
+            response.status_code = 200
+            response.aclose = AsyncMock()
+            continuation_responses.append(response)
+
+        async def mock_parse_kiro_stream(*args, **kwargs):
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={
+                    "id": "toolu_search_1",
+                    "function": {
+                        "name": "web_search",
+                        "arguments": {"query": "synthetic query 1"},
+                    },
+                },
+            )
+            yield KiroEvent(type="context_usage", context_usage_percentage=1.0)
+
+        continuation_results = [
+            StreamResult(
+                content="",
+                thinking_content="",
+                tool_calls=[{
+                    "id": f"toolu_search_{round_number + 1}",
+                    "function": {
+                        "name": "web_search",
+                        "arguments": {"query": f"synthetic query {round_number + 1}"},
+                    },
+                }],
+                usage=None,
+                context_usage_percentage=float(round_number),
+            )
+            for round_number in range(1, 5)
+        ]
+        continuation_results.append(StreamResult(
+            content="Final answer after bounded searches.",
+            thinking_content="",
+            tool_calls=[],
+            usage=None,
+            context_usage_percentage=5.0,
+        ))
+
+        search_results = [
+            (
+                f"srvtoolu_search_{round_number}",
+                {
+                    "results": [{
+                        "title": f"Synthetic result {round_number}",
+                        "url": f"https://example.com/result-{round_number}",
+                        "snippet": f"Synthetic snippet {round_number}.",
+                    }],
+                    "totalResults": 1,
+                },
+            )
+            for round_number in range(1, 6)
+        ]
+        continuation = AsyncMock(side_effect=continuation_responses)
+        events = []
+
+        with (
+            patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream),
+            patch(
+                "kiro.streaming_anthropic.collect_stream_to_result",
+                AsyncMock(side_effect=continuation_results),
+            ),
+            patch(
+                "kiro.mcp_tools.call_kiro_mcp_api",
+                AsyncMock(side_effect=search_results),
+            ) as mcp_call,
+            patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]),
+        ):
+            async for event in stream_kiro_to_anthropic(
+                mock_response,
+                "claude-sonnet-5",
+                mock_model_cache,
+                mock_auth_manager,
+                web_search_continuation=continuation,
+                max_web_search_rounds=5,
+            ):
+                events.append(event)
+
+        joined_events = "".join(events)
+        assert continuation.await_count == 5
+        assert [call.args[2] for call in continuation.await_args_list] == [
+            True, True, True, True, False,
+        ]
+        assert mcp_call.await_count == 5
+        for response in continuation_responses:
+            response.aclose.assert_awaited_once()
+        assert joined_events.count('"type": "server_tool_use"') == 5
+        assert "Final answer after bounded searches." in joined_events
+        assert "<web_search>" not in joined_events
+        assert joined_events.count("event: message_start") == 1
+        assert joined_events.count("event: message_stop") == 1
+        assert '"stop_reason": "end_turn"' in joined_events
+
+    @pytest.mark.asyncio
+    async def test_mixed_client_tool_stops_without_internal_continuation(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        """
+        What it does: Handles web search and a client tool in the same Kiro turn.
+        Purpose: Let Claude Code execute the client tool before model continuation.
+        """
+        async def mock_parse_kiro_stream(*args, **kwargs):
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={
+                    "id": "toolu_kiro_search",
+                    "function": {
+                        "name": "web_search",
+                        "arguments": {"query": "example query"},
+                    },
+                },
+            )
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={
+                    "id": "toolu_client",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": {"path": "example.txt"},
+                    },
+                },
+            )
+            yield KiroEvent(type="context_usage", context_usage_percentage=1.0)
+
+        continuation = AsyncMock()
+        events = []
+        with (
+            patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream),
+            patch("kiro.mcp_tools.call_kiro_mcp_api", AsyncMock(return_value=(
+                "srvtoolu_test",
+                {"results": [], "totalResults": 0},
+            ))),
+            patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]),
+        ):
+            async for event in stream_kiro_to_anthropic(
+                mock_response,
+                "claude-sonnet-5",
+                mock_model_cache,
+                mock_auth_manager,
+                web_search_continuation=continuation,
+            ):
+                events.append(event)
+
+        joined_events = "".join(events)
+        print("Verifying mixed client tool remains client-controlled...")
+        continuation.assert_not_awaited()
+        assert "server_tool_use" in joined_events
+        assert "read_file" in joined_events
+        assert '"stop_reason": "tool_use"' in joined_events
+
+    @pytest.mark.asyncio
+    async def test_continuation_failure_falls_back_to_search_summary(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        """
+        What it does: Preserves search results when the second Kiro request fails.
+        Purpose: Avoid turning a successful search into an empty assistant response.
+        """
+        async def mock_parse_kiro_stream(*args, **kwargs):
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={
+                    "id": "toolu_kiro_search",
+                    "function": {
+                        "name": "web_search",
+                        "arguments": {"query": "example query"},
+                    },
+                },
+            )
+            yield KiroEvent(type="context_usage", context_usage_percentage=1.0)
+
+        continuation = AsyncMock(side_effect=RuntimeError("continuation failed"))
+        events = []
+        with (
+            patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream),
+            patch("kiro.mcp_tools.call_kiro_mcp_api", AsyncMock(return_value=(
+                "srvtoolu_test",
+                {
+                    "results": [{
+                        "title": "Example",
+                        "url": "https://example.com",
+                        "snippet": "Synthetic result text",
+                    }],
+                    "totalResults": 1,
+                },
+            ))),
+            patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]),
+        ):
+            async for event in stream_kiro_to_anthropic(
+                mock_response,
+                "claude-sonnet-5",
+                mock_model_cache,
+                mock_auth_manager,
+                web_search_continuation=continuation,
+            ):
+                events.append(event)
+
+        joined_events = "".join(events)
+        print("Verifying deterministic summary fallback...")
+        assert "<web_search>" in joined_events
+        assert "Synthetic result text" in joined_events
+        assert joined_events.count("event: message_stop") == 1
+        assert '"stop_reason": "end_turn"' in joined_events
+
+
+# ==================================================================================================
 # Tests for error handling
 # ==================================================================================================
 


### PR DESCRIPTION
## Summary

- continue Kiro generation after an intercepted Anthropic Path B WebSearch instead of ending with a raw search dump
- preserve Anthropic `server_tool_use` and `web_search_tool_result` blocks in the original SSE message before streaming the model's natural answer
- retain server-search history across mixed client-tool turns so the model can continue the original task
- bound internal search continuation to five rounds and remove `web_search` on the final continuation request
- fall back to the deterministic search summary if model continuation fails
- accept Anthropic server WebSearch blocks when clients replay conversation history

## Testing

- `pytest -q` (`1701 passed`)
- live Anthropic SSE verification produced `server_tool_use`, `web_search_tool_result`, then natural `text`, with `stop_reason=end_turn`

Closes #258
