### PR TITLE
fix(streaming): report OpenAI stream errors in-band instead of raising

### DIFF
--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -86,6 +86,32 @@ async def verify_api_key(auth_header: str = Security(api_key_header)) -> bool:
     return True
 
 
+def build_sse_error_chunk(exc: Exception) -> str:
+    """
+    Build an SSE data chunk describing a streaming failure.
+    
+    Once StreamingResponse has sent its headers, the HTTP status code can no
+    longer be changed: re-raising makes Starlette abort with "Caught handled
+    exception, but response already started" and the client receives a stream
+    with no error information at all. Reporting the error in-band keeps the
+    reason visible to the client (same approach as /v1/messages).
+    
+    Args:
+        exc: Exception raised while streaming. HTTPException status_code and
+             detail are preserved, any other exception is reported as 500.
+    
+    Returns:
+        SSE chunk in OpenAI error format, ready to be yielded
+    """
+    return "data: " + json.dumps({
+        "error": {
+            "message": str(getattr(exc, "detail", None) or exc),
+            "type": "kiro_api_error",
+            "code": getattr(exc, "status_code", 500),
+        }
+    }) + "\n\n"
+
+
 # --- Router ---
 router = APIRouter()
 
@@ -397,11 +423,13 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                                 logger.debug("Client disconnected during streaming (GeneratorExit in routes)")
                             except Exception as e:
                                 streaming_error = e
+                                # Response headers are already sent: report the error
+                                # in-band instead of raising (see build_sse_error_chunk)
                                 try:
+                                    yield build_sse_error_chunk(e)
                                     yield "data: [DONE]\n\n"
                                 except Exception:
-                                    pass
-                                raise
+                                    pass  # Client already disconnected
                             finally:
                                 await http_client.close()
                                 if streaming_error:
@@ -694,13 +722,13 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                     logger.debug("Client disconnected during streaming (GeneratorExit in routes)")
                 except Exception as e:
                     streaming_error = e
-                    # Try to send [DONE] to client before finishing
-                    # so client doesn't "hang" waiting for data
+                    # Response headers are already sent: report the error
+                    # in-band instead of raising (see build_sse_error_chunk)
                     try:
+                        yield build_sse_error_chunk(e)
                         yield "data: [DONE]\n\n"
                     except Exception:
                         pass  # Client already disconnected
-                    raise
                 finally:
                     await http_client.close()
                     # Log access log for streaming (success or error)

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -2519,3 +2519,68 @@ class TestCountTokensEndpoint:
         assert data["input_tokens"] > 0
         
         print("✅ max_tokens is NOT required for count_tokens")
+
+
+# =============================================================================
+# Tests for streaming errors raised after the response has started
+# =============================================================================
+
+class TestStreamingErrorAfterResponseStart:
+    """
+    Tests that a streaming failure on /v1/messages is reported in-band.
+
+    Once StreamingResponse has sent its headers, raising from the generator makes
+    Starlette fail with "Caught handled exception, but response already started."
+    This is the Anthropic counterpart of the same test in test_routes_openai.py -
+    both APIs must report streaming failures as SSE events instead of raising.
+    """
+
+    @patch('kiro.routes_anthropic.stream_with_first_token_retry_anthropic')
+    @patch('kiro.routes_anthropic.KiroHttpClient')
+    def test_first_token_timeout_is_sent_as_sse_error_event(
+        self,
+        mock_kiro_http_client_class,
+        mock_stream_with_retry,
+        test_client,
+        valid_proxy_api_key
+    ):
+        """
+        What it does: Verifies a 504 from the streaming pipeline becomes an SSE error event.
+        Purpose: Ensure clients see the reason instead of an empty stream + server traceback.
+        """
+        print("Setup: Mocking upstream 200 response and failing stream...")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.request_with_retry = AsyncMock(return_value=mock_response)
+        mock_client_instance.close = AsyncMock()
+        mock_client_instance.client = MagicMock()
+        mock_kiro_http_client_class.return_value = mock_client_instance
+
+        async def failing_stream(*args, **kwargs):
+            raise HTTPException(
+                status_code=504,
+                detail="Model did not respond within 15.0s after 3 attempts. Please try again."
+            )
+            yield ""  # pragma: no cover - makes this an async generator
+
+        mock_stream_with_retry.side_effect = failing_stream
+
+        print("Action: POST /v1/messages with stream=true...")
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-4-5",
+                "max_tokens": 1024,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True
+            }
+        )
+
+        print(f"Checking: status={response.status_code}, body={response.text[:200]}")
+        assert response.status_code == 200, "Headers are already sent, status stays 200"
+        assert "event: error" in response.text, "Error must be reported as an SSE event"
+        assert "Model did not respond" in response.text, "Error event must carry the reason"
+        print("✅ Streaming error delivered in-band without raising")

