### PR TITLE
Add claude-auto alias for the auto model

### DIFF
--- a/kiro/config.py
+++ b/kiro/config.py
@@ -245,9 +245,11 @@ HIDDEN_MODELS: Dict[str, str] = {
 #       "gpt-5": "claude-sonnet-4.5"
 #   }
 #
-# Default: {"auto-kiro": "auto"} to avoid Cursor IDE conflict
+# Default: {"auto-kiro": "auto", "claude-auto": "auto"} to avoid Cursor IDE conflict
+# and Claude Desktop's rejection of model names without an Anthropic-y term.
 MODEL_ALIASES: Dict[str, str] = {
     "auto-kiro": "auto",  # Default alias to avoid Cursor's "auto" model conflict
+    "claude-auto": "auto",  # Alias with "claude" prefix so Claude Desktop accepts it
 }
 
 # Models to hide from /v1/models endpoint.


### PR DESCRIPTION
## Summary
- Adds `claude-auto` as an additional default entry in `MODEL_ALIASES`, mapping to the underlying `auto` model.

## Why
Claude Desktop rejects model names that lack an Anthropic-y term (e.g. `claude`, `anthropic`, `opus`, `sonnet`, `haiku`). Neither the raw `auto` model ID nor the existing `auto-kiro` alias satisfy that check, so Claude Desktop users can't select the auto model at all. Adding `claude-auto` alongside `auto-kiro` gives Claude Desktop users a usable name while leaving existing aliases and behavior untouched.

## Test plan
- [x] `pytest tests/unit/test_model_resolver.py` — 118 passed
- [x] Full suite `pytest` — 1691 passed