### PR TITLE
WIP: resolve configured model aliases in converter paths

### DIFF
--- a/kiro/config.py
+++ b/kiro/config.py
@@ -248,6 +248,13 @@ HIDDEN_MODELS: Dict[str, str] = {
 # Default: {"auto-kiro": "auto"} to avoid Cursor IDE conflict
 MODEL_ALIASES: Dict[str, str] = {
     "auto-kiro": "auto",  # Default alias to avoid Cursor's "auto" model conflict
+    "custom:Kiro-Claude-Sonnet-4.5-0": "claude-sonnet-4.5",
+    "custom:Kiro-Claude-Opus-4.5-1": "claude-opus-4.5",
+    "custom:Kiro-Claude-Opus-4.6-2": "claude-opus-4.6",
+    "custom:Kiro-Claude-Sonnet-4.6-3": "claude-sonnet-4.6",
+    "custom:Kiro-Claude-Haiku-4.5-4": "claude-haiku-4.5",
+    "custom:Kiro-Minimax-M2.5-5": "minimax-m2.5",
+    "custom:Kiro-Qwen3-Coder-Next-6": "qwen3-coder-next",
 }
 
 # Models to hide from /v1/models endpoint.
@@ -578,4 +585,3 @@ def get_kiro_api_host(region: str) -> str:
 def get_kiro_q_host(region: str) -> str:
     """Return Q API host for the specified region."""
     return KIRO_Q_HOST_TEMPLATE.format(region=region)
-

--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -28,7 +28,7 @@ from typing import Any, Dict, List, Optional
 
 from loguru import logger
 
-from kiro.config import HIDDEN_MODELS
+from kiro.config import HIDDEN_MODELS, MODEL_ALIASES
 from kiro.model_resolver import get_model_id_for_kiro
 from kiro.models_anthropic import (
     AnthropicMessagesRequest,
@@ -462,7 +462,7 @@ def anthropic_to_kiro(
 
     # Get model ID for Kiro API (normalizes + resolves hidden models)
     # Pass-through principle: we normalize and send to Kiro, Kiro decides if valid
-    model_id = get_model_id_for_kiro(request.model, HIDDEN_MODELS)
+    model_id = get_model_id_for_kiro(request.model, HIDDEN_MODELS, MODEL_ALIASES)
 
     # Extract thinking configuration from thinking parameter
     thinking_config = extract_thinking_config_from_anthropic(request)

--- a/kiro/converters_openai.py
+++ b/kiro/converters_openai.py
@@ -33,7 +33,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from loguru import logger
 
-from kiro.config import HIDDEN_MODELS
+from kiro.config import HIDDEN_MODELS, MODEL_ALIASES
 from kiro.model_resolver import get_model_id_for_kiro
 from kiro.models_openai import ChatMessage, ChatCompletionRequest, Tool
 
@@ -420,7 +420,7 @@ def build_kiro_payload(
     
     # Get model ID for Kiro API (normalizes + resolves hidden models)
     # Pass-through principle: we normalize and send to Kiro, Kiro decides if valid
-    model_id = get_model_id_for_kiro(request_data.model, HIDDEN_MODELS)
+    model_id = get_model_id_for_kiro(request_data.model, HIDDEN_MODELS, MODEL_ALIASES)
     
     # Extract thinking configuration from reasoning_effort
     thinking_config = extract_thinking_config_from_openai(request_data)

--- a/kiro/model_resolver.py
+++ b/kiro/model_resolver.py
@@ -189,12 +189,16 @@ def normalize_model_name(name: str) -> str:
     return name
 
 
-def get_model_id_for_kiro(model_name: str, hidden_models: Dict[str, str]) -> str:
+def get_model_id_for_kiro(
+    model_name: str,
+    hidden_models: Dict[str, str],
+    aliases: Optional[Dict[str, str]] = None,
+) -> str:
     """
     Get the model ID to send to Kiro API.
     
     This is a simple helper for converters that don't have access to the full
-    ModelResolver. It normalizes the name and checks hidden models.
+    ModelResolver. It resolves aliases, normalizes the name, and checks hidden models.
     
     For hidden models (like claude-3.7-sonnet), returns the internal Kiro ID.
     For regular models, returns the normalized name.
@@ -202,6 +206,7 @@ def get_model_id_for_kiro(model_name: str, hidden_models: Dict[str, str]) -> str
     Args:
         model_name: External model name from client
         hidden_models: Dict mapping display names to internal Kiro IDs
+        aliases: Optional mapping of client aliases to model IDs
     
     Returns:
         Model ID to send to Kiro API
@@ -214,7 +219,17 @@ def get_model_id_for_kiro(model_name: str, hidden_models: Dict[str, str]) -> str
         >>> get_model_id_for_kiro("claude-3-7-sonnet", {"claude-3.7-sonnet": "CLAUDE_3_7_SONNET_20250219_V1_0"})
         'CLAUDE_3_7_SONNET_20250219_V1_0'
     """
-    normalized = normalize_model_name(model_name)
+    resolved = model_name
+    visited: set[str] = set()
+    while aliases and resolved in aliases:
+        if resolved in visited:
+            logger.warning(f"Model alias cycle detected for '{model_name}'; using original model name")
+            resolved = model_name
+            break
+        visited.add(resolved)
+        resolved = aliases[resolved]
+
+    normalized = normalize_model_name(resolved)
     internal = hidden_models.get(normalized, normalized)
     return to_runtime_model_id(internal)
 

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -1471,6 +1471,20 @@ class TestAnthropicToKiro:
         assert "userInputMessage" in result["conversationState"]["currentMessage"]
         assert result["profileArn"] == "arn:aws:test"
 
+    def test_resolves_configured_model_alias(self):
+        """Configured aliases are resolved in the Anthropic converter path."""
+        request = AnthropicMessagesRequest(
+            model="custom:Kiro-Claude-Opus-4.6-2",
+            messages=[AnthropicMessage(role="user", content="Hello!")],
+            max_tokens=1024,
+        )
+
+        with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
+            result = anthropic_to_kiro(request, "conv-123", "")
+
+        model_id = result["conversationState"]["currentMessage"]["userInputMessage"]["modelId"]
+        assert model_id == "claude-opus-4.6"
+
     def test_includes_system_prompt(self):
         """
         What it does: Verifies that system prompt is included.

--- a/tests/unit/test_converters_openai.py
+++ b/tests/unit/test_converters_openai.py
@@ -816,6 +816,18 @@ class TestBuildKiroPayload:
         # claude-sonnet-4-5 should normalize to claude-sonnet-4.5 (dashes→dots)
         print(f"Comparing model_id: Expected 'claude-sonnet-4.5', Got '{model_id}'")
         assert model_id == "claude-sonnet-4.5"
+
+    def test_resolves_configured_model_alias(self):
+        """Configured aliases are resolved in the OpenAI converter path."""
+        request = ChatCompletionRequest(
+            model="custom:Kiro-Claude-Opus-4.6-2",
+            messages=[ChatMessage(role="user", content="Hello")],
+        )
+
+        result = build_kiro_payload(request, "conv-123", "")
+
+        model_id = result["conversationState"]["currentMessage"]["userInputMessage"]["modelId"]
+        assert model_id == "claude-opus-4.6"
     
     def test_includes_tools_in_context(self):
         """

--- a/tests/unit/test_model_resolver.py
+++ b/tests/unit/test_model_resolver.py
@@ -629,6 +629,42 @@ class TestGetModelIdForKiro:
         print(f"Comparing result: Expected 'claude-unknown-model' (pass-through), Got '{result}'")
         assert result == "claude-unknown-model"
 
+    def test_resolves_alias_before_normalization(self):
+        """Aliases are resolved before model-name normalization."""
+        aliases = {"my-haiku": "claude-haiku-4-5"}
+
+        result = get_model_id_for_kiro("my-haiku", {}, aliases)
+
+        assert result == "claude-haiku-4.5"
+
+    def test_resolves_alias_chain(self):
+        """Alias chains resolve to their final model ID."""
+        aliases = {
+            "team-default": "my-opus",
+            "my-opus": "claude-opus-4.6",
+        }
+
+        result = get_model_id_for_kiro("team-default", {}, aliases)
+
+        assert result == "claude-opus-4.6"
+
+    def test_alias_resolves_to_hidden_model(self):
+        """Alias resolution still applies the hidden-model lookup."""
+        aliases = {"legacy": "claude-3.7-sonnet"}
+        hidden = {"claude-3.7-sonnet": "CLAUDE_3_7_SONNET_INTERNAL"}
+
+        result = get_model_id_for_kiro("legacy", hidden, aliases)
+
+        assert result == "CLAUDE_3_7_SONNET_INTERNAL"
+
+    def test_alias_cycle_falls_back_to_original_name(self):
+        """Cyclic aliases cannot recurse indefinitely."""
+        aliases = {"model-a": "model-b", "model-b": "model-a"}
+
+        result = get_model_id_for_kiro("model-a", {}, aliases)
+
+        assert result == "model-a"
+
 
 # =============================================================================
 # TestModelResolver - Tests for ModelResolver class


### PR DESCRIPTION
## Recovery purpose

Preserves the safe, intentional portion of a local alias-resolution change on current upstream `main`.

## Changes

- Resolve configured aliases in both OpenAI and Anthropic converter paths.
- Preserve the local non-secret `custom:Kiro-*` compatibility mappings.
- Support alias chains while safely falling back on cyclic mappings.
- Add helper and end-to-end converter regression coverage.

## Explicit exclusions

- No credential files or databases.
- No `.DS_Store`.
- No machine-local `docker-compose.yml` credential mount.
- No secret-bearing alias values.

## Existing overlap

This is intentionally draft because PRs #184 and #198 address portions of the generic alias-resolution issue. This recovery branch additionally covers both converter paths, cycle safety, and the local compatibility mappings; maintainers can choose whether to consolidate or close it after preservation.

## Validation

- Targeted resolver/converter tests: 266 passed.
- Full suite: 1,697 passed with 3 existing async-mock runtime warnings.
- `git diff --check`: passed.