--- a/tests/unit/test_routes_openai.py
+++ b/tests/unit/test_routes_openai.py
@@ -980,6 +980,223 @@ class TestHTTPClientSelection:
 
 
 # =============================================================================
+# Tests for streaming errors raised after the response has started
+# =============================================================================
+
+class TestBuildSseErrorChunk:
+    """
+    Tests for build_sse_error_chunk() - in-band reporting of streaming failures.
+    """
+
+    def test_http_exception_preserves_status_and_detail(self):
+        """
+        What it does: Verifies HTTPException status_code and detail end up in the chunk.
+        Purpose: Ensure the client learns why the stream failed (e.g. 504 first-token timeout).
+        """
+        print("Setup: HTTPException(504)...")
+        from kiro.routes_openai import build_sse_error_chunk
+
+        chunk = build_sse_error_chunk(
+            HTTPException(status_code=504, detail="Model did not respond within 15.0s")
+        )
+
+        print(f"Chunk: {chunk!r}")
+        assert chunk.startswith("data: ")
+        assert chunk.endswith("\n\n")
+        payload = json.loads(chunk[len("data: "):])
+        assert payload["error"]["code"] == 504
+        assert payload["error"]["message"] == "Model did not respond within 15.0s"
+        assert payload["error"]["type"] == "kiro_api_error"
+        print("✅ Status and detail preserved")
+
+    def test_generic_exception_reported_as_500(self):
+        """
+        What it does: Verifies a non-HTTP exception is reported with code 500.
+        Purpose: Ensure unexpected failures still produce a valid error chunk.
+        """
+        print("Setup: RuntimeError...")
+        from kiro.routes_openai import build_sse_error_chunk
+
+        chunk = build_sse_error_chunk(RuntimeError("connection dropped"))
+
+        payload = json.loads(chunk[len("data: "):])
+        print(f"Payload: {payload}")
+        assert payload["error"]["code"] == 500
+        assert payload["error"]["message"] == "connection dropped"
+        print("✅ Generic exception reported as 500")
+
+    def test_exception_without_message_is_still_valid_json(self):
+        """
+        What it does: Verifies an exception with an empty message produces valid JSON.
+        Purpose: Edge case - clients must never receive a malformed SSE chunk.
+        """
+        print("Setup: Exception with empty message...")
+        from kiro.routes_openai import build_sse_error_chunk
+
+        chunk = build_sse_error_chunk(RuntimeError())
+
+        payload = json.loads(chunk[len("data: "):])
+        print(f"Payload: {payload}")
+        assert payload["error"]["code"] == 500
+        assert isinstance(payload["error"]["message"], str)
+        print("✅ Empty message handled")
+
+
+class TestStreamingErrorAfterResponseStart:
+    """
+    Tests that a streaming failure is reported in-band as an SSE error chunk.
+
+    Once StreamingResponse has sent its headers, raising from the generator makes
+    Starlette fail with "Caught handled exception, but response already started."
+    and the client receives a stream with no error information at all.
+    """
+
+    @patch('kiro.routes_openai.stream_with_first_token_retry')
+    @patch('kiro.routes_openai.KiroHttpClient')
+    def test_first_token_timeout_is_sent_as_sse_error_chunk(
+        self,
+        mock_kiro_http_client_class,
+        mock_stream_with_retry,
+        test_client,
+        valid_proxy_api_key
+    ):
+        """
+        What it does: Verifies a 504 from the streaming pipeline becomes an SSE error chunk.
+        Purpose: Ensure clients see the reason instead of an empty stream + server traceback.
+        """
+        print("Setup: Mocking upstream 200 response and failing stream...")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.request_with_retry = AsyncMock(return_value=mock_response)
+        mock_client_instance.close = AsyncMock()
+        mock_client_instance.client = MagicMock()
+        mock_kiro_http_client_class.return_value = mock_client_instance
+
+        async def failing_stream(*args, **kwargs):
+            raise HTTPException(
+                status_code=504,
+                detail="Model did not respond within 15.0s after 3 attempts. Please try again."
+            )
+            yield ""  # pragma: no cover - makes this an async generator
+
+        mock_stream_with_retry.side_effect = failing_stream
+
+        print("Action: POST /v1/chat/completions with stream=true...")
+        response = test_client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
+            json={
+                "model": "claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True
+            }
+        )
+
+        print(f"Checking: status={response.status_code}, body={response.text[:200]}")
+        assert response.status_code == 200, "Headers are already sent, status stays 200"
+        assert '"code": 504' in response.text, "Error chunk must carry the upstream status"
+        assert "Model did not respond" in response.text, "Error chunk must carry the detail"
+        assert response.text.rstrip().endswith("data: [DONE]"), "Stream must be terminated"
+        print("✅ Streaming error delivered in-band without raising")
+
+    @patch('kiro.routes_openai.stream_with_first_token_retry')
+    @patch('kiro.routes_openai.KiroHttpClient')
+    def test_mid_stream_error_keeps_already_sent_chunks(
+        self,
+        mock_kiro_http_client_class,
+        mock_stream_with_retry,
+        test_client,
+        valid_proxy_api_key
+    ):
+        """
+        What it does: Verifies a failure after some chunks were sent appends an error chunk.
+        Purpose: Mid-stream upstream drops (e.g. RemoteProtocolError) must not truncate silently.
+        """
+        print("Setup: Mocking stream that fails after one chunk...")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.request_with_retry = AsyncMock(return_value=mock_response)
+        mock_client_instance.close = AsyncMock()
+        mock_client_instance.client = MagicMock()
+        mock_kiro_http_client_class.return_value = mock_client_instance
+
+        async def failing_stream(*args, **kwargs):
+            yield 'data: {"choices": [{"delta": {"content": "Hi"}}]}\n\n'
+            raise RuntimeError("peer closed connection without sending complete message body")
+
+        mock_stream_with_retry.side_effect = failing_stream
+
+        print("Action: POST /v1/chat/completions with stream=true...")
+        response = test_client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
+            json={
+                "model": "claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True
+            }
+        )
+
+        print(f"Checking: body={response.text[:300]}")
+        assert response.status_code == 200
+        assert '"content": "Hi"' in response.text, "Chunks sent before the error are preserved"
+        assert '"code": 500' in response.text, "Unexpected failures are reported as 500"
+        assert "peer closed connection" in response.text
+        assert response.text.rstrip().endswith("data: [DONE]")
+        print("✅ Mid-stream error reported after already sent chunks")
+
+    @patch('kiro.routes_openai.stream_with_first_token_retry')
+    @patch('kiro.routes_openai.KiroHttpClient')
+    def test_successful_stream_has_no_error_chunk(
+        self,
+        mock_kiro_http_client_class,
+        mock_stream_with_retry,
+        test_client,
+        valid_proxy_api_key
+    ):
+        """
+        What it does: Verifies a healthy stream is passed through unchanged.
+        Purpose: Ensure the error path does not affect the happy path.
+        """
+        print("Setup: Mocking successful stream...")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.request_with_retry = AsyncMock(return_value=mock_response)
+        mock_client_instance.close = AsyncMock()
+        mock_client_instance.client = MagicMock()
+        mock_kiro_http_client_class.return_value = mock_client_instance
+
+        async def ok_stream(*args, **kwargs):
+            yield 'data: {"choices": [{"delta": {"content": "Hi"}}]}\n\n'
+            yield "data: [DONE]\n\n"
+
+        mock_stream_with_retry.side_effect = ok_stream
+
+        print("Action: POST /v1/chat/completions with stream=true...")
+        response = test_client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
+            json={
+                "model": "claude-sonnet-4-5",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True
+            }
+        )
+
+        print(f"Checking: body={response.text[:200]}")
+        assert response.status_code == 200
+        assert "kiro_api_error" not in response.text, "No error chunk on the happy path"
+        assert response.text.count("data: [DONE]") == 1, "[DONE] must not be duplicated"
+        print("✅ Happy path unchanged")
+
+
+# =============================================================================
 # Tests for Truncation Recovery message modification (Issue #56)
 # =============================================================================
 


