### PR TITLE
fix(parsers): match the upstream metering event so credits are not lost

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -282,6 +282,22 @@ PROXY_API_KEY="my-super-secret-password-123"
 # TRUNCATION_RECOVERY=true
 
 # ===========================================
+# BILLING
+# ===========================================
+
+# Expose the credits billed by Kiro as "usage.credits_used" on the OpenAI endpoint.
+# Credits are ALWAYS written to the log regardless of this setting:
+#   [Credit] req=<id> model=<model> credits=<float> calls=<n>
+# This flag only controls whether they are also added to the response payload,
+# which is a non-standard field for OpenAI clients.
+#
+# Credits are NOT dollars. Never rename this field to "cost" - downstream proxies
+# such as LiteLLM treat "cost" as a real charge and would mis-bill.
+#
+# Default: false
+# EXPOSE_CREDITS_USED=false
+
+# ===========================================
 # LOGGING
 # ===========================================
 

--- a/docs/en/ARCHITECTURE.md
+++ b/docs/en/ARCHITECTURE.md
@@ -329,7 +329,8 @@ Advanced AWS SSE format parser with support for:
 | `tool_start` | Start of tool call (name, toolUseId) |
 | `tool_input` | Continuation of input for tool call |
 | `tool_stop` | End of tool call |
-| `usage` | Credit consumption information |
+| `usage` | Cache token usage (dict; not sent by current upstream versions) |
+| `metering` | Credits billed for the request (`{"unit":"credit",...,"usage":<float>}`) |
 | `context_usage` | Context usage percentage |
 
 #### Helper Functions

--- a/docs/ru/ARCHITECTURE.md
+++ b/docs/ru/ARCHITECTURE.md
@@ -329,7 +329,8 @@ OpenAI messages преобразуются в Kiro conversationState:
 | `tool_start` | Начало tool call (name, toolUseId) |
 | `tool_input` | Продолжение input для tool call |
 | `tool_stop` | Завершение tool call |
