### PR TITLE
fix(docker): set runtime user via compose to match host uid for volume access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: kiro-gateway
+    user: "${UID:-1000}:${GID:-1000}"
     ports:
       - "8000:8000"
     environment:


### PR DESCRIPTION
Run as the host user so mounted volumes (e.g. kiro-cli SQLite DB) are accessible. Since the kiro user in the image owns /app, this PR ensures the UID matches the host user who owns the files on mounted volumes