### PR DESCRIPTION
## What

`stream_wrapper()` in `chat_completions()` re-raised the exception after `StreamingResponse` had already sent its headers, so Starlette cannot turn it into an error response and aborts the connection instead:

```
ERROR | kiro.streaming_core:stream_with_first_token_retry - [FirstTokenTimeout] All 3 attempts exhausted - model never responded within 15.0s per attempt
ERROR | kiro.routes_openai:stream_wrapper - HTTP 500 - POST /v1/chat/completions (streaming) - [HTTPException] 504: Model did not respond within 15.0s after 3 attempts.
ERROR | Exception in ASGI application
...
  File "starlette/middleware/base.py", line 198, in __call__
    raise app_exc
  File "starlette/_exception_handler.py", line 56, in wrapped_app
    raise RuntimeError("Caught handled exception, but response already started.") from exc

RuntimeError: Caught handled exception, but response already started.
```

Two consequences:

1. The client gets `data: [DONE]` with no content and no reason - it looks like the gateway silently returned an empty answer. The 504 detail never reaches it.
2. Every occurrence prints a full ASGI traceback for what is an upstream condition, not a gateway bug.

`/v1/messages` already handles this correctly (`event: error`, then a graceful end of stream), so only the OpenAI path was affected.

## Why it happens in practice

