### PR TITLE
feat: support External IdP authentication and current Claude Code clients

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,9 @@ PROXY_API_KEY="my-super-secret-password-123"
 
 # Path to JSON credentials file from Kiro IDE
 # KIRO_CREDS_FILE="~/.aws/sso/cache/kiro-auth-token.json"
+# Enterprise External IdP credentials (including Microsoft Entra ID) are
+# auto-detected from this file. Keep Kiro IDE signed in; clientSecret and
+# PROFILE_ARN are not required because the gateway reads Kiro's active profile.
 
 # ===========================================
 # OPTION 2: Kiro IDE refresh token
@@ -52,7 +55,7 @@ PROXY_API_KEY="my-super-secret-password-123"
 # ===========================================
 
 # AWS CodeWhisperer profile ARN
-# For Kiro IDE: usually auto-detected from credentials file
+# For Kiro IDE: auto-detected from the credentials file or Kiro extension state
 # For kiro-cli (AWS SSO / Builder ID): not needed, will be ignored
 # PROFILE_ARN="arn:aws:codewhisperer:us-east-1:..."
 

--- a/README.md
+++ b/README.md
@@ -686,7 +686,8 @@ curl http://localhost:8000/v1/messages \
   }'
 ```
 
-> **Note:** In Anthropic API, `system` is a separate field, not a message.
+> **Note:** Standard Anthropic requests use a separate `system` field. For Claude Code compatibility,
+> the gateway also accepts `system` entries inside `messages` and promotes them to the Kiro system prompt.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ PROXY_API_KEY="my-super-secret-password-123"
 
 > **Note:** If you have two JSON files in `~/.aws/sso/cache/` (e.g., `kiro-auth-token.json` and a file with a hash name), use `kiro-auth-token.json` in `KIRO_CREDS_FILE`. The gateway will automatically load the other file.
 
+Current Kiro IDE versions may use a direct enterprise OIDC provider such as
+Microsoft Entra ID. Those files are detected from `authMethod: "external_idp"`
+and include `clientId`, `issuerUrl`, `tokenEndpoint`, and `scopes`. The gateway
+refreshes the token directly with that provider and automatically reads the
+selected `profileArn` from Kiro IDE's extension storage. Keep Kiro IDE signed
+in and point `KIRO_CREDS_FILE` at the file it manages; no client secret or
+manual `PROFILE_ARN` is required.
+
 </details>
 
 ### Option 2: Environment Variables (.env file)
@@ -201,6 +209,12 @@ AWS SSO credentials files (from `~/.aws/sso/cache/`) contain:
 <summary>🔍 How it works</summary>
 
 The gateway automatically detects the authentication type based on the credentials file:
+
+- **External IdP (Entra ID, Okta, compatible OIDC)**: Used when Kiro marks the
+  credentials with `authMethod: "external_idp"` or `provider: "ExternalIdp"`
+  - Endpoint: The HTTPS `tokenEndpoint` recorded by Kiro IDE
+  - Request: OAuth public-client refresh grant (no client secret)
+  - Kiro API requests include `TokenType: EXTERNAL_IDP`
 
 - **Kiro Desktop Auth** (default): Used when `clientId` and `clientSecret` are NOT present
   - Endpoint: `https://prod.{region}.auth.desktop.kiro.dev/refreshToken`

--- a/docs/en/ARCHITECTURE.md
+++ b/docs/en/ARCHITECTURE.md
@@ -454,9 +454,14 @@ prompt_tokens = total_tokens - completion_tokens             (subtraction)
 
 ### 3.14. Kiro API Endpoints
 
-All URLs are dynamically formed based on the region:
+Runtime URLs are dynamically formed based on the region. Token refresh is
+selected from the credential type:
 
-*   **Token Refresh:** `POST https://prod.{region}.auth.desktop.kiro.dev/refreshToken`
+*   **Kiro Desktop Refresh:** `POST https://prod.{region}.auth.desktop.kiro.dev/refreshToken`
+*   **AWS SSO OIDC Refresh:** `POST https://oidc.{region}.amazonaws.com/token`
+*   **External IdP Refresh:** `POST` to the validated HTTPS `tokenEndpoint`
+    stored by Kiro IDE. Uses a public-client refresh grant and adds
+    `TokenType: EXTERNAL_IDP` to subsequent Kiro requests.
 *   **List Models:** `GET https://q.{region}.amazonaws.com/ListAvailableModels`
 *   **Generate Response:** `POST https://codewhisperer.{region}.amazonaws.com/generateAssistantResponse`
 