-| `usage` | Информация о потреблении кредитов |
+| `usage` | Использование cache-токенов (dict; текущие версии upstream его не шлют) |
+| `metering` | Списанные за запрос кредиты (`{"unit":"credit",...,"usage":<float>}`) |
 | `context_usage` | Процент использования контекста |
 
 #### Вспомогательные функции

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -333,6 +333,18 @@ TOOL_DESCRIPTION_MAX_LENGTH: int = int(os.getenv("TOOL_DESCRIPTION_MAX_LENGTH", 
 TRUNCATION_RECOVERY: bool = os.getenv("TRUNCATION_RECOVERY", "true").lower() in ("true", "1", "yes")
 
 # ==================================================================================================
+# Billing Settings
+# ==================================================================================================
+
+# Expose the credits billed by Kiro as `usage.credits_used` on the OpenAI endpoint.
+# Credits are always written to the log as `[Credit] req=... credits=... calls=...`;
+# this flag only controls whether they are also added to the response payload.
+# Off by default because it adds a non-standard field to the OpenAI response contract.
+# Note: credits are NOT dollars - do not rename this field to `cost`, downstream
+# proxies (e.g. LiteLLM) treat `cost` as a real charge and would mis-bill.
+EXPOSE_CREDITS_USED: bool = os.getenv("EXPOSE_CREDITS_USED", "false").lower() in ("true", "1", "yes")
+
+# ==================================================================================================
 # Logging Settings
 # ==================================================================================================
 

--- a/kiro/parsers.py
+++ b/kiro/parsers.py
@@ -220,7 +220,8 @@ class AwsEventStreamParser:
     - tool_start: Start of tool call (name, toolUseId)
     - tool_input: Continuation of input for tool call
     - tool_stop: End of tool call
-    - usage: Credit consumption information
+    - usage: Cache token usage (dict, sent by some upstream versions)
+    - metering: Credits billed for the request (float, MeteringEvent)
     - context_usage: Context usage percentage
     
     Attributes:
@@ -245,6 +246,7 @@ class AwsEventStreamParser:
         ('{"stop":', 'tool_stop'),
         ('{"followupPrompt":', 'followup'),
         ('{"usage":', 'usage'),
+        ('{"unit":', 'metering'),
         ('{"contextUsagePercentage":', 'context_usage'),
     ]
     
@@ -326,11 +328,38 @@ class AwsEventStreamParser:
             return self._process_tool_stop_event(data)
         elif event_type == 'usage':
             return {"type": "usage", "data": data.get('usage', 0)}
+        elif event_type == 'metering':
+            return self._process_metering_event(data)
         elif event_type == 'context_usage':
             return {"type": "context_usage", "data": data.get('contextUsagePercentage', 0)}
         
         return None
     
+    def _process_metering_event(self, data: dict) -> Optional[Dict[str, Any]]:
+        """
+        Processes upstream billing event.
+
+        Wire format: {"unit":"credit","unitPlural":"credits","usage":<float>}
+        (the `MeteringEvent` of the AWS CodeWhisperer streaming client).
+
+        Note the pattern matches on `{"unit":` and the unit value is validated
+        here instead: matching on `{"unit":"credit"` would silently break on a
+        single extra space in the upstream JSON.
+        """
+        # Only 'credit' is known. A different unit means upstream changed how it
+        # bills, so warn instead of silently dropping part of the charge.
+        unit = data.get('unit')
+        if unit != 'credit':
+            logger.warning(f"Unknown metering unit from upstream: {unit!r}, event ignored")
+            return None
+
+        usage = data.get('usage')
+        if not isinstance(usage, (int, float)) or isinstance(usage, bool):
+            logger.warning(f"Metering event with non-numeric usage: {usage!r}, event ignored")
+            return None
+
+        return {"type": "metering", "data": float(usage)}
+
     def _process_content_event(self, data: dict) -> Optional[Dict[str, Any]]:
         """Processes content event."""
         content = data.get('content', '')

--- a/kiro/streaming_anthropic.py
+++ b/kiro/streaming_anthropic.py
@@ -197,7 +197,12 @@ async def stream_kiro_to_anthropic(
     # Track context usage for token calculation
     context_usage_percentage: Optional[float] = None
     upstream_cache_usage: Dict[str, int] = {}
-    
+
+    # Billing credits. Must accumulate: one downstream request can trigger
+    # several upstream calls (tool use), each emitting its own metering event.
+    credits_used = 0.0
+    upstream_calls = 0
+
     # Track truncated tool calls for recovery
     truncated_tools: List[Dict[str, Any]] = []
     
@@ -522,7 +527,17 @@ async def stream_kiro_to_anthropic(
                 context_usage_percentage = event.context_usage_percentage
             elif event.type == "usage" and event.usage:
                 upstream_cache_usage.update(_extract_cache_usage_fields(event.usage))
-        
+            elif event.type == "metering" and event.credits:
+                credits_used += event.credits
+                upstream_calls += 1
+
+        # Credits actually billed upstream. req= is the dedup key for log-based
+        # reconciliation, so keep it in the line.
+        logger.info(
+            f"[Credit] req={message_id} model={model} "
+            f"credits={credits_used:.12f} calls={upstream_calls}"
+        )
+
         # Track completion signals for truncation detection
         stream_completed_normally = context_usage_percentage is not None
         
@@ -760,7 +775,13 @@ async def collect_anthropic_response(
     # Collect stream result
     result = await collect_stream_to_result(response)
     upstream_cache_usage = _extract_cache_usage_fields(result.usage)
-    
+
+    # Same line format as the streaming path so both can be parsed alike
+    logger.info(
+        f"[Credit] req={message_id} model={model} "
+        f"credits={result.credits:.12f} calls={result.upstream_calls}"
+    )
+
     # Build content blocks
     content_blocks = []
     

--- a/kiro/streaming_core.py
+++ b/kiro/streaming_core.py
@@ -68,11 +68,12 @@ class KiroEvent:
     This format is API-agnostic and can be converted to both OpenAI and Anthropic formats.
     
     Attributes:
-        type: Event type (content, thinking, tool_use, usage, context_usage, error)
+        type: Event type (content, thinking, tool_use, usage, metering, context_usage, error)
         content: Text content (for content events)
         thinking_content: Thinking/reasoning content (for thinking events)
         tool_use: Tool use data (for tool_use events)
-        usage: Usage/metering data (for usage events)
+        usage: Cache token usage data (for usage events)
+        credits: Credits billed by upstream (for metering events)
         context_usage_percentage: Context usage percentage (for context_usage events)
         is_first_thinking_chunk: Whether this is the first thinking chunk
         is_last_thinking_chunk: Whether this is the last thinking chunk
@@ -82,6 +83,7 @@ class KiroEvent:
     thinking_content: Optional[str] = None
     tool_use: Optional[Dict[str, Any]] = None
     usage: Optional[Dict[str, Any]] = None
+    credits: Optional[float] = None
     context_usage_percentage: Optional[float] = None
     is_first_thinking_chunk: bool = False
     is_last_thinking_chunk: bool = False
@@ -96,13 +98,17 @@ class StreamResult:
         content: Full text content
         thinking_content: Full thinking/reasoning content
         tool_calls: List of tool calls
-        usage: Usage information
+        usage: Cache token usage information
+        credits: Total credits billed by upstream (summed over all metering events)
+        upstream_calls: Number of metering events seen (>1 when tools trigger extra upstream calls)
         context_usage_percentage: Context usage percentage from Kiro API
     """
     content: str = ""
     thinking_content: str = ""
     tool_calls: List[Dict[str, Any]] = field(default_factory=list)
     usage: Optional[Dict[str, Any]] = None
+    credits: float = 0.0
+    upstream_calls: int = 0
     context_usage_percentage: Optional[float] = None
 
 
@@ -277,7 +283,10 @@ async def _process_chunk(
         
         elif event["type"] == "usage":
             yield KiroEvent(type="usage", usage=event["data"])
-        
+
+        elif event["type"] == "metering":
+            yield KiroEvent(type="metering", credits=event["data"])
+
         elif event["type"] == "context_usage":
             yield KiroEvent(type="context_usage", context_usage_percentage=event["data"])
 
@@ -319,6 +328,11 @@ async def collect_stream_to_result(
             result.tool_calls.append(event.tool_use)
         elif event.type == "usage" and event.usage:
             result.usage = event.usage
+        elif event.type == "metering" and event.credits:
+            # Must accumulate: one downstream request can trigger several upstream
+            # calls (tool use), each emitting its own metering event.
+            result.credits += event.credits
+            result.upstream_calls += 1
         elif event.type == "context_usage" and event.context_usage_percentage is not None:
             result.context_usage_percentage = event.context_usage_percentage
     

--- a/kiro/streaming_openai.py
+++ b/kiro/streaming_openai.py
@@ -42,6 +42,7 @@ from kiro.config import (
     FIRST_TOKEN_TIMEOUT,
     FIRST_TOKEN_MAX_RETRIES,
     FAKE_REASONING_HANDLING,
+    EXPOSE_CREDITS_USED,
 )
 from kiro.tokenizer import count_tokens, count_message_tokens, count_tools_tokens
 
@@ -119,6 +120,10 @@ async def stream_kiro_to_openai_internal(
     first_chunk = True
     
     metering_data = None
+    # Billing credits. Kept apart from metering_data (the cache-token dict) on
+    # purpose: the two events carry different types and would overwrite each other.
+    credits_used = 0.0
+    upstream_calls = 0
     context_usage_percentage = None
     full_content = ""
     full_thinking_content = ""  # Accumulated thinking content for non-streaming
@@ -264,12 +269,24 @@ async def stream_kiro_to_openai_internal(
             
             elif event.type == "usage" and event.usage:
                 metering_data = event.usage
-            
+
+            elif event.type == "metering" and event.credits:
+                # Accumulate - tool calls trigger several upstream calls per request
+                credits_used += event.credits
+                upstream_calls += 1
+
             elif event.type == "context_usage" and event.context_usage_percentage is not None:
                 context_usage_percentage = event.context_usage_percentage
         
+        # Credits actually billed upstream. req= is the dedup key for log-based
+        # reconciliation, so keep it in the line.
+        logger.info(
+            f"[Credit] req={completion_id} model={model} "
+            f"credits={credits_used:.12f} calls={upstream_calls}"
+        )
+
         # Track completion signals for truncation detection
-        received_usage = metering_data is not None
+        received_usage = metering_data is not None or upstream_calls > 0
         received_context_usage = context_usage_percentage is not None
         stream_completed_normally = received_usage or received_context_usage
         
@@ -402,8 +419,9 @@ async def stream_kiro_to_openai_internal(
             }
         }
         
-        if metering_data:
-            final_chunk["usage"]["credits_used"] = metering_data
+        # Opt-in: adding credits_used changes the response contract for clients
+        if EXPOSE_CREDITS_USED and upstream_calls > 0:
+            final_chunk["usage"]["credits_used"] = credits_used
         
         # Log final token values being sent to client
         logger.debug(

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -480,6 +480,102 @@ class TestAwsEventStreamParserFeed:
         assert events[0]["type"] == "usage"
         assert events[0]["data"] == 1.5
     
+    def test_parses_metering_event(self, aws_event_parser):
+        """
+        What it does: Tests parsing of the upstream billing (metering) event.
+        Goal: Ensure the credits actually charged by Kiro are extracted.
+        """
+        print("Setup: Chunk with metering event...")
+        chunk = b'{"unit":"credit","unitPlural":"credits","usage":0.02730794364842454}'
+
+        print("Action: Parsing chunk...")
+        events = aws_event_parser.feed(chunk)
+
+        print(f"Result: {events}")
+        assert len(events) == 1
+        assert events[0]["type"] == "metering"
+        assert events[0]["data"] == 0.02730794364842454
+
+    def test_parses_multiple_metering_events(self, aws_event_parser):
+        """
+        What it does: Tests a tool-call stream carrying two metering events.
+        Goal: Both must surface - a single request can trigger several upstream calls.
+        """
+        print("Setup: Chunk with two metering events...")
+        chunk = (
+            b'{"unit":"credit","unitPlural":"credits","usage":0.0930}'
+            b'{"content":"text"}'
+            b'{"unit":"credit","unitPlural":"credits","usage":0.5290}'
+        )
+
+        print("Action: Parsing chunk...")
+        events = aws_event_parser.feed(chunk)
+
+        print(f"Result: {events}")
+        metering = [e["data"] for e in events if e["type"] == "metering"]
+        assert metering == [0.0930, 0.5290]
+
+    def test_metering_event_split_across_chunks(self, aws_event_parser):
+        """
+        What it does: Splits a metering event across two chunks.
+        Goal: Ensure the buffer reassembles it instead of dropping or duplicating it.
+        """
+        print("Setup: Metering event cut in half...")
+        events1 = aws_event_parser.feed(b'{"unit":"credit","unitPlur')
+        events2 = aws_event_parser.feed(b'al":"credits","usage":0.5}')
+
+        print(f"Result: {events1} / {events2}")
+        assert events1 == []
+        assert len(events2) == 1
+        assert events2[0]["type"] == "metering"
+        assert events2[0]["data"] == 0.5
+
+    def test_ignores_unknown_metering_unit(self, aws_event_parser):
+        """
+        What it does: Feeds a metering event with an unknown unit.
+        Goal: Event is dropped, but the content event after it must survive.
+        """
+        print("Setup: Metering event with unit=token followed by content...")
+        chunk = b'{"unit":"token","unitPlural":"tokens","usage":1234}{"content":"after"}'
+
+        print("Action: Parsing chunk...")
+        events = aws_event_parser.feed(chunk)
+
+        print(f"Result: {events}")
+        assert len(events) == 1
+        assert events[0]["type"] == "content"
+        assert events[0]["data"] == "after"
+
+    def test_does_not_match_unit_inside_content(self, aws_event_parser):
+        """
+        What it does: Model output that itself contains {"unit": ... } as JSON text.
+        Goal: The escaped quotes inside content must not be parsed as a metering event.
+        """
+        print("Setup: Content event whose text contains an escaped unit object...")
+        chunk = b'{"content":"example: {\\"unit\\":\\"kg\\"}"}'
+
+        print("Action: Parsing chunk...")
+        events = aws_event_parser.feed(chunk)
+
+        print(f"Result: {events}")
+        assert len(events) == 1
+        assert events[0]["type"] == "content"
+        assert events[0]["data"] == 'example: {"unit":"kg"}'
+
+    def test_ignores_metering_event_with_non_numeric_usage(self, aws_event_parser):
+        """
+        What it does: Feeds a metering event whose usage is not a number.
+        Goal: Dropped rather than propagated as a bogus credit value.
+        """
+        print("Setup: Metering event with usage as string...")
+        chunk = b'{"unit":"credit","unitPlural":"credits","usage":"n/a"}'
+
+        print("Action: Parsing chunk...")
+        events = aws_event_parser.feed(chunk)
+
+        print(f"Result: {events}")
+        assert events == []
+
     def test_parses_context_usage_event(self, aws_event_parser):
         """
         What it does: Tests parsing of context_usage event.

--- a/tests/unit/test_streaming_anthropic.py
+++ b/tests/unit/test_streaming_anthropic.py
@@ -1184,7 +1184,7 @@ class TestStreamingAnthropicContextUsage:
         What it does: Passes through upstream cache usage fields when available.
         Goal: Ensure no fake values, only real upstream usage keys.
         """
-        mock_result = MagicMock(
+        mock_result = StreamResult(
             content="done",
             thinking_content="",
             tool_calls=[],

--- a/tests/unit/test_streaming_openai.py
+++ b/tests/unit/test_streaming_openai.py
@@ -1324,35 +1324,88 @@ class TestStreamingOpenaiBracketToolCalls:
 class TestStreamingOpenaiMeteringData:
     """Tests for metering data handling."""
     
-    @pytest.mark.asyncio
-    async def test_includes_credits_used_in_usage(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
-        """
-        What it does: Includes credits_used in usage when metering data present.
-        Goal: Verify metering data is included.
-        """
-        print("Setup: Mock stream with metering data...")
-        
+    async def _final_chunk(self, events, http_client, response, model_cache, auth_manager):
+        """Runs the stream and returns the parsed final chunk (the one before [DONE])."""
         async def mock_parse_kiro_stream(*args, **kwargs):
-            yield KiroEvent(type="content", content="Hello")
-            yield KiroEvent(type="usage", usage={"credits": 0.001})
-        
-        print("Action: Streaming to OpenAI format...")
+            for event in events:
+                yield event
+
         chunks = []
-        
         with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
             with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    http_client, response, "claude-sonnet-4",
+                    model_cache, auth_manager
                 ):
                     chunks.append(chunk)
-        
-        print(f"Received {len(chunks)} chunks")
-        
-        # Final chunk should have credits_used
-        final_chunk = chunks[-2]  # Before [DONE]
-        assert '"credits_used"' in final_chunk
-        print("✓ credits_used included in usage")
+
+        return json.loads(chunks[-2][len("data:"):].strip())
+
+    @pytest.mark.asyncio
+    async def test_credits_used_hidden_by_default(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+        """
+        What it does: Keeps credits_used out of the payload while EXPOSE_CREDITS_USED is off.
+        Goal: Verify the fix does not silently change the OpenAI response contract.
+        """
+        print("Setup: Mock stream with a metering event, flag off (default)...")
+        events = [
+            KiroEvent(type="content", content="Hello"),
+            KiroEvent(type="metering", credits=0.0273),
+        ]
+
+        print("Action: Streaming to OpenAI format...")
+        final_chunk = await self._final_chunk(
+            events, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+        )
+
+        print(f"Result usage: {final_chunk['usage']}")
+        assert "credits_used" not in final_chunk["usage"]
+        print("✓ credits_used absent by default")
+
+    @pytest.mark.asyncio
+    async def test_includes_credits_used_when_enabled(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+        """
+        What it does: Includes summed credits_used when EXPOSE_CREDITS_USED is on.
+        Goal: Verify metering events reach the payload and are accumulated, not overwritten.
+        """
+        print("Setup: Mock stream with two metering events (tool call scenario)...")
+        events = [
+            KiroEvent(type="content", content="Hello"),
+            KiroEvent(type="metering", credits=0.0930),
+            KiroEvent(type="metering", credits=0.5290),
+        ]
+
+        print("Action: Streaming with EXPOSE_CREDITS_USED enabled...")
+        with patch('kiro.streaming_openai.EXPOSE_CREDITS_USED', True):
+            final_chunk = await self._final_chunk(
+                events, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+            )
+
+        print(f"Result usage: {final_chunk['usage']}")
+        assert final_chunk["usage"]["credits_used"] == pytest.approx(0.6220)
+        print("✓ credits_used summed across metering events")
+
+    @pytest.mark.asyncio
+    async def test_cache_usage_event_is_not_reported_as_credits(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+        """
+        What it does: Keeps the cache-token usage event out of credits_used.
+        Goal: credits_used is a float from metering events, never the usage dict.
+        """
+        print("Setup: Mock stream with a cache usage event only...")
+        events = [
+            KiroEvent(type="content", content="Hello"),
+            KiroEvent(type="usage", usage={"cacheReadInputTokens": 12}),
+        ]
+
+        print("Action: Streaming with EXPOSE_CREDITS_USED enabled...")
+        with patch('kiro.streaming_openai.EXPOSE_CREDITS_USED', True):
+            final_chunk = await self._final_chunk(
+                events, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+            )
+
+        print(f"Result usage: {final_chunk['usage']}")
+        assert "credits_used" not in final_chunk["usage"]
+        print("✓ cache usage dict not leaked into credits_used")
 
 
 # ==================================================================================================


### PR DESCRIPTION
## Problem

`AwsEventStreamParser.EVENT_PATTERNS` looks for `{"usage":`, but the upstream billing event is:

```json
{"unit":"credit","unitPlural":"credits","usage":0.02730794364842454}
```

`usage` is the third key, so `buffer.find('{"usage":')` never matches it. Consequences:

- `metering_data` in `streaming_openai.py` stays `None`, so the existing `final_chunk["usage"]["credits_used"] = metering_data` has never produced a field. I hit the OpenAI endpoint three times in a row and `credits_used` did not appear once.
- `_extract_cache_usage_fields(event.usage)` in `streaming_anthropic.py` never runs either, so the cache usage forwarding added in #135 has never taken effect.
- `stream_completed_normally = received_usage or received_context_usage` effectively has one leg: `received_usage` is always `False`.

I dumped the raw upstream chunks with `DEBUG_MODE=all` over several requests, including tool-call rounds. The only event keys the current API version sends are `{"content"`, `{"contextUsagePercentage"`, `{"unit"`, `{"name"` and `{"input"`. `{"usage":{...}}` does not appear at all.

The field name in the AWS SDK really is `usage` (`MeteringEvent { usage: f64, unit: String }`), which is probably where the pattern came from, but `unit` is serialized first.

## Fix

A separate `metering` event type rather than reusing `usage`:

- `usage` carries cache token counts (a dict), `metering` carries credits (a float). Reusing one type would let them overwrite each other if upstream ever starts sending `{"usage":{...}}`, and the symptom would be a credit value silently turning into a dict.
- The pattern matches `{"unit":` only, and the unit value is checked in `_process_metering_event`. Matching `{"unit":"credit"` would break silently on one extra space in the upstream JSON. An unknown unit logs a warning instead of being dropped quietly, since it would mean upstream changed how it bills.
- Credits are accumulated, not overwritten. One downstream request can trigger several upstream calls when tools are used: I captured a single `/v1/messages` request with two credit events, 0.0930 + 0.5290, so keeping only the last one undercounts by 15%.
- Both APIs and both streaming and non-streaming paths are covered.
- Each request logs `[Credit] req=<id> model=<model> credits=<float> calls=<n>`.

`usage.credits_used` on the OpenAI endpoint is behind a new `EXPOSE_CREDITS_USED` env var, default off, so that fixing the parser does not by itself start adding a non-standard field to responses. Say the word and I will flip the default to on.

The Anthropic path only accumulates and logs; its payload is unchanged.

One note for whoever touches this later: credits are not dollars, and the field must not be renamed to `cost`. Downstream proxies such as LiteLLM have an explicit `cost` field on their usage model and would treat the value as a real charge.

## Behaviour change

`received_usage` in `streaming_openai.py` starts being `True`, so truncation detection becomes slightly less eager. That restores what the condition was written to do. In every capture I took, `contextUsagePercentage` and the metering event arrive together, so the verdict rarely differs in practice, and receiving a metering event is itself a strong signal that upstream finished and billed the request. The Anthropic path does not consult metering for truncation detection at all, so it is unaffected.

## Tests

`pytest tests/unit`: 1594 passed before, 1602 after, no failures.

New parser tests: a single event, two events in one stream, an event split across chunks, an unknown unit (dropped without swallowing the next event), non-numeric usage, and content that itself contains an escaped `{\"unit\":\"kg\"}`.

New OpenAI streaming tests: the field is absent by default, credits are summed when the flag is on, and a cache-usage dict is never reported as credits.

Separately, I ran the old and the new pattern table side by side over 7 streams (a real capture with binary frame headers, two-round tool calls, escaped `unit` inside content, a chunk split in the middle of the event, an unknown unit, thinking plus signature events, and metering only), asserting that every non-metering event is identical before and after. That is the property I actually cared about: no side effects on existing parsing.

Related: #159 asks for credit visibility through `getUsageLimits`. That endpoint has no per-model breakdown (its `usageBreakdown` and `totalUsage` are null and `ResourceType` has no model dimension), whereas the metering event gives the exact credits for the request that just ran.