Any streaming failure after the first byte of the response reaches this path. The easiest way to hit it is the first-token retry loop, because not every model streams reasoning deltas: the non-Claude models exposed by Kiro send nothing at all while they think, so the first byte only arrives together with the answer.

Measured with one heavy request (~270 KB payload, 20 tools, non-Claude model), first-token timeout temporarily raised to 180 s to observe the real latency:

| attempt | upstream headers | first body byte |
|---|---|---|
| 1 | 8.5 s | 38.8 s |
| 2 | 12.4 s | 32.0 s |
| 3 | 9.6 s | 35.2 s |

A Claude model on the same gateway starts emitting `reasoning_content` after ~2-4 s, which is why the default `FIRST_TOKEN_TIMEOUT=15` has been fine so far. With a model that stays silent while reasoning, all three attempts time out and the resulting 504 lands on the broken error path above.

Whether the default timeout should change is a separate discussion - this PR only fixes the error reporting.

Related: #129 (mid-stream `RemoteProtocolError`) hits the same code path on `/v1/chat/completions`, and improvement 2 requested there - telling the client it was a connection drop - now works for the OpenAI API too.

## Change

- New helper `build_sse_error_chunk(exc)` renders an exception as an OpenAI-format error chunk. `HTTPException.status_code` / `.detail` are preserved, anything else is reported as 500.
- Both `stream_wrapper()` variants (account-system branch and legacy branch) now yield the error chunk followed by `[DONE]` and no longer re-raise.

The client now receives the reason:

```
data: {"error": {"message": "Model did not respond within 15.0s after 3 attempts. Please try again.", "type": "kiro_api_error", "code": 504}}

data: [DONE]
```

Server-side logging and debug-log flushing are unchanged - `streaming_error` is still set, so the existing `HTTP 500 - POST /v1/chat/completions (streaming)` access log line and `flush_on_error()` still fire.

## Tests

`tests/unit/test_routes_openai.py`

- `TestBuildSseErrorChunk` - HTTPException status/detail preserved; generic exception reported as 500; exception with an empty message still produces valid JSON.
- `TestStreamingErrorAfterResponseStart` - first-token timeout produces `code: 504` + `[DONE]`; mid-stream failure keeps the chunks already sent and appends `code: 500`; happy path unaffected (no error chunk, exactly one `[DONE]`).

`tests/unit/test_routes_anthropic.py`

- `TestStreamingErrorAfterResponseStart` - parity test asserting `/v1/messages` reports the failure as `event: error` without raising. It passes on `main` as well; it is there to keep the two APIs from drifting apart again.

Verification: 5 of the 7 new tests fail on `main` (the 3 helper tests plus the 2 OpenAI streaming-failure tests, which abort with the `RuntimeError` above) and all 7 pass with this change. Full unit suite: same pass/fail set before and after this change, no new failures.