@@ -651,6 +656,12 @@ TOOL_DESCRIPTION_MAX_LENGTH="10000"
   "region": "us-east-1"
 }
 ```
+
+Enterprise Kiro IDE credentials can additionally contain `authMethod`,
+`provider`, `clientId`, `issuerUrl`, `tokenEndpoint`, and `scopes`. When
+`authMethod` is `external_idp`, the selected CodeWhisperer profile ARN is read
+from Kiro IDE extension global storage because it is not part of the token
+cache.
 
 ## 7. API Endpoints
 

--- a/kiro/auth.py
+++ b/kiro/auth.py
@@ -24,7 +24,7 @@ Manages the lifecycle of access tokens:
 - Loading credentials from .env or JSON file
 - Automatic token refresh on expiration
 - Thread-safe refresh using asyncio.Lock
-- Support for both Kiro Desktop Auth and AWS SSO OIDC (kiro-cli)
+- Support for Kiro Desktop, AWS SSO OIDC, and enterprise External IdP auth
 """
 
 import asyncio
@@ -36,11 +36,14 @@ from datetime import datetime, timezone, timedelta
 from enum import Enum
 from pathlib import Path
 from typing import Optional
+from urllib.parse import urlparse
 
 import httpx
 from loguru import logger
 
 from kiro.config import (
+    BASE_RETRY_DELAY,
+    MAX_RETRIES,
     TOKEN_REFRESH_THRESHOLD,
     SQLITE_READONLY,
     get_kiro_refresh_url,
@@ -48,11 +51,16 @@ from kiro.config import (
     get_kiro_q_host,
     get_aws_sso_oidc_url,
 )
-from kiro.utils import get_machine_fingerprint
+from kiro.utils import (
+    detect_kiro_agent_profile_arn,
+    extract_region_from_profile_arn,
+    get_machine_fingerprint,
+)
 
 
 # Supported SQLite token keys (searched in priority order)
 SQLITE_TOKEN_KEYS = [
+    "kirocli:external-idp:token",  # Enterprise external IdP (Entra ID, Okta, etc.)
     "kirocli:social:token",      # Social login (Google, GitHub, Microsoft, etc.)
     "kirocli:odic:token",        # AWS SSO OIDC (kiro-cli corporate)
     "codewhisperer:odic:token",  # Legacy AWS SSO OIDC
@@ -77,9 +85,15 @@ class AuthType(Enum):
         - Uses https://oidc.{region}.amazonaws.com/token
         - Form body: grant_type=refresh_token&client_id=...&client_secret=...&refresh_token=...
         - Requires clientId and clientSecret from credentials file
+
+    EXTERNAL_IDP: Enterprise OIDC credentials from Kiro IDE
+        - Uses the tokenEndpoint stored in the Kiro credential cache
+        - Form body: grant_type=refresh_token&client_id=...&refresh_token=...
+        - Requires the TokenType: EXTERNAL_IDP header on Kiro API requests
     """
     KIRO_DESKTOP = "kiro_desktop"
     AWS_SSO_OIDC = "aws_sso_oidc"
+    EXTERNAL_IDP = "external_idp"
 
 
 class KiroAuthManager:
@@ -91,7 +105,7 @@ class KiroAuthManager:
     - Automatic token refresh on expiration
     - Expiration time validation (expiresAt)
     - Saving updated tokens to file
-    - Both Kiro Desktop Auth and AWS SSO OIDC (kiro-cli) authentication
+    - Kiro Desktop, AWS SSO OIDC, and enterprise External IdP authentication
     
     Attributes:
         profile_arn: AWS CodeWhisperer profile ARN
@@ -99,7 +113,7 @@ class KiroAuthManager:
         api_host: API host for the current region
         q_host: Q API host for the current region
         fingerprint: Unique machine fingerprint
-        auth_type: Type of authentication (KIRO_DESKTOP or AWS_SSO_OIDC)
+        auth_type: Authentication mechanism selected from credential metadata
     
     Example:
         >>> # Kiro Desktop Auth (default)
@@ -156,6 +170,14 @@ class KiroAuthManager:
         
         # Enterprise Kiro IDE specific fields
         self._client_id_hash: Optional[str] = None  # clientIdHash from Enterprise Kiro IDE
+
+        # External identity provider fields (Entra ID, Okta, and compatible OIDC providers)
+        self._auth_method: Optional[str] = None
+        self._provider: Optional[str] = None
+        self._token_endpoint: Optional[str] = None
+        self._issuer_url: Optional[str] = None
+        self._external_scopes: Optional[str] = None
+        self._audience: Optional[str] = None
         
         # Auto-detected API region from credentials
         # This is separate from SSO region because q.amazonaws.com endpoints
@@ -184,6 +206,14 @@ class KiroAuthManager:
         
         # Determine auth type based on available credentials
         self._detect_auth_type()
+
+        # External IdP credentials do not include the selected profile ARN.
+        # Kiro IDE stores it separately in extension global storage.
+        if self._auth_type == AuthType.EXTERNAL_IDP:
+            if not self._profile_arn:
+                self._profile_arn = detect_kiro_agent_profile_arn()
+            if self._profile_arn and not self._detected_api_region:
+                self._detected_api_region = extract_region_from_profile_arn(self._profile_arn)
         
         # Determine final API region with priority hierarchy:
         # 1. Explicit api_region parameter (per-account) - HIGHEST
@@ -230,15 +260,40 @@ class KiroAuthManager:
             f"api_host={self._api_host}, "
             f"q_host={self._q_host}"
         )
+
+    @staticmethod
+    def _normalize_external_scopes(scopes: object) -> Optional[str]:
+        """
+        Normalizes OIDC scopes to the form-encoded OAuth representation.
+
+        Args:
+            scopes: A space-delimited string or list of scope strings.
+
+        Returns:
+            A space-delimited scope string, otherwise None.
+        """
+        if isinstance(scopes, str):
+            normalized = " ".join(scopes.split())
+            return normalized or None
+        if isinstance(scopes, list) and all(isinstance(scope, str) for scope in scopes):
+            normalized = " ".join(scope.strip() for scope in scopes if scope.strip())
+            return normalized or None
+        return None
     
     def _detect_auth_type(self) -> None:
         """
         Detects authentication type based on available credentials.
         
-        AWS SSO OIDC credentials contain clientId and clientSecret.
-        Kiro Desktop credentials do not contain these fields.
+        External IdP credentials are explicitly marked by Kiro IDE. AWS SSO
+        OIDC credentials contain both clientId and clientSecret. Remaining
+        credentials use the Kiro Desktop refresh service.
         """
-        if self._client_id and self._client_secret:
+        auth_method = (self._auth_method or "").lower()
+        provider = (self._provider or "").lower()
+        if auth_method == "external_idp" or provider == "externalidp":
+            self._auth_type = AuthType.EXTERNAL_IDP
+            logger.info("Detected auth type: External IdP")
+        elif self._client_id and self._client_secret:
             self._auth_type = AuthType.AWS_SSO_OIDC
             logger.info("Detected auth type: AWS SSO OIDC (kiro-cli)")
         else:
@@ -305,6 +360,21 @@ class KiroAuthManager:
                     # Load scopes if available
                     if 'scopes' in token_data:
                         self._scopes = token_data['scopes']
+                        self._external_scopes = self._normalize_external_scopes(token_data['scopes'])
+
+                    # Load External IdP metadata if available
+                    if 'auth_method' in token_data:
+                        self._auth_method = token_data['auth_method']
+                    if 'provider' in token_data:
+                        self._provider = token_data['provider']
+                    if 'token_endpoint' in token_data:
+                        self._token_endpoint = token_data['token_endpoint']
+                    if 'issuer_url' in token_data:
+                        self._issuer_url = token_data['issuer_url']
+                    if 'client_id' in token_data:
+                        self._client_id = token_data['client_id']
+                    if 'audience' in token_data:
+                        self._audience = token_data['audience']
                     
                     # Parse expires_at (RFC3339 format)
                     if 'expires_at' in token_data:
@@ -437,6 +507,20 @@ class KiroAuthManager:
                 self._client_id = data['clientId']
             if 'clientSecret' in data:
                 self._client_secret = data['clientSecret']
+
+            # Load External IdP fields written by current Kiro IDE versions.
+            if 'authMethod' in data:
+                self._auth_method = data['authMethod']
+            if 'provider' in data:
+                self._provider = data['provider']
+            if 'tokenEndpoint' in data:
+                self._token_endpoint = data['tokenEndpoint']
+            if 'issuerUrl' in data:
+                self._issuer_url = data['issuerUrl']
+            if 'scopes' in data:
+                self._external_scopes = self._normalize_external_scopes(data['scopes'])
+            if 'audience' in data:
+                self._audience = data['audience']
             
             # Parse expiresAt
             if 'expiresAt' in data:
@@ -511,6 +595,19 @@ class KiroAuthManager:
                 existing_data['expiresAt'] = self._expires_at.isoformat()
             if self._profile_arn:
                 existing_data['profileArn'] = self._profile_arn
+            if self._auth_type == AuthType.EXTERNAL_IDP:
+                external_fields = {
+                    'authMethod': self._auth_method,
+                    'provider': self._provider,
+                    'tokenEndpoint': self._token_endpoint,
+                    'issuerUrl': self._issuer_url,
+                    'clientId': self._client_id,
+                    'scopes': self._external_scopes,
+                    'audience': self._audience,
+                }
+                existing_data.update(
+                    {key: value for key, value in external_fields.items() if value is not None}
+                )
             
             # Save
             with open(path, 'w', encoding='utf-8') as f:
@@ -612,10 +709,26 @@ class KiroAuthManager:
             existing_data["refresh_token"] = self._refresh_token
             existing_data["expires_at"] = self._expires_at.isoformat() if self._expires_at else None
             existing_data["region"] = self._sso_region or self._region
+            if self._profile_arn:
+                existing_data["profile_arn"] = self._profile_arn
             
             # Update scopes if we have them
             if self._scopes:
                 existing_data["scopes"] = self._scopes
+
+            if self._auth_type == AuthType.EXTERNAL_IDP:
+                external_fields = {
+                    "auth_method": self._auth_method,
+                    "provider": self._provider,
+                    "token_endpoint": self._token_endpoint,
+                    "issuer_url": self._issuer_url,
+                    "client_id": self._client_id,
+                    "scopes": self._external_scopes,
+                    "audience": self._audience,
+                }
+                existing_data.update(
+                    {key: value for key, value in external_fields.items() if value is not None}
+                )
             
             token_json = json.dumps(existing_data)
             
@@ -671,6 +784,7 @@ class KiroAuthManager:
         Routes to appropriate refresh method based on auth type:
         - KIRO_DESKTOP: Uses Kiro Desktop Auth endpoint
         - AWS_SSO_OIDC: Uses AWS SSO OIDC endpoint
+        - EXTERNAL_IDP: Uses the configured enterprise OIDC token endpoint
         
         Raises:
             ValueError: If refresh token is not set or response doesn't contain accessToken
@@ -678,8 +792,188 @@ class KiroAuthManager:
         """
         if self._auth_type == AuthType.AWS_SSO_OIDC:
             await self._refresh_token_aws_sso_oidc()
+        elif self._auth_type == AuthType.EXTERNAL_IDP:
+            await self._refresh_token_external_idp()
         else:
             await self._refresh_token_kiro_desktop()
+
+    def _validate_external_idp_configuration(self) -> str:
+        """
+        Validates External IdP credentials before making a refresh request.
+
+        Returns:
+            The validated token endpoint URL.
+
+        Raises:
+            ValueError: If required fields are missing or endpoint URLs are
+                unsafe or inconsistent.
+        """
+        if not self._refresh_token:
+            raise ValueError(
+                "External IdP refresh token is missing. Sign in to Kiro IDE again, "
+                "then restart the gateway."
+            )
+        if not self._client_id:
+            raise ValueError(
+                "External IdP clientId is missing from the Kiro credentials file. "
+                "Sign in to Kiro IDE again to recreate it."
+            )
+        if not self._token_endpoint:
+            raise ValueError(
+                "External IdP tokenEndpoint is missing from the Kiro credentials file. "
+                "Sign in to Kiro IDE again to recreate it."
+            )
+
+        token_endpoint = urlparse(self._token_endpoint)
+        if (
+            token_endpoint.scheme.lower() != "https"
+            or not token_endpoint.hostname
+            or token_endpoint.username
+            or token_endpoint.password
+        ):
+            raise ValueError(
+                "External IdP tokenEndpoint must be an HTTPS URL without embedded credentials."
+            )
+
+        if self._issuer_url:
+            issuer_url = urlparse(self._issuer_url)
+            if (
+                issuer_url.scheme.lower() != "https"
+                or not issuer_url.hostname
+                or issuer_url.username
+                or issuer_url.password
+            ):
+                raise ValueError(
+                    "External IdP issuerUrl must be an HTTPS URL without embedded credentials."
+                )
+            if issuer_url.hostname.lower() != token_endpoint.hostname.lower():
+                raise ValueError(
+                    "External IdP tokenEndpoint host must match issuerUrl host. "
+                    "Sign in to Kiro IDE again if the credential cache was modified."
+                )
+
+        return self._token_endpoint
+
+    def _reload_external_idp_credentials(self) -> None:
+        """
+        Reloads credentials managed by a concurrently running Kiro client.
+
+        Kiro IDE and kiro-cli may rotate refresh tokens. Reloading the source
+        before retrying prevents the gateway from repeatedly using a stale
+        in-memory token.
+        """
+        if self._sqlite_db:
+            self._load_credentials_from_sqlite(self._sqlite_db)
+        elif self._creds_file:
+            self._load_credentials_from_file(self._creds_file)
+        self._detect_auth_type()
+
+    async def _refresh_token_external_idp(self) -> None:
+        """
+        Refreshes an enterprise token through its configured OIDC provider.
+
+        Authentication errors trigger one credential-source reload because
+        Kiro IDE may have rotated the refresh token. Transient provider errors
+        use bounded exponential backoff.
+
+        Raises:
+            ValueError: If External IdP configuration or response data is invalid.
+            httpx.HTTPError: If the provider request fails after retries.
+        """
+        source_reloaded = False
+        retry_attempt = 0
+
+        while True:
+            try:
+                await self._do_external_idp_refresh()
+                return
+            except httpx.HTTPStatusError as error:
+                status_code = error.response.status_code
+                if status_code in (400, 401) and not source_reloaded and (
+                    self._creds_file or self._sqlite_db
+                ):
+                    logger.warning(
+                        "External IdP refresh was rejected; reloading Kiro credentials once."
+                    )
+                    self._reload_external_idp_credentials()
+                    source_reloaded = True
+                    continue
+
+                if (status_code == 429 or status_code >= 500) and retry_attempt < MAX_RETRIES:
+                    delay = BASE_RETRY_DELAY * (2 ** retry_attempt)
+                    retry_attempt += 1
+                    logger.warning(
+                        f"External IdP refresh temporarily failed with HTTP {status_code}; "
+                        f"retrying in {delay:.1f}s ({retry_attempt}/{MAX_RETRIES})."
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                raise
+            except (httpx.TimeoutException, httpx.TransportError) as error:
+                if retry_attempt >= MAX_RETRIES:
+                    raise
+                delay = BASE_RETRY_DELAY * (2 ** retry_attempt)
+                retry_attempt += 1
+                logger.warning(
+                    f"External IdP refresh network error ({type(error).__name__}); "
+                    f"retrying in {delay:.1f}s ({retry_attempt}/{MAX_RETRIES})."
+                )
+                await asyncio.sleep(delay)
+
+    async def _do_external_idp_refresh(self) -> None:
+        """
+        Performs one OAuth 2.0 public-client refresh-token grant.
+
+        Raises:
+            ValueError: If credentials or provider response data are invalid.
+            httpx.HTTPStatusError: If the provider returns an HTTP error.
+            httpx.HTTPError: If the provider cannot be reached.
+        """
+        token_endpoint = self._validate_external_idp_configuration()
+        logger.info("Refreshing Kiro token via External IdP...")
+
+        payload = {
+            "grant_type": "refresh_token",
+            "client_id": self._client_id,
+            "refresh_token": self._refresh_token,
+        }
+        if self._external_scopes:
+            payload["scope"] = self._external_scopes
+
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        async with httpx.AsyncClient(timeout=30) as client:
+            response = await client.post(token_endpoint, data=payload, headers=headers)
+            response.raise_for_status()
+            try:
+                result = response.json()
+            except json.JSONDecodeError as error:
+                raise ValueError(
+                    "External IdP returned a non-JSON token response."
+                ) from error
+
+        new_access_token = result.get("access_token")
+        new_refresh_token = result.get("refresh_token")
+        if not new_access_token:
+            raise ValueError("External IdP response did not contain access_token.")
+
+        expires_in_value = result.get("expires_in", 3600)
+        try:
+            expires_in = float(expires_in_value)
+        except (TypeError, ValueError) as error:
+            raise ValueError("External IdP response contained an invalid expires_in value.") from error
+
+        self._access_token = new_access_token
+        if new_refresh_token:
+            self._refresh_token = new_refresh_token
+        self._expires_at = datetime.now(timezone.utc) + timedelta(
+            seconds=max(expires_in - 60, 0)
+        )
+
+        logger.info(f"Token refreshed via External IdP, expires: {self._expires_at.isoformat()}")
+        if self._sqlite_db:
+            self._save_credentials_to_sqlite()
+        else:
+            self._save_credentials_to_file()
     
     async def _refresh_token_kiro_desktop(self) -> None:
         """
@@ -898,6 +1192,19 @@ class KiroAuthManager:
                 if self._access_token and not self.is_token_expiring_soon():
                     logger.debug("SQLite reload provided fresh token, no refresh needed")
                     return self._access_token
+
+            # Kiro IDE may refresh or rotate External IdP credentials while it
+            # is running. Reload its JSON cache before making our own request.
+            if (
+                self._auth_type == AuthType.EXTERNAL_IDP
+                and self._creds_file
+                and self.is_token_expiring_soon()
+            ):
+                logger.debug("External IdP mode: reloading Kiro IDE credentials before refresh")
+                self._reload_external_idp_credentials()
+                if self._access_token and not self.is_token_expiring_soon():
+                    logger.debug("Kiro IDE credential reload provided a fresh token")
+                    return self._access_token
             
             # Try to refresh the token
             try:
@@ -973,5 +1280,12 @@ class KiroAuthManager:
     
     @property
     def auth_type(self) -> AuthType:
-        """Authentication type (KIRO_DESKTOP or AWS_SSO_OIDC)."""
+        """Authentication type used for token refresh and Kiro requests."""
         return self._auth_type
+
+    @property
+    def token_type(self) -> Optional[str]:
+        """Kiro token-type header value required by External IdP sessions."""
+        if self._auth_type == AuthType.EXTERNAL_IDP:
+            return "EXTERNAL_IDP"
+        return None

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -278,10 +278,16 @@ FALLBACK_MODELS: List[Dict[str, str]] = [
     {"modelId": "claude-sonnet-4"},
     {"modelId": "claude-sonnet-4.5"},
     {"modelId": "claude-sonnet-4.6"},
+    {"modelId": "claude-sonnet-5"},
     {"modelId": "claude-haiku-4.5"},
     {"modelId": "claude-opus-4.5"},
     {"modelId": "claude-opus-4.6"},
     {"modelId": "claude-opus-4.7"},
+    {"modelId": "claude-opus-4.8"},
+    {"modelId": "claude-opus-5"},
+    {"modelId": "gpt-5.6-sol"},
+    {"modelId": "gpt-5.6-terra"},
+    {"modelId": "gpt-5.6-luna"},
     {"modelId": "deepseek-3.2"},
     {"modelId": "glm-5"},
     {"modelId": "minimax-m2.1"},
@@ -578,4 +584,3 @@ def get_kiro_api_host(region: str) -> str:
 def get_kiro_q_host(region: str) -> str:
     """Return Q API host for the specified region."""
     return KIRO_Q_HOST_TEMPLATE.format(region=region)
-

--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -24,7 +24,7 @@ This module is an adapter layer that converts Anthropic-specific formats
 to the unified format used by converters_core.py.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from loguru import logger
 
@@ -111,6 +111,48 @@ def extract_system_prompt(system: Any) -> str:
         return "\n".join(text_parts)
 
     return str(system)
+
+
+def extract_inline_system_messages(
+    messages: List[AnthropicMessage],
+) -> Tuple[str, List[AnthropicMessage]]:
+    """
+    Extract Claude Code inline system messages from conversation messages.
+
+    Anthropic's public Messages API represents the system prompt in a top-level
+    field, but Claude Code may also send system-role messages in the messages
+    array. Kiro cannot represent that role in conversation history, so these
+    messages are promoted to the system prompt while all conversational
+    messages retain their original order.
+
+    Args:
+        messages: Anthropic messages, including possible system-role messages.
+
+    Returns:
+        A tuple containing the combined inline system prompt and the remaining
+        user/assistant messages.
+    """
+    system_parts: List[str] = []
+    conversational_messages: List[AnthropicMessage] = []
+    system_message_count = 0
+
+    for message in messages:
+        if message.role != "system":
+            conversational_messages.append(message)
+            continue
+
+        system_message_count += 1
+        system_text = convert_anthropic_content_to_text(message.content)
+        if system_text:
+            system_parts.append(system_text)
+
+    if system_message_count > 0:
+        logger.debug(
+            f"Promoted {system_message_count} inline Anthropic system message(s) "
+            "to the Kiro system prompt"
+        )
+
+    return "\n\n".join(system_parts), conversational_messages
 
 
 def extract_tool_results_from_anthropic_content(content: Any) -> List[Dict[str, Any]]:
@@ -450,15 +492,27 @@ def anthropic_to_kiro(
     Raises:
         ValueError: If there are no messages to send
     """
-    # Convert messages to unified format
-    unified_messages = convert_anthropic_messages(request.messages)
+    # Claude Code may send system-role messages inside the messages array.
+    # Promote them before conversion so the actual user turn remains current.
+    inline_system_prompt, conversational_messages = extract_inline_system_messages(
+        request.messages
+    )
+
+    # Convert the remaining user/assistant messages to unified format
+    unified_messages = convert_anthropic_messages(conversational_messages)
 
     # Convert tools to unified format
     unified_tools = convert_anthropic_tools(request.tools)
 
-    # System prompt is already separate in Anthropic format!
-    # It can be a string or list of content blocks (for prompt caching)
-    system_prompt = extract_system_prompt(request.system)
+    # Combine the standard top-level system field with any inline system
+    # messages sent by Claude Code. Preserve their source order within each
+    # form and put the standard system prompt first.
+    top_level_system_prompt = extract_system_prompt(request.system)
+    system_prompt = "\n\n".join(
+        prompt
+        for prompt in (top_level_system_prompt, inline_system_prompt)
+        if prompt
+    )
 
     # Get model ID for Kiro API (normalizes + resolves hidden models)
     # Pass-through principle: we normalize and send to Kiro, Kiro decides if valid

--- a/kiro/mcp_tools.py
+++ b/kiro/mcp_tools.py
@@ -41,6 +41,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from loguru import logger
 
 from kiro.tokenizer import count_message_tokens, count_tokens
+from kiro.utils import get_external_idp_headers
 
 # Import debug_logger
 try:
@@ -153,6 +154,7 @@ async def call_kiro_mcp_api(
             "x-amzn-codewhisperer-optout": "false",
             "Content-Type": "application/json"
         }
+        headers.update(get_external_idp_headers(auth_manager))
         
         mcp_url = f"{auth_manager.q_host}/mcp"
         logger.debug(f"Calling MCP API: {mcp_url}")

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -183,11 +183,11 @@ class AnthropicMessage(BaseModel):
     Message in Anthropic format.
 
     Attributes:
-        role: Message role (user or assistant)
+        role: Message role (user, assistant, or inline system compatibility message)
         content: Message content (string or list of content blocks)
     """
 
-    role: Literal["user", "assistant"]
+    role: Literal["user", "assistant", "system"]
     content: Union[str, List[ContentBlock]]
 
     model_config = {"extra": "allow"}

--- a/kiro/utils.py
+++ b/kiro/utils.py
@@ -26,8 +26,12 @@ and other common utilities.
 
 import hashlib
 import json
+import os
+import re
+import sys
 import uuid
-from typing import TYPE_CHECKING, List, Dict, Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from loguru import logger
 
@@ -58,7 +62,27 @@ def get_machine_fingerprint() -> str:
         return hashlib.sha256(b"default-kiro-gateway").hexdigest()
 
 
-def get_kiro_headers(auth_manager: "KiroAuthManager", token: str) -> dict:
+def get_external_idp_headers(auth_manager: "KiroAuthManager") -> Dict[str, str]:
+    """
+    Builds request headers that are specific to External IdP authentication.
+
+    Kiro marks tokens issued by a configured enterprise identity provider with
+    ``TokenType: EXTERNAL_IDP``. The header is required for both the Q runtime
+    and MCP endpoints; without it, a valid Entra ID token is rejected.
+
+    Args:
+        auth_manager: Authentication manager describing the active auth type.
+
+    Returns:
+        External IdP headers, or an empty dictionary for other auth types.
+    """
+    token_type = getattr(auth_manager, "token_type", None)
+    if token_type == "EXTERNAL_IDP":
+        return {"TokenType": token_type}
+    return {}
+
+
+def get_kiro_headers(auth_manager: "KiroAuthManager", token: str) -> Dict[str, str]:
     """
     Builds headers for Kiro API requests.
     
@@ -76,7 +100,7 @@ def get_kiro_headers(auth_manager: "KiroAuthManager", token: str) -> dict:
     """
     fingerprint = auth_manager.fingerprint
     
-    return {
+    headers = {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/x-amz-json-1.0",
         "x-amz-target": "AmazonCodeWhispererStreamingService.GenerateAssistantResponse",
@@ -87,6 +111,139 @@ def get_kiro_headers(auth_manager: "KiroAuthManager", token: str) -> dict:
         "amz-sdk-invocation-id": str(uuid.uuid4()),
         "amz-sdk-request": "attempt=1; max=3",
     }
+    headers.update(get_external_idp_headers(auth_manager))
+    return headers
+
+
+def get_kiro_agent_profile_roots() -> List[Path]:
+    """
+    Returns platform-specific Kiro Agent global-storage directories.
+
+    Returns:
+        Candidate directories containing Kiro's ``profile.json`` file.
+    """
+    if sys.platform == "darwin":
+        return [
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "Kiro"
+            / "User"
+            / "globalStorage"
+            / "kiro.kiroagent"
+        ]
+
+    if os.name == "nt":
+        app_data = os.getenv("APPDATA")
+        if not app_data:
+            return []
+        return [
+            Path(app_data)
+            / "Kiro"
+            / "User"
+            / "globalStorage"
+            / "kiro.kiroagent"
+        ]
+
+    config_home = Path(os.getenv("XDG_CONFIG_HOME", str(Path.home() / ".config")))
+    return [
+        config_home
+        / "Kiro"
+        / "User"
+        / "globalStorage"
+        / "kiro.kiroagent"
+    ]
+
+
+def _is_valid_profile_arn(profile_arn: Any) -> bool:
+    """
+    Validates a Kiro/CodeWhisperer profile ARN.
+
+    Args:
+        profile_arn: Candidate value read from Kiro state.
+
+    Returns:
+        True when the value has the expected profile ARN structure.
+    """
+    if not isinstance(profile_arn, str):
+        return False
+    return bool(
+        re.fullmatch(
+            r"arn:[^:]+:codewhisperer:[a-z0-9-]+:[^:]*:profile/.+",
+            profile_arn,
+        )
+    )
+
+
+def detect_kiro_agent_profile_arn(
+    search_roots: Optional[List[Path]] = None,
+) -> Optional[str]:
+    """
+    Detects the active CodeWhisperer profile ARN stored by Kiro IDE.
+
+    The External IdP credential cache does not contain ``profileArn``. Kiro
+    stores the selected profile separately in its extension global storage, so
+    the gateway reads that file when External IdP auth is active.
+
+    Args:
+        search_roots: Optional directories to search instead of platform
+            defaults. This is primarily useful for tests.
+
+    Returns:
+        The first valid profile ARN found, otherwise None.
+    """
+    roots = search_roots if search_roots is not None else get_kiro_agent_profile_roots()
+
+    for root in roots:
+        candidates = [root / "profile.json"]
+        if root.exists():
+            try:
+                candidates.extend(
+                    path for path in sorted(root.rglob("profile.json"))
+                    if path not in candidates
+                )
+            except OSError as error:
+                logger.debug(f"Unable to search Kiro profile directory {root}: {error}")
+
+        for profile_path in candidates:
+            try:
+                with open(profile_path, "r", encoding="utf-8") as profile_file:
+                    profile_data = json.load(profile_file)
+            except FileNotFoundError:
+                continue
+            except (OSError, json.JSONDecodeError, TypeError) as error:
+                logger.debug(f"Unable to read Kiro profile file {profile_path}: {error}")
+                continue
+
+            if not isinstance(profile_data, dict):
+                continue
+
+            profile_arn = profile_data.get("arn") or profile_data.get("profileArn")
+            if _is_valid_profile_arn(profile_arn):
+                logger.info(f"Profile ARN auto-detected from Kiro IDE: {profile_path}")
+                return profile_arn
+
+            logger.debug(f"Ignoring invalid profile ARN in {profile_path}")
+
+    return None
+
+
+def extract_region_from_profile_arn(profile_arn: str) -> Optional[str]:
+    """
+    Extracts the AWS region from a validated CodeWhisperer profile ARN.
+
+    Args:
+        profile_arn: CodeWhisperer profile ARN.
+
+    Returns:
+        AWS region from the ARN, otherwise None.
+    """
+    if not _is_valid_profile_arn(profile_arn):
+        return None
+    region = profile_arn.split(":", 5)[3]
+    if re.fullmatch(r"[a-z]+(?:-[a-z0-9]+)+-\d+", region):
+        return region
+    return None
 
 
 def generate_completion_id() -> str:

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -7,13 +7,75 @@ Tests token management logic for Kiro without real network requests.
 
 import asyncio
 import json
+import sqlite3
 import pytest
 from datetime import datetime, timezone, timedelta
+from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 import httpx
 
 from kiro.auth import KiroAuthManager, AuthType
-from kiro.config import TOKEN_REFRESH_THRESHOLD, get_aws_sso_oidc_url
+from kiro.config import MAX_RETRIES, TOKEN_REFRESH_THRESHOLD, get_aws_sso_oidc_url
+from kiro.utils import detect_kiro_agent_profile_arn, get_kiro_headers
+
+
+@pytest.fixture
+def temp_external_idp_creds_file(tmp_path: Path) -> str:
+    """
+    Creates a Kiro IDE External IdP credential cache for isolated tests.
+
+    Returns:
+        Path to the temporary JSON credential file.
+    """
+    credentials = {
+        "authMethod": "external_idp",
+        "provider": "ExternalIdp",
+        "accessToken": "expired_external_access_token",
+        "refreshToken": "external_refresh_token",
+        "expiresAt": "2020-01-01T00:00:00.000Z",
+        "clientId": "external_public_client_id",
+        "issuerUrl": "https://login.microsoftonline.com/test-tenant/v2.0",
+        "tokenEndpoint": (
+            "https://login.microsoftonline.com/test-tenant/oauth2/v2.0/token"
+        ),
+        "scopes": "openid profile offline_access codewhisperer:completions",
+    }
+    credentials_path = tmp_path / "external-idp.json"
+    credentials_path.write_text(json.dumps(credentials), encoding="utf-8")
+    return str(credentials_path)
+
+
+@pytest.fixture
+def external_idp_manager(temp_external_idp_creds_file: str) -> KiroAuthManager:
+    """
+    Creates an External IdP manager without reading workstation profile state.
+
+    Returns:
+        Initialized External IdP authentication manager.
+    """
+    with patch("kiro.auth.detect_kiro_agent_profile_arn", return_value=None):
+        return KiroAuthManager(creds_file=temp_external_idp_creds_file)
+
+
+def make_external_idp_response(
+    status_code: int = 200,
+    payload: dict | None = None,
+) -> httpx.Response:
+    """
+    Builds an HTTP response associated with a provider token request.
+
+    Args:
+        status_code: HTTP response status.
+        payload: JSON response body.
+
+    Returns:
+        HTTPX response suitable for refresh tests.
+    """
+    request = httpx.Request(
+        "POST",
+        "https://login.microsoftonline.com/test-tenant/oauth2/v2.0/token",
+    )
+    return httpx.Response(status_code, json=payload or {}, request=request)
 
 
 class TestKiroAuthManagerInitialization:
@@ -511,16 +573,19 @@ class TestAuthTypeEnum:
     def test_auth_type_enum_values(self):
         """
         What it does: Verifies AuthType enum values.
-        Purpose: Ensure enum contains KIRO_DESKTOP and AWS_SSO_OIDC.
+        Purpose: Ensure enum contains all supported authentication mechanisms.
         """
         print("Verification: AuthType contains KIRO_DESKTOP...")
         assert AuthType.KIRO_DESKTOP.value == "kiro_desktop"
         
         print("Verification: AuthType contains AWS_SSO_OIDC...")
         assert AuthType.AWS_SSO_OIDC.value == "aws_sso_oidc"
+
+        print("Verification: AuthType contains EXTERNAL_IDP...")
+        assert AuthType.EXTERNAL_IDP.value == "external_idp"
         
-        print(f"Comparing value count: Expected 2, Got {len(AuthType)}")
-        assert len(AuthType) == 2
+        print(f"Comparing value count: Expected 3, Got {len(AuthType)}")
+        assert len(AuthType) == 3
 
 
 # =============================================================================
@@ -4251,3 +4316,491 @@ class TestAPIRegionPriorityHierarchy:
         print(f"Result: api_host={manager5._api_host}")
         assert "ap-south-1" in manager5._api_host
 
+
+# =============================================================================
+# Tests for Kiro IDE External IdP authentication
+# =============================================================================
+
+
+class TestExternalIdpCredentialLoading:
+    """Tests External IdP detection, loading, and Kiro profile discovery."""
+
+    def test_loads_current_kiro_external_idp_schema(
+        self,
+        external_idp_manager: KiroAuthManager,
+    ) -> None:
+        """
+        What it does: Loads the External IdP fields written by Kiro IDE.
+        Purpose: Prevent Entra credentials from falling back to desktop auth.
+        """
+        assert external_idp_manager.auth_type == AuthType.EXTERNAL_IDP
+        assert external_idp_manager._client_id == "external_public_client_id"
+        assert external_idp_manager._provider == "ExternalIdp"
+        assert external_idp_manager._token_endpoint.endswith("/oauth2/v2.0/token")
+        assert "offline_access" in external_idp_manager._external_scopes
+        assert external_idp_manager.token_type == "EXTERNAL_IDP"
+
+    def test_external_marker_takes_priority_over_client_secret(
+        self,
+        temp_external_idp_creds_file: str,
+    ) -> None:
+        """
+        What it does: Detects explicit External IdP metadata before AWS SSO.
+        Purpose: Ensure extra cache fields cannot route Entra tokens to AWS OIDC.
+        """
+        credentials_path = Path(temp_external_idp_creds_file)
+        credentials = json.loads(credentials_path.read_text(encoding="utf-8"))
+        credentials["clientSecret"] = "unexpected_secret"
+        credentials_path.write_text(json.dumps(credentials), encoding="utf-8")
+
+        with patch("kiro.auth.detect_kiro_agent_profile_arn", return_value=None):
+            manager = KiroAuthManager(creds_file=temp_external_idp_creds_file)
+
+        assert manager.auth_type == AuthType.EXTERNAL_IDP
+
+    def test_auto_detects_profile_and_region_from_kiro_ide(
+        self,
+        temp_external_idp_creds_file: str,
+    ) -> None:
+        """
+        What it does: Reads Kiro's separately stored active enterprise profile.
+        Purpose: Supply runtime profileArn without manual .env configuration.
+        """
+        profile_arn = (
+            "arn:aws:codewhisperer:eu-central-1:123456789012:profile/test-profile"
+        )
+        with patch(
+            "kiro.auth.detect_kiro_agent_profile_arn",
+            return_value=profile_arn,
+        ):
+            manager = KiroAuthManager(creds_file=temp_external_idp_creds_file)
+
+        assert manager.profile_arn == profile_arn
+        assert "runtime.eu-central-1.kiro.dev" in manager.api_host
+
+    def test_derives_region_from_profile_persisted_after_refresh(
+        self,
+        temp_external_idp_creds_file: str,
+    ) -> None:
+        """
+        What it does: Restarts from an External IdP cache containing profileArn.
+        Purpose: Preserve automatic region selection after the first refresh.
+        """
+        credentials_path = Path(temp_external_idp_creds_file)
+        credentials = json.loads(credentials_path.read_text(encoding="utf-8"))
+        credentials["profileArn"] = (
+            "arn:aws:codewhisperer:eu-west-1:123456789012:profile/test-profile"
+        )
+        credentials_path.write_text(json.dumps(credentials), encoding="utf-8")
+
+        with patch("kiro.auth.detect_kiro_agent_profile_arn") as detect_mock:
+            manager = KiroAuthManager(creds_file=temp_external_idp_creds_file)
+
+        detect_mock.assert_not_called()
+        assert manager.profile_arn == credentials["profileArn"]
+        assert "runtime.eu-west-1.kiro.dev" in manager.api_host
+
+    @pytest.mark.parametrize("profile_key", ["arn", "profileArn"])
+    def test_profile_discovery_supports_known_key_names(
+        self,
+        tmp_path: Path,
+        profile_key: str,
+    ) -> None:
+        """
+        What it does: Parses both Kiro profile-file key variants.
+        Purpose: Preserve compatibility across Kiro IDE releases.
+        """
+        profile_arn = (
+            "arn:aws:codewhisperer:us-east-1:123456789012:profile/test-profile"
+        )
+        profile_root = tmp_path / "kiro.kiroagent"
+        profile_root.mkdir()
+        (profile_root / "profile.json").write_text(
+            json.dumps({profile_key: profile_arn}),
+            encoding="utf-8",
+        )
+
+        assert detect_kiro_agent_profile_arn([profile_root]) == profile_arn
+
+    @pytest.mark.parametrize(
+        "profile_contents",
+        ["not-json", json.dumps({"arn": "https://example.com/not-an-arn"}), "[]"],
+    )
+    def test_profile_discovery_ignores_malformed_state(
+        self,
+        tmp_path: Path,
+        profile_contents: str,
+    ) -> None:
+        """
+        What it does: Rejects malformed profile files and invalid ARN values.
+        Purpose: Avoid sending corrupt local state to the Kiro runtime.
+        """
+        profile_root = tmp_path / "kiro.kiroagent"
+        profile_root.mkdir()
+        (profile_root / "profile.json").write_text(profile_contents, encoding="utf-8")
+
+        assert detect_kiro_agent_profile_arn([profile_root]) is None
+
+
+class TestExternalIdpValidation:
+    """Tests required fields and SSRF-resistant endpoint validation."""
+
+    @pytest.mark.parametrize(
+        ("token_endpoint", "issuer_url", "expected_message"),
+        [
+            (
+                "http://login.microsoftonline.com/tenant/oauth2/v2.0/token",
+                "https://login.microsoftonline.com/tenant/v2.0",
+                "tokenEndpoint must be an HTTPS URL",
+            ),
+            (
+                "https://user:password@login.microsoftonline.com/tenant/token",
+                "https://login.microsoftonline.com/tenant/v2.0",
+                "without embedded credentials",
+            ),
+            (
+                "https://tokens.example.com/oauth/token",
+                "https://issuer.example.com/",
+                "host must match issuerUrl host",
+            ),
+        ],
+    )
+    def test_rejects_unsafe_or_inconsistent_provider_urls(
+        self,
+        external_idp_manager: KiroAuthManager,
+        token_endpoint: str,
+        issuer_url: str,
+        expected_message: str,
+    ) -> None:
+        """
+        What it does: Validates provider-controlled refresh destinations.
+        Purpose: Prevent credential disclosure to unsafe endpoints.
+        """
+        external_idp_manager._token_endpoint = token_endpoint
+        external_idp_manager._issuer_url = issuer_url
+
+        with pytest.raises(ValueError, match=expected_message):
+            external_idp_manager._validate_external_idp_configuration()
+
+    @pytest.mark.parametrize(
+        ("missing_field", "expected_message"),
+        [
+            ("_refresh_token", "refresh token is missing"),
+            ("_client_id", "clientId is missing"),
+            ("_token_endpoint", "tokenEndpoint is missing"),
+        ],
+    )
+    def test_reports_actionable_missing_credential_fields(
+        self,
+        external_idp_manager: KiroAuthManager,
+        missing_field: str,
+        expected_message: str,
+    ) -> None:
+        """
+        What it does: Fails before network I/O when required data is absent.
+        Purpose: Direct users back to Kiro login instead of legacy endpoints.
+        """
+        setattr(external_idp_manager, missing_field, None)
+
+        with pytest.raises(ValueError, match=expected_message):
+            external_idp_manager._validate_external_idp_configuration()
+
+
+class TestExternalIdpRefresh:
+    """Tests OAuth refresh behavior, rotation persistence, and retry handling."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_uses_public_client_form_grant_and_persists_rotation(
+        self,
+        external_idp_manager: KiroAuthManager,
+        temp_external_idp_creds_file: str,
+    ) -> None:
+        """
+        What it does: Refreshes Entra tokens using Kiro's public-client flow.
+        Purpose: Match the working Kiro IDE request without a client secret.
+        """
+        response = make_external_idp_response(
+            payload={
+                "access_token": "new_external_access_token",
+                "refresh_token": "rotated_external_refresh_token",
+                "expires_in": 3600,
+            }
+        )
+        post = AsyncMock(return_value=response)
+        client = AsyncMock()
+        client.__aenter__.return_value.post = post
+
+        with patch("kiro.auth.httpx.AsyncClient", return_value=client):
+            await external_idp_manager._refresh_token_request()
+
+        post.assert_awaited_once()
+        call = post.await_args
+        assert call.args[0] == external_idp_manager._token_endpoint
+        assert call.kwargs["data"] == {
+            "grant_type": "refresh_token",
+            "client_id": "external_public_client_id",
+            "refresh_token": "external_refresh_token",
+            "scope": "openid profile offline_access codewhisperer:completions",
+        }
+        assert "client_secret" not in call.kwargs["data"]
+        assert call.kwargs["headers"]["Content-Type"] == (
+            "application/x-www-form-urlencoded"
+        )
+        assert external_idp_manager._access_token == "new_external_access_token"
+        assert external_idp_manager._refresh_token == "rotated_external_refresh_token"
+
+        saved = json.loads(Path(temp_external_idp_creds_file).read_text(encoding="utf-8"))
+        assert saved["accessToken"] == "new_external_access_token"
+        assert saved["refreshToken"] == "rotated_external_refresh_token"
+        assert saved["tokenEndpoint"] == external_idp_manager._token_endpoint
+        assert saved["clientId"] == "external_public_client_id"
+
+    @pytest.mark.asyncio
+    async def test_refresh_reloads_rotated_credentials_once_after_unauthorized(
+        self,
+        external_idp_manager: KiroAuthManager,
+    ) -> None:
+        """
+        What it does: Retries an auth rejection after reloading Kiro state.
+        Purpose: Cooperate safely with refresh-token rotation by Kiro IDE.
+        """
+        responses = [
+            make_external_idp_response(401, {"error": "invalid_grant"}),
+            make_external_idp_response(
+                payload={"access_token": "fresh_access", "expires_in": 3600}
+            ),
+        ]
+        post = AsyncMock(side_effect=responses)
+        client = AsyncMock()
+        client.__aenter__.return_value.post = post
+
+        def reload_credentials() -> None:
+            external_idp_manager._refresh_token = "rotated_by_kiro"
+
+        with (
+            patch("kiro.auth.httpx.AsyncClient", return_value=client),
+            patch.object(
+                external_idp_manager,
+                "_reload_external_idp_credentials",
+                side_effect=reload_credentials,
+            ) as reload_mock,
+        ):
+            await external_idp_manager._refresh_token_external_idp()
+
+        reload_mock.assert_called_once()
+        assert post.await_count == 2
+        assert post.await_args_list[1].kwargs["data"]["refresh_token"] == "rotated_by_kiro"
+
+    @pytest.mark.asyncio
+    async def test_refresh_retries_transient_http_failure(
+        self,
+        external_idp_manager: KiroAuthManager,
+    ) -> None:
+        """
+        What it does: Retries provider throttling and server failures.
+        Purpose: Avoid surfacing short-lived IdP outages to API clients.
+        """
+        responses = [
+            make_external_idp_response(500, {"error": "temporarily_unavailable"}),
+            make_external_idp_response(
+                payload={"access_token": "fresh_access", "expires_in": 3600}
+            ),
+        ]
+        post = AsyncMock(side_effect=responses)
+        client = AsyncMock()
+        client.__aenter__.return_value.post = post
+
+        with (
+            patch("kiro.auth.httpx.AsyncClient", return_value=client),
+            patch("kiro.auth.asyncio.sleep", new_callable=AsyncMock) as sleep_mock,
+        ):
+            await external_idp_manager._refresh_token_external_idp()
+
+        assert post.await_count == 2
+        sleep_mock.assert_awaited_once_with(1.0)
+
+    @pytest.mark.asyncio
+    async def test_refresh_retries_timeout_then_succeeds(
+        self,
+        external_idp_manager: KiroAuthManager,
+    ) -> None:
+        """
+        What it does: Retries a provider read timeout.
+        Purpose: Cover transient network errors independently from HTTP status.
+        """
+        request = httpx.Request("POST", external_idp_manager._token_endpoint)
+        post = AsyncMock(
+            side_effect=[
+                httpx.ReadTimeout("provider timeout", request=request),
+                make_external_idp_response(
+                    payload={"access_token": "fresh_access", "expires_in": 3600}
+                ),
+            ]
+        )
+        client = AsyncMock()
+        client.__aenter__.return_value.post = post
+
+        with (
+            patch("kiro.auth.httpx.AsyncClient", return_value=client),
+            patch("kiro.auth.asyncio.sleep", new_callable=AsyncMock) as sleep_mock,
+        ):
+            await external_idp_manager._refresh_token_external_idp()
+
+        assert post.await_count == 2
+        sleep_mock.assert_awaited_once_with(1.0)
+
+    @pytest.mark.asyncio
+    async def test_refresh_stops_after_bounded_transient_retries(
+        self,
+        external_idp_manager: KiroAuthManager,
+    ) -> None:
+        """
+        What it does: Exhausts the configured transient retry budget.
+        Purpose: Ensure an unavailable IdP cannot hang gateway requests forever.
+        """
+        response = make_external_idp_response(
+            503,
+            {"error": "temporarily_unavailable"},
+        )
+        post = AsyncMock(return_value=response)
+        client = AsyncMock()
+        client.__aenter__.return_value.post = post
+
+        with (
+            patch("kiro.auth.httpx.AsyncClient", return_value=client),
+            patch("kiro.auth.asyncio.sleep", new_callable=AsyncMock) as sleep_mock,
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await external_idp_manager._refresh_token_external_idp()
+
+        assert post.await_count == MAX_RETRIES + 1
+        assert sleep_mock.await_count == MAX_RETRIES
+
+    @pytest.mark.asyncio
+    async def test_get_access_token_uses_fresh_token_written_by_kiro(
+        self,
+        external_idp_manager: KiroAuthManager,
+        temp_external_idp_creds_file: str,
+    ) -> None:
+        """
+        What it does: Reloads the IDE cache before issuing a refresh grant.
+        Purpose: Avoid unnecessary rotation when Kiro already refreshed a token.
+        """
+        credentials_path = Path(temp_external_idp_creds_file)
+        credentials = json.loads(credentials_path.read_text(encoding="utf-8"))
+        credentials["accessToken"] = "fresh_token_from_kiro"
+        credentials["expiresAt"] = "2099-01-01T00:00:00.000Z"
+        credentials_path.write_text(json.dumps(credentials), encoding="utf-8")
+
+        with patch.object(
+            external_idp_manager,
+            "_refresh_token_request",
+            new_callable=AsyncMock,
+        ) as refresh_mock:
+            token = await external_idp_manager.get_access_token()
+
+        assert token == "fresh_token_from_kiro"
+        refresh_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rejects_token_response_without_access_token(
+        self,
+        external_idp_manager: KiroAuthManager,
+    ) -> None:
+        """
+        What it does: Rejects a syntactically valid but incomplete response.
+        Purpose: Never replace working state with a missing access token.
+        """
+        response = make_external_idp_response(payload={"expires_in": 3600})
+        post = AsyncMock(return_value=response)
+        client = AsyncMock()
+        client.__aenter__.return_value.post = post
+
+        with (
+            patch("kiro.auth.httpx.AsyncClient", return_value=client),
+            pytest.raises(ValueError, match="did not contain access_token"),
+        ):
+            await external_idp_manager._do_external_idp_refresh()
+
+
+class TestExternalIdpSqlitePersistence:
+    """Tests complete External IdP metadata round-tripping in kiro-cli SQLite."""
+
+    def test_loads_and_preserves_external_idp_metadata(self, tmp_path: Path) -> None:
+        """
+        What it does: Loads and saves the External IdP SQLite record.
+        Purpose: Avoid losing refresh-critical metadata during token rotation.
+        """
+        database_path = tmp_path / "data.sqlite3"
+        token_data = {
+            "auth_method": "external_idp",
+            "provider": "ExternalIdp",
+            "access_token": "old_access",
+            "refresh_token": "old_refresh",
+            "expires_at": "2020-01-01T00:00:00Z",
+            "client_id": "sqlite_public_client",
+            "issuer_url": "https://login.microsoftonline.com/tenant/v2.0",
+            "token_endpoint": (
+                "https://login.microsoftonline.com/tenant/oauth2/v2.0/token"
+            ),
+            "scopes": ["openid", "offline_access"],
+            "future_field": "preserve-me",
+        }
+        with sqlite3.connect(database_path) as connection:
+            connection.execute("CREATE TABLE auth_kv (key TEXT PRIMARY KEY, value TEXT)")
+            connection.execute("CREATE TABLE state (key TEXT PRIMARY KEY, value TEXT)")
+            connection.execute(
+                "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
+                ("kirocli:external-idp:token", json.dumps(token_data)),
+            )
+
+        with patch("kiro.auth.detect_kiro_agent_profile_arn", return_value=None):
+            manager = KiroAuthManager(sqlite_db=str(database_path))
+        assert manager.auth_type == AuthType.EXTERNAL_IDP
+        assert manager._client_id == "sqlite_public_client"
+        assert manager._external_scopes == "openid offline_access"
+
+        manager._access_token = "new_access"
+        manager._refresh_token = "new_refresh"
+        manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+        manager._save_credentials_to_sqlite()
+
+        with sqlite3.connect(database_path) as connection:
+            saved_json = connection.execute(
+                "SELECT value FROM auth_kv WHERE key = ?",
+                ("kirocli:external-idp:token",),
+            ).fetchone()[0]
+        saved = json.loads(saved_json)
+        assert saved["access_token"] == "new_access"
+        assert saved["refresh_token"] == "new_refresh"
+        assert saved["token_endpoint"] == token_data["token_endpoint"]
+        assert saved["issuer_url"] == token_data["issuer_url"]
+        assert saved["client_id"] == "sqlite_public_client"
+        assert saved["scopes"] == "openid offline_access"
+        assert saved["future_field"] == "preserve-me"
+
+
+class TestExternalIdpRequestHeaders:
+    """Tests shared Kiro request headers for External IdP access tokens."""
+
+    def test_runtime_headers_include_external_token_type(
+        self,
+        external_idp_manager: KiroAuthManager,
+    ) -> None:
+        """
+        What it does: Builds shared runtime headers for External IdP auth.
+        Purpose: Cover OpenAI/Anthropic streaming and non-streaming paths.
+        """
+        headers = get_kiro_headers(external_idp_manager, "external_access_token")
+
+        assert headers["Authorization"] == "Bearer external_access_token"
+        assert headers["TokenType"] == "EXTERNAL_IDP"
+
+    def test_non_external_runtime_headers_do_not_include_token_type(self) -> None:
+        """
+        What it does: Builds legacy desktop headers after the shared change.
+        Purpose: Prevent regressions for existing authentication methods.
+        """
+        manager = KiroAuthManager(refresh_token="desktop_refresh")
+
+        assert "TokenType" not in get_kiro_headers(manager, "desktop_access")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -589,6 +589,25 @@ class TestFallbackModelsConfig:
         print("Verification: Contains at least one Claude model...")
         has_claude = any("claude" in mid.lower() for mid in model_ids)
         assert has_claude, "No Claude models in fallback list"
+
+    def test_fallback_models_include_current_kiro_ide_models(self) -> None:
+        """
+        What it does: Verifies that newly advertised Kiro IDE models are present.
+        Purpose: Ensure list-only clients can select every requested current model.
+        """
+        from kiro.config import FALLBACK_MODELS
+
+        expected_models = {
+            "claude-opus-5",
+            "claude-sonnet-5",
+            "claude-opus-4.8",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+        }
+        advertised_models = {model["modelId"] for model in FALLBACK_MODELS}
+
+        assert expected_models <= advertised_models
     
     def test_fallback_models_use_dot_format(self):
         """
@@ -694,6 +713,34 @@ class TestFallbackModelsIntegration:
         
         print(f"Comparing sets: Expected {fallback_ids}, Got {available_set}")
         assert fallback_ids == available_set
+
+    @pytest.mark.asyncio
+    async def test_current_kiro_ide_models_resolve_without_rewriting(self) -> None:
+        """
+        What it does: Resolves each newly advertised model through the cache.
+        Purpose: Ensure selecting a listed model sends its exact Kiro model ID.
+        """
+        from kiro.cache import ModelInfoCache
+        from kiro.config import FALLBACK_MODELS
+        from kiro.model_resolver import ModelResolver
+
+        expected_models = {
+            "claude-opus-5",
+            "claude-sonnet-5",
+            "claude-opus-4.8",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+        }
+        cache = ModelInfoCache()
+        await cache.update(FALLBACK_MODELS)
+        resolver = ModelResolver(cache=cache, hidden_models={})
+
+        for model_id in expected_models:
+            resolution = resolver.resolve(model_id)
+            assert resolution.source == "cache"
+            assert resolution.is_verified is True
+            assert resolution.internal_id == model_id
 
 
 # ==================================================================================================

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -407,7 +407,13 @@ class TestServerPortConfig:
         """
         print("Setup: Removing SERVER_PORT from environment...")
         
-        with patch.dict(os.environ, {}, clear=False):
+        # Prevent the project .env from re-populating SERVER_PORT during the
+        # module reload. The test is specifically validating the no-config
+        # default and must remain isolated from a developer's local settings.
+        with patch.dict(os.environ, {}, clear=False), patch(
+            "dotenv.load_dotenv",
+            return_value=False,
+        ):
             if "SERVER_PORT" in os.environ:
                 del os.environ["SERVER_PORT"]
             

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -18,6 +18,7 @@ from unittest.mock import patch, MagicMock
 from kiro.converters_anthropic import (
     convert_anthropic_content_to_text,
     extract_system_prompt,
+    extract_inline_system_messages,
     extract_tool_results_from_anthropic_content,
     extract_images_from_tool_results,
     extract_tool_uses_from_anthropic_content,
@@ -939,6 +940,76 @@ class TestExtractToolUsesFromAnthropicContent:
 
 
 # ==================================================================================================
+# Tests for extract_inline_system_messages
+# ==================================================================================================
+
+
+class TestExtractInlineSystemMessages:
+    """Tests for Claude Code inline system-message extraction."""
+
+    def test_extracts_inline_system_message_and_preserves_user_turn(self):
+        """
+        What it does: Extracts a system message that follows a user message.
+        Purpose: Ensure Claude Code's actual user turn remains the active Kiro message.
+        """
+        messages = [
+            AnthropicMessage(role="user", content="hello"),
+            AnthropicMessage(
+                role="system",
+                content=[{"type": "text", "text": "Runtime reminder"}],
+            ),
+        ]
+
+        system_prompt, conversational_messages = extract_inline_system_messages(messages)
+
+        assert system_prompt == "Runtime reminder"
+        assert [message.role for message in conversational_messages] == ["user"]
+        assert conversational_messages[0].content == "hello"
+
+    def test_combines_multiple_system_messages_in_source_order(self):
+        """
+        What it does: Extracts multiple interleaved system messages.
+        Purpose: Preserve every instruction and its order while retaining conversation order.
+        """
+        messages = [
+            AnthropicMessage(role="system", content="First instruction"),
+            AnthropicMessage(role="user", content="Question"),
+            AnthropicMessage(role="assistant", content="Answer"),
+            AnthropicMessage(role="system", content="Second instruction"),
+            AnthropicMessage(role="user", content="Follow-up"),
+        ]
+
+        system_prompt, conversational_messages = extract_inline_system_messages(messages)
+
+        assert system_prompt == "First instruction\n\nSecond instruction"
+        assert [message.role for message in conversational_messages] == [
+            "user",
+            "assistant",
+            "user",
+        ]
+        assert [message.content for message in conversational_messages] == [
+            "Question",
+            "Answer",
+            "Follow-up",
+        ]
+
+    def test_ignores_empty_system_text_without_dropping_conversation(self):
+        """
+        What it does: Handles an empty inline system message.
+        Purpose: Avoid adding meaningless separators or changing conversational messages.
+        """
+        messages = [
+            AnthropicMessage(role="user", content="Question"),
+            AnthropicMessage(role="system", content=[]),
+        ]
+
+        system_prompt, conversational_messages = extract_inline_system_messages(messages)
+
+        assert system_prompt == ""
+        assert conversational_messages == [messages[0]]
+
+
+# ==================================================================================================
 # Tests for convert_anthropic_messages
 # ==================================================================================================
 
@@ -1498,6 +1569,95 @@ class TestAnthropicToKiro:
         ]["content"]
         print(f"Current content: {current_content}")
         assert "You are a helpful assistant." in current_content
+
+    def test_promotes_inline_system_message_without_replacing_current_user_turn(self):
+        """
+        What it does: Converts the inline system-message shape emitted by Claude Code.
+        Purpose: Keep the user's prompt current while preserving the system reminder.
+        """
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-5",
+            messages=[
+                AnthropicMessage(
+                    role="user",
+                    content=[{"type": "text", "text": "hello"}],
+                ),
+                AnthropicMessage(
+                    role="system",
+                    content=[
+                        {
+                            "type": "text",
+                            "text": "<system-reminder>Use the current date.</system-reminder>",
+                        }
+                    ],
+                ),
+            ],
+            max_tokens=1024,
+        )
+
+        with patch(
+            "kiro.converters_anthropic.get_model_id_for_kiro",
+            return_value="claude-sonnet-5",
+        ):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
+                result = anthropic_to_kiro(request, "conv-123", "arn:aws:test")
+
+        conversation_state = result["conversationState"]
+        current_content = conversation_state["currentMessage"]["userInputMessage"][
+            "content"
+        ]
+        assert "<system-reminder>Use the current date.</system-reminder>" in current_content
+        assert current_content.endswith("hello")
+        assert "history" not in conversation_state
+
+    def test_combines_top_level_and_inline_system_prompts(self):
+        """
+        What it does: Converts requests containing both supported system prompt forms.
+        Purpose: Preserve top-level and Claude Code inline instructions together.
+        """
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-5",
+            system="Top-level instruction",
+            messages=[
+                AnthropicMessage(role="system", content="Inline instruction"),
+                AnthropicMessage(role="user", content="Question"),
+            ],
+            max_tokens=1024,
+        )
+
+        with patch(
+            "kiro.converters_anthropic.get_model_id_for_kiro",
+            return_value="claude-sonnet-5",
+        ):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
+                result = anthropic_to_kiro(request, "conv-123", "arn:aws:test")
+
+        current_content = result["conversationState"]["currentMessage"][
+            "userInputMessage"
+        ]["content"]
+        assert current_content.startswith(
+            "Top-level instruction\n\nInline instruction\n\n"
+        )
+        assert current_content.endswith("Question")
+
+    def test_rejects_request_with_only_inline_system_messages(self):
+        """
+        What it does: Converts a request with no conversational user or assistant turn.
+        Purpose: Return the existing actionable error instead of manufacturing user content.
+        """
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-5",
+            messages=[AnthropicMessage(role="system", content="Instruction only")],
+            max_tokens=1024,
+        )
+
+        with patch(
+            "kiro.converters_anthropic.get_model_id_for_kiro",
+            return_value="claude-sonnet-5",
+        ):
+            with patch("kiro.converters_core.FAKE_REASONING_ENABLED", False):
+                with pytest.raises(ValueError, match="No messages to send"):
+                    anthropic_to_kiro(request, "conv-123", "arn:aws:test")
 
     def test_includes_tools(self):
         """

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -28,6 +28,40 @@ from kiro.mcp_tools import (
 )
 
 
+class TestExternalIdpMCPHeaders:
+    """Tests External IdP authentication headers on the separate MCP path."""
+
+    @pytest.mark.asyncio
+    async def test_mcp_request_includes_external_token_type(self) -> None:
+        """
+        What it does: Calls MCP with an External IdP authentication manager.
+        Purpose: Ensure web search receives Kiro's required token-type header.
+        """
+        auth_manager = Mock()
+        auth_manager.get_access_token = AsyncMock(return_value="external_access")
+        auth_manager.q_host = "https://q.us-east-1.api.aws"
+        auth_manager.token_type = "EXTERNAL_IDP"
+        mcp_response = {
+            "jsonrpc": "2.0",
+            "result": {
+                "content": [{"type": "text", "text": json.dumps({"results": []})}],
+                "isError": False,
+            },
+        }
+        response = Mock(status_code=200)
+        response.json.return_value = mcp_response
+        post = AsyncMock(return_value=response)
+        client = AsyncMock()
+        client.__aenter__.return_value.post = post
+
+        with patch("kiro.mcp_tools.httpx.AsyncClient", return_value=client):
+            await call_kiro_mcp_api("test", auth_manager)
+
+        headers = post.await_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer external_access"
+        assert headers["TokenType"] == "EXTERNAL_IDP"
+
+
 # ==================================================================================================
 # Tests for ID Generation
 # ==================================================================================================

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -389,6 +389,33 @@ class TestContentBlockUnion:
 
 
 # ==================================================================================================
+# Tests for AnthropicMessage roles
+# ==================================================================================================
+
+
+class TestAnthropicMessageRoles:
+    """Tests for roles accepted by AnthropicMessage."""
+
+    @pytest.mark.parametrize("role", ["user", "assistant", "system"])
+    def test_accepts_supported_roles(self, role):
+        """
+        What it does: Verifies all gateway-supported Anthropic roles validate.
+        Purpose: Support Claude Code inline system messages without weakening role validation.
+        """
+        message = AnthropicMessage(role=role, content="Test content")
+
+        assert message.role == role
+
+    def test_rejects_unknown_role(self):
+        """
+        What it does: Verifies arbitrary message roles remain invalid.
+        Purpose: Ensure Claude Code compatibility does not allow malformed roles.
+        """
+        with pytest.raises(ValidationError):
+            AnthropicMessage(role="developer", content="Test content")
+
+
+# ==================================================================================================
 # Tests for AnthropicMessage with Image Content (Issue #30 fix verification)
 # ==================================================================================================
 

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -384,6 +384,41 @@ class TestMessagesValidation:
 
 class TestMessagesSystemPrompt:
     """Tests for system prompt handling on /v1/messages endpoint."""
+
+    @pytest.mark.parametrize("stream", [False, True])
+    def test_accepts_claude_code_inline_system_message(
+        self, test_client, valid_proxy_api_key, stream
+    ):
+        """
+        What it does: Sends Claude Code's system-role message shape in both response modes.
+        Purpose: Prevent 422 validation failures for streaming and non-streaming requests.
+        """
+        response = test_client.post(
+            "/v1/messages",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-5",
+                "max_tokens": 1024,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "hello"}],
+                    },
+                    {
+                        "role": "system",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "<system-reminder>Use the current date.</system-reminder>",
+                            }
+                        ],
+                    },
+                ],
+                "stream": stream,
+            },
+        )
+
+        assert response.status_code != 422
     
     def test_accepts_system_as_separate_field(self, test_client, valid_proxy_api_key):
         """
@@ -2148,6 +2183,33 @@ class TestCountTokensEndpoint:
         assert data["input_tokens"] > 0
         
         print(f"✅ Token count: {data['input_tokens']} tokens")
+
+    def test_count_tokens_accepts_inline_system_message(
+        self, test_client, valid_proxy_api_key
+    ):
+        """
+        What it does: Counts a Claude Code request containing an inline system message.
+        Purpose: Keep Claude Code's compaction preflight compatible with message generation.
+        """
+        response = test_client.post(
+            "/v1/messages/count_tokens",
+            headers={"x-api-key": valid_proxy_api_key},
+            json={
+                "model": "claude-sonnet-5",
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {
+                        "role": "system",
+                        "content": [
+                            {"type": "text", "text": "Runtime system reminder"}
+                        ],
+                    },
+                ],
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["input_tokens"] > 0
     
     def test_count_tokens_with_tools(self, test_client, valid_proxy_api_key):
         """


### PR DESCRIPTION
## Summary

This PR improves compatibility with current Kiro IDE enterprise sessions and Claude Code clients.

It adds:

- External OIDC identity-provider authentication, including Microsoft Entra ID
- Support for Claude Code inline `system` messages
- Additional fallback model identifiers currently exposed by Kiro IDE

## Motivation

Current Kiro IDE versions may authenticate enterprise users through an external OIDC provider. These credentials contain fields such as:

- `authMethod: "external_idp"`
- `clientId`
- `issuerUrl`
- `tokenEndpoint`
- `scopes`

The gateway previously classified these credentials as Kiro Desktop authentication and sent the refresh token to:

```text
https://prod.<region>.auth.desktop.kiro.dev/refreshToken
```

That endpoint rejects External IdP refresh tokens with HTTP 401.

Additionally, current Claude Code versions can place `system`-role messages inside the `messages` array. The gateway's Anthropic request model rejected these requests during Pydantic validation with HTTP 422.

## Changes

### External IdP authentication

- Add an `EXTERNAL_IDP` authentication type
- Detect credentials using `authMethod: "external_idp"` or `provider: "ExternalIdp"`
- Refresh access tokens through the OIDC `tokenEndpoint` recorded by Kiro
- Use the OAuth public-client refresh-token grant without requiring a client secret
- Normalize string and list-based OIDC scopes
- Persist rotated access and refresh tokens to JSON credentials or the kiro-cli SQLite database
- Reload credentials managed by Kiro before refreshing an expiring token
- Reload credentials once after a 400 or 401 response in case Kiro rotated the refresh token
- Retry rate-limit, server, timeout, and transport failures with bounded exponential backoff
- Send the required `TokenType: EXTERNAL_IDP` header to Kiro runtime and MCP endpoints
- Discover the selected `profileArn` from Kiro IDE extension storage when it is absent from the credential file
- Derive the API region from the discovered profile ARN when possible

### Security

External IdP endpoints are validated before use:

- The token endpoint must use HTTPS
- Embedded URL credentials are rejected
- When an issuer URL is available, its host must match the token endpoint host
- Tokens and credentials are not written to logs

### Claude Code compatibility

- Accept `system` as an Anthropic message role
- Extract inline system messages before converting conversation history
- Promote their text into Kiro's system prompt
- Combine inline instructions with the standard top-level Anthropic `system` field
- Preserve the original user and assistant message ordering
- Keep the actual user prompt as Kiro's active message
- Support the same request shape for streaming, non-streaming, and `/v1/messages/count_tokens`
- Continue rejecting unknown roles such as `developer`

This fixes errors such as:

```text
422 Input should be 'user' or 'assistant'
location: body.messages.1.role
input: system
```

### Fallback model list

Add the following model identifiers to the fallback `/v1/models` response:

- `claude-opus-5`
- `claude-sonnet-5`
- `claude-opus-4.8`
- `gpt-5.6-sol`
- `gpt-5.6-terra`
- `gpt-5.6-luna`

These entries help clients that require model selection from `/v1/models`. Model resolution remains pass-through, so Kiro remains the final authority on whether a model is available to the authenticated account.

### Documentation

- Document External IdP credential detection and refresh behavior
- Document automatic Kiro IDE profile ARN discovery
- Document Claude Code inline system-message compatibility
- Update the architecture documentation and `.env.example`

## Testing

Full test suite:

```text
uv run pytest -q
1732 passed, 4 warnings
```

Coverage includes:

- External IdP detection from JSON and SQLite credentials
- Scope normalization
- Refresh-token rotation and persistence
- Credential reload after authentication failure
- Transient failure retries and retry exhaustion
- Invalid, mismatched, or unsafe provider endpoints
- Missing and malformed provider responses
- Runtime and MCP `TokenType` headers
- Profile ARN and region discovery
- Inline system-message validation and extraction
- Multiple and empty inline system messages
- Combined top-level and inline system prompts
- Streaming and non-streaming Anthropic requests
- Claude Code token-count requests
- Fallback model advertisement and exact model resolution

## Manual verification

Verified with:

- Kiro IDE authenticated through a company Microsoft Entra ID tenant
- External IdP credentials managed by the running Kiro IDE
- Gateway running locally on port 9001
- Successful model discovery and streaming completions
- A Claude Code-shaped request containing a user message followed by an inline system message

The previously failing Claude Code request now returns HTTP 200 and a valid Anthropic SSE response.
