### PR TITLE
feat(models): add Claude Sonnet 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Made with ❤️ by [@Jwadow](https://github.com/jwadow)
 
 > 🔒 **Claude Opus 4.5** was removed from the free tier on January 17, 2026. It may be available on paid tiers — check your IDE/CLI model list.
 
+🧠 **Claude Sonnet 5** — Experimental preview with 1M context window. Latest generation, strongest reasoning and coding.
+
 🚀 **Claude Sonnet 4.5** — Balanced performance. Great for coding, writing, and general-purpose tasks.
 
 ⚡ **Claude Haiku 4.5** — Lightning fast. Perfect for quick responses, simple tasks, and chat.

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -278,6 +278,7 @@ FALLBACK_MODELS: List[Dict[str, str]] = [
     {"modelId": "claude-sonnet-4"},
     {"modelId": "claude-sonnet-4.5"},
     {"modelId": "claude-sonnet-4.6"},
+    {"modelId": "claude-sonnet-5"},
     {"modelId": "claude-haiku-4.5"},
     {"modelId": "claude-opus-4.5"},
     {"modelId": "claude-opus-4.6"},

--- a/kiro/model_resolver.py
+++ b/kiro/model_resolver.py
@@ -93,6 +93,7 @@ def normalize_model_name(name: str) -> str:
     2. claude-haiku-4-5-20251001 → claude-haiku-4.5 (strip date suffix)
     3. claude-haiku-4-5-latest → claude-haiku-4.5 (strip 'latest' suffix)
     4. claude-sonnet-4-20250514 → claude-sonnet-4 (strip date, no minor)
+    4b. claude-sonnet-5-latest → claude-sonnet-5 (strip 'latest', no minor)
     5. claude-3-7-sonnet → claude-3.7-sonnet (legacy format normalization)
     6. claude-3-7-sonnet-20250219 → claude-3.7-sonnet (legacy + strip date)
     7. claude-4.5-opus-high → claude-opus-4.5 (inverted format with suffix)
@@ -114,6 +115,8 @@ def normalize_model_name(name: str) -> str:
         'claude-sonnet-4'
         >>> normalize_model_name("claude-sonnet-4-20250514")
         'claude-sonnet-4'
+        >>> normalize_model_name("claude-sonnet-5-latest")
+        'claude-sonnet-5'
         >>> normalize_model_name("claude-3-7-sonnet")
         'claude-3.7-sonnet'
         >>> normalize_model_name("claude-3-7-sonnet-20250219")
@@ -145,10 +148,10 @@ def normalize_model_name(name: str) -> str:
         minor = match.group(2)  # 5
         return f"{base}.{minor}"  # claude-haiku-4.5
     
-    # Pattern 2: Standard format without minor - claude-{family}-{major}(-{date})?
-    # Matches: claude-sonnet-4, claude-sonnet-4-20250514
-    # Groups: (claude-sonnet-4), optional date
-    no_minor_pattern = r'^(claude-(?:haiku|sonnet|opus)-\d+)(?:-\d{8})?$'
+    # Pattern 2: Standard format without minor - claude-{family}-{major}(-{suffix})?
+    # Matches: claude-sonnet-4, claude-sonnet-4-20250514, claude-sonnet-5-latest
+    # Groups: (claude-sonnet-4), optional date/latest/numeric suffix
+    no_minor_pattern = r'^(claude-(?:haiku|sonnet|opus)-\d+)(?:-(?:\d{8}|latest|\d+))?$'
     match = re.match(no_minor_pattern, name_lower)
     if match:
         return match.group(1)  # claude-sonnet-4

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -183,11 +183,13 @@ class AnthropicMessage(BaseModel):
     Message in Anthropic format.
 
     Attributes:
-        role: Message role (user or assistant)
+        role: Message role (user, assistant, or system). System-role messages
+               (sent inline by some clients, e.g. Claude Code CLI 2.x) are
+               normalized to 'user' downstream by normalize_message_roles().
         content: Message content (string or list of content blocks)
     """
 
-    role: Literal["user", "assistant"]
+    role: Literal["user", "assistant", "system"]
     content: Union[str, List[ContentBlock]]
 
     model_config = {"extra": "allow"}

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -691,6 +691,121 @@ class TestFallbackModelsIntegration:
 
 
 # ==================================================================================================
+# Tests for Claude Sonnet 5 Support
+# ==================================================================================================
+class TestClaudeSonnet5Support:
+    """Tests verifying Claude Sonnet 5 is registered as a known/fallback model."""
+
+    def test_claude_sonnet_5_in_fallback_models(self):
+        """
+        What it does: Verifies that claude-sonnet-5 is present in FALLBACK_MODELS.
+        Purpose: Ensure the newest Sonnet generation is known to the gateway even
+                 when /ListAvailableModels is unreachable (DNS failure recovery).
+        """
+        print("Setup: Importing FALLBACK_MODELS...")
+        from kiro.config import FALLBACK_MODELS
+
+        model_ids = [m["modelId"] for m in FALLBACK_MODELS]
+        print(f"Model IDs in fallback list: {model_ids}")
+
+        print("Verification: 'claude-sonnet-5' is present...")
+        assert "claude-sonnet-5" in model_ids
+
+    def test_claude_sonnet_5_normalizes_to_itself(self):
+        """
+        What it does: Verifies that normalize_model_name leaves claude-sonnet-5 unchanged.
+        Purpose: claude-sonnet-5 has no minor version segment (like claude-sonnet-4),
+                 so normalization must be a no-op pass-through.
+        """
+        print("Setup: Importing normalize_model_name...")
+        from kiro.model_resolver import normalize_model_name
+
+        cases = [
+            "claude-sonnet-5",
+            "claude-sonnet-5-20260601",  # date suffix should be stripped
+            "claude-sonnet-5-latest",     # 'latest' suffix should be stripped
+        ]
+
+        for case in cases:
+            print(f"Action: Normalizing '{case}'...")
+            result = normalize_model_name(case)
+            print(f"  Result: '{result}'")
+            print(f"  Comparing: Expected 'claude-sonnet-5', Got '{result}'")
+            assert result == "claude-sonnet-5"
+
+    @pytest.mark.asyncio
+    async def test_claude_sonnet_5_resolves_from_fallback_cache(self):
+        """
+        What it does: Verifies claude-sonnet-5 resolves via the fallback cache path,
+                      not passthrough, once FALLBACK_MODELS has been loaded into cache.
+        Purpose: Ensure /v1/messages and /v1/chat/completions treat claude-sonnet-5
+                 as a verified model (is_verified=True), matching other known models.
+        """
+        print("Setup: Importing FALLBACK_MODELS and creating cache...")
+        from kiro.config import FALLBACK_MODELS
+        from kiro.cache import ModelInfoCache
+        from kiro.model_resolver import ModelResolver
+
+        cache = ModelInfoCache()
+        await cache.update(FALLBACK_MODELS)
+
+        resolver = ModelResolver(cache=cache, hidden_models={})
+
+        print("Action: Resolving 'claude-sonnet-5'...")
+        resolution = resolver.resolve("claude-sonnet-5")
+
+        print(f"  Resolution source: {resolution.source}")
+        print(f"  Normalized: {resolution.normalized}")
+        print(f"  Internal ID: {resolution.internal_id}")
+        print(f"  Is verified: {resolution.is_verified}")
+
+        print("Comparing normalized: Expected 'claude-sonnet-5'...")
+        assert resolution.normalized == "claude-sonnet-5"
+
+        print("Comparing source: Expected 'cache'...")
+        assert resolution.source == "cache"
+
+        print("Comparing is_verified: Expected True...")
+        assert resolution.is_verified is True
+
+        print("Comparing internal_id: Expected 'claude-sonnet-5'...")
+        assert resolution.internal_id == "claude-sonnet-5"
+
+    def test_claude_sonnet_5_appears_in_model_family_suggestions(self):
+        """
+        What it does: Verifies claude-sonnet-5 is suggested for other Sonnet-family
+                      lookups, and never for Haiku/Opus lookups (family isolation).
+        Purpose: Error messages for invalid Sonnet models should list claude-sonnet-5
+                 as a valid alternative once it's in FALLBACK_MODELS.
+        """
+        print("Setup: Creating cache and resolver from FALLBACK_MODELS...")
+        from kiro.config import FALLBACK_MODELS
+        from kiro.cache import ModelInfoCache
+        from kiro.model_resolver import ModelResolver
+        import asyncio
+
+        cache = ModelInfoCache()
+        asyncio.run(cache.update(FALLBACK_MODELS))
+
+        resolver = ModelResolver(cache=cache, hidden_models={})
+
+        print("Action: Getting suggestions for a bogus Sonnet model...")
+        sonnet_suggestions = resolver.get_suggestions_for_model("claude-sonnet-99")
+        print(f"  Sonnet suggestions: {sonnet_suggestions}")
+        assert "claude-sonnet-5" in sonnet_suggestions
+
+        print("Action: Getting suggestions for a bogus Opus model...")
+        opus_suggestions = resolver.get_suggestions_for_model("claude-opus-99")
+        print(f"  Opus suggestions: {opus_suggestions}")
+        assert "claude-sonnet-5" not in opus_suggestions
+
+        print("Action: Getting suggestions for a bogus Haiku model...")
+        haiku_suggestions = resolver.get_suggestions_for_model("claude-haiku-99")
+        print(f"  Haiku suggestions: {haiku_suggestions}")
+        assert "claude-sonnet-5" not in haiku_suggestions
+
+
+# ==================================================================================================
 # Tests for WebSearch Configuration
 # ==================================================================================================
 

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -389,6 +389,95 @@ class TestContentBlockUnion:
 
 
 # ==================================================================================================
+# Tests for AnthropicMessage role field (system-role message support)
+# ==================================================================================================
+
+class TestAnthropicMessageRole:
+    """
+    Tests for AnthropicMessage.role accepting 'system' in addition to 'user'/'assistant'.
+
+    Some clients (notably Claude Code CLI 2.x) send messages with role='system'
+    inline in the `messages` array (e.g. injected <system-reminder> context),
+    rather than exclusively via the top-level `system` field. Without this,
+    the request fails with a 422 literal_error before reaching
+    normalize_message_roles(), which already exists to convert such roles
+    to 'user' downstream (see converters_core.py, fixes issue #64).
+    """
+
+    def test_user_role_still_valid(self):
+        """
+        What it does: Verifies 'user' role still validates (no regression).
+        Purpose: Ensure widening the Literal didn't break the common case.
+        """
+        print("Setup: Creating AnthropicMessage with role='user'...")
+        message = AnthropicMessage(role="user", content="Hello")
+
+        print(f"Comparing role: Expected 'user', Got '{message.role}'")
+        assert message.role == "user"
+
+    def test_assistant_role_still_valid(self):
+        """
+        What it does: Verifies 'assistant' role still validates (no regression).
+        Purpose: Ensure widening the Literal didn't break the common case.
+        """
+        print("Setup: Creating AnthropicMessage with role='assistant'...")
+        message = AnthropicMessage(role="assistant", content="Hi there")
+
+        print(f"Comparing role: Expected 'assistant', Got '{message.role}'")
+        assert message.role == "assistant"
+
+    def test_system_role_is_accepted(self):
+        """
+        What it does: Verifies 'system' role validates without raising.
+        Purpose: Reproduces the Claude Code CLI 2.x request shape that
+                 previously raised a 422 literal_error on this field.
+        """
+        print("Setup: Creating AnthropicMessage with role='system'...")
+        message = AnthropicMessage(role="system", content="<system-reminder>context</system-reminder>")
+
+        print(f"Comparing role: Expected 'system', Got '{message.role}'")
+        assert message.role == "system"
+
+    def test_invalid_role_still_rejected(self):
+        """
+        What it does: Verifies an unrelated invalid role (e.g. 'tool') still raises.
+        Purpose: Ensure the fix only widens the Literal to the specific
+                 known-safe value, not arbitrary strings.
+        """
+        print("Setup: Attempting AnthropicMessage with role='tool'...")
+        with pytest.raises(ValidationError):
+            AnthropicMessage(role="tool", content="oops")
+
+    def test_system_role_message_in_full_request_validates(self):
+        """
+        What it does: Verifies a full AnthropicMessagesRequest with a
+                      system-role message inline in `messages` validates
+                      (reproduces the exact Claude Code CLI 2.x payload shape).
+        Purpose: Regression test for the 422 error:
+                 "Input should be 'user' or 'assistant'" on messages[i].role.
+        """
+        print("Setup: Building request with inline system-role message...")
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-5",
+            max_tokens=1024,
+            messages=[
+                AnthropicMessage(role="system", content="<system-reminder>context</system-reminder>"),
+                AnthropicMessage(role="user", content="What model are you?"),
+            ],
+        )
+
+        print(f"Comparing messages length: Expected 2, Got {len(request.messages)}")
+        assert len(request.messages) == 2
+
+        print(f"Comparing first message role: Expected 'system', Got '{request.messages[0].role}'")
+        assert request.messages[0].role == "system"
+
+        print(f"Comparing second message role: Expected 'user', Got '{request.messages[1].role}'")
+        assert request.messages[1].role == "user"
+
+
+
+# ==================================================================================================
 # Tests for AnthropicMessage with Image Content (Issue #30 fix verification)
 # ==================================================================================================
 


### PR DESCRIPTION
## Summary

This PR bundles two related fixes needed to get Claude Sonnet 5 working
end-to-end with Claude Code CLI 2.x through the gateway:

1. **Register `claude-sonnet-5`** as a known model
2. **Fix a request-validation bug** that blocks Claude Code CLI 2.x from
   working with *any* model (not just Sonnet 5) — found while testing #1

### 1. Claude Sonnet 5 support

- `kiro/config.py`: add `claude-sonnet-5` to `FALLBACK_MODELS`, so it's
  recognized as a known model during DNS-failure recovery instead of an
  unverified passthrough.
- `kiro/model_resolver.py`: fix a gap in `normalize_model_name`'s
  no-minor-version pattern. Models without a minor segment (`claude-sonnet-4`,
  `claude-sonnet-5`) only stripped an 8-digit date suffix, not a `latest` or
  trailing-numeric suffix — unlike the with-minor-version pattern, which
  already handled all three. This meant `claude-sonnet-5-latest` failed to
  normalize and incorrectly resolved as unverified passthrough.
- `README.md`: list Claude Sonnet 5 in Available Models.
- `tests/unit/test_config.py`: new `TestClaudeSonnet5Support` — fallback
  registration, name normalization (plain/date/latest suffixes), cache
  resolution (`source=cache`, `is_verified=True`), and family-isolated
  suggestions.

### 2. Accept `role=system` inline in AnthropicMessage

Claude Code CLI 2.x sends messages with `role="system"` inline in the
`messages` array (e.g. injected `<system-reminder>` context), rather than
exclusively via the top-level `system` field. `AnthropicMessage.role` only
accepted `user`/`assistant`, so these requests failed with a 422
`literal_error` — before ever reaching `normalize_message_roles()` in
`converters_core.py`, which already exists to convert unknown roles to
`user` downstream (same lineage as the alternating-roles fix in #64).

Reproduced directly: running `claude -p "..."` against the gateway failed
with:
