### PR TITLE
chore: ignore local credential artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,13 @@
 .env.local
 credentials.json
 state.json
+/kiro-credentials/
 
 # IDE
 .vscode/
 .idea/
 .shard/
+.DS_Store
 
 # Python
 __pycache__/


### PR DESCRIPTION
## Summary
- Ignore the root-local `kiro-credentials/` directory so credential databases cannot be added accidentally.
- Ignore macOS `.DS_Store` metadata.
- Preserve all existing source and configuration files.

## Validation
- `git check-ignore -v kiro-credentials/example.sqlite3 .DS_Store`
- Full local suite: 1,432 tests passed.